### PR TITLE
Update the example file with a provider that supports service_tier

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     firehydrant = {
       source = "firehydrant/firehydrant"
-      version = "0.1.2"
+      version = "0.1.3"
     }
   }
 }


### PR DESCRIPTION
The example doesn't current work since the `service_tier` was added in
the 0.1.3 provider and this currently is locked to 0.1.2. Easy fix to
upgrade to latest!