### PR TITLE
Add owner attribute to r/service, d/service, & d/services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ examples/terraform.tfstate
 dist/
 terraform-provider-firehydrant
 .tool-versions
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ ENHANCEMENTS:
 
 * provider: Added Terraform version to the user agent header ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
 * resource/service: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
-* data source/service: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
-* data source/services: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
+* resource/service: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
+* data_source/service: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
+* data_source/service: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
+* data_source/services: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
+* data_source/services: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
 
 ## 0.1.4
 

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -29,5 +29,6 @@ data "firehydrant_service" "example-service" {
   active incident. Defaults to `false`.
 - **description** (String, Read-only) A description for the service.
 - **name** (String, Read-only) The name of the service.
+- **owner_id** (String, Read-only) The ID of the team that owns this service.
 - **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
   Lower values represent higher criticality. Defaults to `5`.

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -35,7 +35,6 @@ data "firehydrant_services" "managed-true-labeled-services" {
 
 ### Optional
 
-- **id** (String, Optional) The ID of this resource.
 - **labels** (Map of String, Optional)
 - **query** (String, Optional)
 
@@ -52,6 +51,6 @@ data "firehydrant_services" "managed-true-labeled-services" {
   active incident. Defaults to `false`.
 - **description** (String, Read-only) A description for the service.
 - **name** (String, Read-only) The name of the service.
+- **owner_id** (String, Read-only) The ID of the team that owns this service.
 - **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
   Lower values represent higher criticality. Defaults to `5`.
-

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -41,6 +41,7 @@ resource "firehydrant_service" "example-service" {
 - **description** (String, Optional) A description for the service.
 - **labels** (Map of String, Optional) Key-value pairs associated with the service. Useful for 
    supporting searching and filtering of the service catalog.
+- **owner_id** (String, Optional) The ID of the team that owns this service.
 - **service_tier** (Integer, Optional) The service tier of this resource - between 1 - 5. 
    Lower values represent higher criticality. Defaults to `5`.
 

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -27,35 +27,51 @@ type PingResponse struct {
 // CreateServiceRequest is the payload for creating a service
 // URL: POST https://api.firehydrant.io/v1/services
 type CreateServiceRequest struct {
-	Name        string            `json:"name"`
-	Description string            `json:"description"`
-	ServiceTier int               `json:"service_tier,int,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
 	AlertOnAdd  bool              `json:"alert_on_add,omitempty"`
+	Description string            `json:"description"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Name        string            `json:"name"`
+	Owner       *ServiceTeam      `json:"owner,omitempty"`
+	ServiceTier int               `json:"service_tier,int,omitempty"`
+}
+
+// ServiceTeam represents a team when creating a service
+type ServiceTeam struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // UpdateServiceRequest is the payload for updating a service
 // URL: PATCH https://api.firehydrant.io/v1/services/{id}
 type UpdateServiceRequest struct {
-	Name        string            `json:"name,omitempty"`
-	Description string            `json:"description,omitempty"`
-	ServiceTier int               `json:"service_tier,int,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
 	AlertOnAdd  bool              `json:"alert_on_add,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Owner       *ServiceTeam      `json:"owner,omitempty"`
+	RemoveOwner bool              `json:"remove_owner,omitempty"`
+	ServiceTier int               `json:"service_tier,int,omitempty"`
 }
 
 // ServiceResponse is the payload for retrieving a service
 // URL: GET https://api.firehydrant.io/v1/services/{id}
 type ServiceResponse struct {
 	ID          string            `json:"id"`
-	Name        string            `json:"name"`
+	AlertOnAdd  bool              `json:"alert_on_add"`
 	Description string            `json:"description"`
+	Labels      map[string]string `json:"labels"`
+	Name        string            `json:"name"`
+	Owner       *ServiceTeam      `json:"owner"`
 	ServiceTier int               `json:"service_tier"`
 	Slug        string            `json:"slug"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
-	Labels      map[string]string `json:"labels"`
-	AlertOnAdd  bool              `json:"alert_on_add"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // ServiceQuery is the query used to search for services

--- a/provider/service_data_test.go
+++ b/provider/service_data_test.go
@@ -1,0 +1,43 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccServiceDataSource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDataSourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "alert_on_add", "false"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "service_tier", "5"),
+				),
+			},
+		},
+	})
+}
+
+func testAccServiceDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_service" "test_service" {
+  name = "test-service-%s"
+}
+
+data "firehydrant_service" "test_service" {
+  id = firehydrant_service.test_service.id
+}`, rName)
+}

--- a/provider/service_resources_test.go
+++ b/provider/service_resources_test.go
@@ -1,0 +1,399 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccServiceResource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckServiceResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_basic("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "false"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceResource_update(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckServiceResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_basic("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "false"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "5"),
+				),
+			},
+			{
+				Config: testAccServiceResourceConfig_update(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_update("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceResource_updateOwnerID(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckServiceResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceResourceConfig_update(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_update("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "1"),
+				),
+			},
+			{
+				Config: testAccServiceResourceConfig_updateChangeOwnerID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_update("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "1"),
+				),
+			},
+			{
+				Config: testAccServiceResourceConfig_updateRemoveOwnerID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_updateRemoveOwnerID("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+					// Make sure owner_id is not set
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "owner_id", ""),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceResourceImport_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceResourceConfig_update(rName),
+			},
+
+			{
+				ResourceName:      "firehydrant_service.test_service",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckServiceResourceExistsWithAttributes_basic(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		serviceResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if serviceResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		serviceResponse, err := client.Services().Get(context.TODO(), serviceResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := serviceResource.Primary.Attributes["name"], serviceResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = serviceResource.Primary.Attributes["alert_on_add"], fmt.Sprintf("%t", serviceResponse.AlertOnAdd)
+		if expected != got {
+			return fmt.Errorf("Unexpected alert_on_add. Expected: %s, got: %s", expected, got)
+		}
+
+		if serviceResponse.Description != "" {
+			return fmt.Errorf("Unexpected description. Expected no description, got: %s", serviceResponse.Description)
+		}
+
+		//if !reflect.DeepEqual(serviceResponse.Labels, []string{}) {
+		//	return fmt.Errorf("Bad labels: %v", serviceResponse.Labels)
+		//}
+
+		if serviceResponse.Owner != nil {
+			return fmt.Errorf("Unexpected owner. Expected no owner ID, got: %s", serviceResponse.Owner.ID)
+		}
+
+		expected, got = serviceResource.Primary.Attributes["service_tier"], fmt.Sprintf("%d", serviceResponse.ServiceTier)
+		if expected != got {
+			return fmt.Errorf("Unexpected service_tier. Expected: %s, got: %s", expected, got)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckServiceResourceExistsWithAttributes_update(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		serviceResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if serviceResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		serviceResponse, err := client.Services().Get(context.TODO(), serviceResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := serviceResource.Primary.Attributes["name"], serviceResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = serviceResource.Primary.Attributes["alert_on_add"], fmt.Sprintf("%t", serviceResponse.AlertOnAdd)
+		if expected != got {
+			return fmt.Errorf("Unexpected alert_on_add. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = serviceResource.Primary.Attributes["description"], serviceResponse.Description
+		if expected != got {
+			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
+		}
+
+		//if !reflect.DeepEqual(serviceResponse.Labels, []string{}) {
+		//	return fmt.Errorf("Bad labels: %v", serviceResponse.Labels)
+		//}
+
+		if serviceResponse.Owner == nil {
+			return fmt.Errorf("Unexpected owner. Expected owner to be set.")
+		}
+		expected, got = serviceResource.Primary.Attributes["owner_id"], serviceResponse.Owner.ID
+		if expected != got {
+			return fmt.Errorf("Unexpected owner ID. Expected:%s, got: %s", expected, got)
+		}
+
+		expected, got = serviceResource.Primary.Attributes["service_tier"], fmt.Sprintf("%d", serviceResponse.ServiceTier)
+		if expected != got {
+			return fmt.Errorf("Unexpected service_tier. Expected: %s, got: %s", expected, got)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckServiceResourceExistsWithAttributes_updateRemoveOwnerID(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		serviceResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if serviceResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		serviceResponse, err := client.Services().Get(context.TODO(), serviceResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := serviceResource.Primary.Attributes["name"], serviceResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = serviceResource.Primary.Attributes["alert_on_add"], fmt.Sprintf("%t", serviceResponse.AlertOnAdd)
+		if expected != got {
+			return fmt.Errorf("Unexpected alert_on_add. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = serviceResource.Primary.Attributes["description"], serviceResponse.Description
+		if expected != got {
+			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
+		}
+
+		//if !reflect.DeepEqual(serviceResponse.Labels, []string{}) {
+		//	return fmt.Errorf("Bad labels: %v", serviceResponse.Labels)
+		//}
+
+		if serviceResponse.Owner != nil {
+			return fmt.Errorf("Unexpected owner. Expected owner to not be set, got: %s.", serviceResponse.Owner.ID)
+		}
+
+		expected, got = serviceResource.Primary.Attributes["service_tier"], fmt.Sprintf("%d", serviceResponse.ServiceTier)
+		if expected != got {
+			return fmt.Errorf("Unexpected service_tier. Expected: %s, got: %s", expected, got)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckServiceResourceDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		for _, stateResource := range s.RootModule().Resources {
+			if stateResource.Type != "firehydrant_service" {
+				continue
+			}
+
+			if stateResource.Primary.ID == "" {
+				return fmt.Errorf("No instance ID is set")
+			}
+
+			_, err := client.Services().Get(context.TODO(), stateResource.Primary.ID)
+			if err == nil {
+				return fmt.Errorf("Service %s still exists", stateResource.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceResourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_service" "test_service" {
+  name = "test-service-%s"
+}`, rName)
+}
+
+func testAccServiceResourceConfig_update(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_team" "test_team1" {
+  name = "test-team1-%s"
+}
+
+resource "firehydrant_service" "test_service" {
+  name         = "test-service-%s"
+  alert_on_add = true
+  description  = "test-description-%s"
+  owner_id     = firehydrant_team.test_team1.id
+  service_tier = "1"
+}`, rName, rName, rName)
+}
+
+func testAccServiceResourceConfig_updateChangeOwnerID(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_team" "test_team1" {
+  name = "test-team1-%s"
+}
+
+resource "firehydrant_team" "test_team2" {
+  name = "test-team2-%s"
+}
+
+resource "firehydrant_service" "test_service" {
+  name         = "test-service-%s"
+  alert_on_add = true
+  description  = "test-description-%s"
+  owner_id     = firehydrant_team.test_team2.id
+  service_tier = "1"
+}`, rName, rName, rName, rName)
+}
+
+func testAccServiceResourceConfig_updateRemoveOwnerID(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_service" "test_service" {
+  name         = "test-service-%s"
+  alert_on_add = true
+  description  = "test-description-%s"
+  service_tier = "1"
+}`, rName, rName)
+}

--- a/provider/services_data_test.go
+++ b/provider/services_data_test.go
@@ -1,0 +1,69 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccServicesDataSource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicesDataSourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_services.all_services", "services.#"),
+					testAccCheckServicesSet("data.firehydrant_services.all_services"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckServicesSet(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		servicesResource, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Can't find services resource in state: %s", name)
+		}
+
+		if servicesResource.Primary.ID == "" {
+			return fmt.Errorf("Services resource ID not set")
+		}
+
+		attributes := servicesResource.Primary.Attributes
+		services, servicesOk := attributes["services.#"]
+		if !servicesOk {
+			return fmt.Errorf("Services list is missing")
+		}
+
+		servicesCount, err := strconv.Atoi(services)
+		if err != nil {
+			return err
+		}
+
+		if servicesCount <= 1 {
+			return fmt.Errorf("Incorrect number of services - expected at least 1, got %d", servicesCount)
+		}
+
+		return nil
+	}
+}
+
+func testAccServicesDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_service" "test_service" {
+  name = "test-service-%s"
+}
+
+data "firehydrant_services" "all_services" {
+}`, rName)
+}


### PR DESCRIPTION
## Description

This PR adds the owner attribute to the schema for r/service, d/service, and d/services by taking the changes introduced in #12 and adding some additional changes to get the tests working. It also adds missing tests files, updates relevant documentation, and does some minor clean up to make things a little more consistent.

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-tfe /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     #dev_overrides {
     #  "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     #}

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/8083026/terraform-config.txt)
 as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. Run `terraform init`.

#### Upgrading - Existing services with no owner set:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the services you just created.
1. Edit your ~/.terraformrc file and remove the comments in front of the dev_overrides block
   ```
   dev_overrides {
     "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   }
   ```
1.  Run `terraform plan`. This time you should see a yellow warning block telling you that development overrides are in place. Your plan should show no changes. Go ahead and run `terraform apply -refresh-only` to pick up state updates from some of the other unreleased attributes.
1. Run `terraform destroy`. This should succeed and should remove any services you created.
1. Edit your ~/.terraformrc file and comment out the dev_overrides block
   ```
   #dev_overrides {
   # "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   #}
   ```

#### Upgrading - Existing services with an owner set:
1. Run `terraform apply`. This should succeed and if you check in the UI, you should see the services you just created.
1. Update service4 to have an owner team in the UI.
1. Edit your ~/.terraformrc file and remove the comments in front of the dev_overrides block
   ```
   dev_overrides {
     "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   }
   ```
1.  Run `terraform plan`. This time you should see a yellow warning block telling you that development overrides are in place. Your plan should show that service4 has an owner_id and it should show that the owner_id will go from set to null if you applied this plan. 
1. Run `terraform apply -refresh-only` to pick up the owner id.
1. Set owner_id on service4 in your main.tf
   ```
   resource "firehydrant_service" "service4" {
     name         = "service4"
     description  = "description4"
     owner_id     = "d737b6d4-ae88-401f-88a1-945c0c91302b"
     service_tier = 4
     labels = {
       test = "four"
    }
   }
   ```
1. Run `terraform plan` again. This should show no changes.
1. Run `terraform destroy`. This should succeed and should remove any services you created.

#### Happy path - Create:
1. Run `terraform apply`. This should succeed and if you check in the UI, you should see the services you just created.

#### Happy path - Update:
1. Uncomment the team block in you main.tf and change service4's owner_id to this new team's ID:
   ```
   resource "firehydrant_service" "service4" {
     name         = "service4"
     description  = "description4"
     owner_id     = firehydrant_team.team.id
     service_tier = 4
     labels = {
       test = "four"
     }
   }

   resource "firehydrant_team" "team" {
     name        = "team"
   }
   ```
1. Run `terraform apply`. This should show that the new team will be created and the owner_id on service4 will change. It should succeed and you should see these changes reflected in the UI.
1. Remove the owner_id from service4 and run `terraform apply` again. This should succeed and should remove the owner from the UI.

#### Happy path - Destroy:
1. Run `terraform destroy`. This should succeed and should remove any services you created.

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/b3A6Njc2NzMy-create-a-service)
- [Related PR](https://github.com/firehydrant/terraform-provider-firehydrant/pull/12)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.