### PR TITLE
Add basic PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Description
+
+_Describe why you're making this change._
+
+## Testing plan
+
+1. _Describe how to replicate the conditions_
+1. _under which your code performs its purpose,_
+1. _including example Terraform configs where necessary._
+
+## Related links
+
+_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._
+
+- [API documentation](https://developers.firehydrant.io/docs/api/xxxx)
+- [Related PR](https://github.com/firehydrant/firehydrant/pull/xxxx)
+
+## PR readiness 
+
+- [ ] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
+- [ ] An entry has been added to the changelog, if necessary.


### PR DESCRIPTION
## Description

This PR adds a basic PR template. This should help us make sure we include everything that needs to be updated/changed when making provider changes. It should also help make reviews easier.

## Testing plan

1. Read through the template and make sure it makes sense to you and has no typos

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog.