### PR TITLE
Make sure all test resource identifiers are unique in acceptance tests

### DIFF
--- a/provider/functionalities_test.go
+++ b/provider/functionalities_test.go
@@ -25,14 +25,14 @@ func TestAccFunctionalities(t *testing.T) {
 				Config: testFunctionalityConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testFunctionalityExists("firehydrant_functionality.terraform-acceptance-test-functionality"),
-					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "name", rName),
+					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "name", fmt.Sprintf("test-functionality-%s", rName)),
 				),
 			},
 			{
 				Config: testFunctionalityConfig(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testFunctionalityExists("firehydrant_functionality.terraform-acceptance-test-functionality"),
-					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "name", rNameUpdated),
+					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "name", fmt.Sprintf("test-functionality-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "services.#", "0"),
 				),
 			},
@@ -40,10 +40,10 @@ func TestAccFunctionalities(t *testing.T) {
 				Config: testFunctionalityConfigWithService(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testFunctionalityExists("firehydrant_functionality.terraform-acceptance-test-functionality"),
-					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "name", rNameUpdated),
+					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "name", fmt.Sprintf("test-functionality-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "services.#", "1"),
 					resource.TestCheckResourceAttrSet("firehydrant_functionality.terraform-acceptance-test-functionality", "services.0.id"),
-					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "services.0.name", "test service from terraform"),
+					resource.TestCheckResourceAttr("firehydrant_functionality.terraform-acceptance-test-functionality", "services.0.name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 				),
 			},
 		},
@@ -52,7 +52,7 @@ func TestAccFunctionalities(t *testing.T) {
 
 const testFunctionalityConfigTemplate = `
 resource "firehydrant_functionality" "terraform-acceptance-test-functionality" {
-	name = "%s"
+	name = "test-functionality-%s"
 }
 `
 
@@ -62,11 +62,11 @@ func testFunctionalityConfig(rName string) string {
 
 const testFunctionalityWithService = `
 resource "firehydrant_service" "service" {
-	name = "test service from terraform"
+	name = "test-service-%s"
 }
 
 resource "firehydrant_functionality" "terraform-acceptance-test-functionality" {
-	name = "%s"
+	name = "test-functionality-%s"
 
 	services {
 		id = firehydrant_service.service.id
@@ -75,7 +75,7 @@ resource "firehydrant_functionality" "terraform-acceptance-test-functionality" {
 `
 
 func testFunctionalityConfigWithService(rName string) string {
-	return fmt.Sprintf(testFunctionalityWithService, rName)
+	return fmt.Sprintf(testFunctionalityWithService, rName, rName)
 }
 
 func testFunctionalityExists(resourceName string) resource.TestCheckFunc {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -35,22 +35,22 @@ func TestAccService(t *testing.T) {
 				Config: testServiceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testServiceExists("firehydrant_service.terraform-acceptance-test-service"),
-					resource.TestCheckResourceAttr("firehydrant_service.terraform-acceptance-test-service", "name", rName),
-					resource.TestCheckResourceAttr("firehydrant_service.terraform-acceptance-test-service", "description", rName+" description"),
+					resource.TestCheckResourceAttr("firehydrant_service.terraform-acceptance-test-service", "name", fmt.Sprintf("test-service-%s", rName)),
+					resource.TestCheckResourceAttr("firehydrant_service.terraform-acceptance-test-service", "description", fmt.Sprintf("%s description", rName)),
 				),
 			},
 			{
 				Config: testServiceConfig(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testServiceExists("firehydrant_service.terraform-acceptance-test-service"),
-					resource.TestCheckResourceAttr("firehydrant_service.terraform-acceptance-test-service", "name", rNameUpdated),
-					resource.TestCheckResourceAttr("firehydrant_service.terraform-acceptance-test-service", "description", rNameUpdated+" description"),
+					resource.TestCheckResourceAttr("firehydrant_service.terraform-acceptance-test-service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr("firehydrant_service.terraform-acceptance-test-service", "description", fmt.Sprintf("%s description", rNameUpdated)),
 				),
 			},
 			{
 				Config: testServiceDataSourceConfig(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.firehydrant_services.services", "services.0.name", rNameUpdated),
+					resource.TestCheckResourceAttr("data.firehydrant_services.services", "services.0.name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr("data.firehydrant_services.services", "services.0.service_tier", "5"),
 				),
 			},
@@ -66,7 +66,7 @@ func testFireHydrantIsSetup(t *testing.T) {
 
 const testServiceConfigTemplate = `
 resource "firehydrant_service" "terraform-acceptance-test-service" {
-	name = "%s"
+	name = "test-service-%s"
 	description = "%s description"
 	labels = {
 		key1 = "value1"
@@ -76,13 +76,13 @@ resource "firehydrant_service" "terraform-acceptance-test-service" {
 `
 
 func testServiceDataSourceConfig(rName string) string {
-	return fmt.Sprintf(testServiceDataSourceConfigTemplate, rName, rName)
+	return fmt.Sprintf(testServiceDataSourceConfigTemplate, rName, rName, rName)
 }
 
 const testServiceDataSourceConfigTemplate = `
 resource "firehydrant_service" "terraform-acceptance-test-service" {
-	name = "%s"
-	description = "whatever"
+	name = "test-service-%s"
+	description = "%s description"
 	labels = {
 		key1 = "value1"
 	}

--- a/provider/runbooks_test.go
+++ b/provider/runbooks_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestAccRunbooks(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testFireHydrantIsSetup(t) },
@@ -23,7 +24,7 @@ func TestAccRunbooks(t *testing.T) {
 			{
 				Config: testRunbookResourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("firehydrant_runbook.default-incident-process", "name", rName),
+					resource.TestCheckResourceAttr("firehydrant_runbook.default-incident-process", "name", fmt.Sprintf("test-runbook-%s", rName)),
 					resource.TestCheckResourceAttr("firehydrant_runbook.default-incident-process", "description", "this is my description"),
 					resource.TestCheckResourceAttr("firehydrant_runbook.default-incident-process", "steps.#", "1"),
 					resource.TestCheckResourceAttr("firehydrant_runbook.default-incident-process", "steps.0.name", "Create Incident Channel"),
@@ -32,9 +33,9 @@ func TestAccRunbooks(t *testing.T) {
 				),
 			},
 			{
-				Config: testRunbookResourceConfig(rName + " updated"),
+				Config: testRunbookResourceConfig(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("firehydrant_runbook.default-incident-process", "name", rName+" updated"),
+					resource.TestCheckResourceAttr("firehydrant_runbook.default-incident-process", "name", fmt.Sprintf("test-runbook-%s", rNameUpdated)),
 				),
 			},
 		},
@@ -76,7 +77,7 @@ resource "firehydrant_severity" "sev1" {
 }
 
 resource "firehydrant_runbook" "default-incident-process" {
-	name = "%s"
+	name = "test-runbook-%s"
 	type = "incident"
 	description = "this is my description"
 

--- a/provider/serverities_test.go
+++ b/provider/serverities_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAccSeverities(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testFireHydrantIsSetup(t) },
@@ -26,7 +26,7 @@ func TestAccSeverities(t *testing.T) {
 				Config: testSeverityConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testSeverityExists("firehydrant_severity.terraform-acceptance-test-severity"),
-					resource.TestCheckResourceAttr("firehydrant_severity.terraform-acceptance-test-severity", "slug", strings.ToUpper(rName)),
+					resource.TestCheckResourceAttr("firehydrant_severity.terraform-acceptance-test-severity", "slug", fmt.Sprintf("TESTSEVERITY%s", rName)),
 				),
 			},
 			// TODO(bobbytables): Updating severities in Terraform is currently problematic because FireHydrant uses
@@ -45,7 +45,7 @@ func TestAccSeverities(t *testing.T) {
 
 const testSeverityConfigTemplate = `
 resource "firehydrant_severity" "terraform-acceptance-test-severity" {
-	slug = "%s"
+	slug = "TESTSEVERITY%s"
 }
 `
 

--- a/provider/teams_test.go
+++ b/provider/teams_test.go
@@ -26,14 +26,14 @@ func TestAccTeams(t *testing.T) {
 				Config: testTeamConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testTeamExists("firehydrant_team.terraform-acceptance-test-team"),
-					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "name", rName),
+					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "name", fmt.Sprintf("test-team-%s", rName)),
 				),
 			},
 			{
 				Config: testTeamConfig(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testTeamExists("firehydrant_team.terraform-acceptance-test-team"),
-					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "name", rNameUpdated),
+					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "name", fmt.Sprintf("test-team-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "services.#", "0"),
 				),
 			},
@@ -41,10 +41,10 @@ func TestAccTeams(t *testing.T) {
 				Config: testTeamConfigWithService(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testTeamExists("firehydrant_team.terraform-acceptance-test-team"),
-					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "name", rNameUpdated),
+					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "name", fmt.Sprintf("test-team-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "services.#", "1"),
 					resource.TestCheckResourceAttrSet("firehydrant_team.terraform-acceptance-test-team", "services.0.id"),
-					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "services.0.name", "test service from terraform"),
+					resource.TestCheckResourceAttr("firehydrant_team.terraform-acceptance-test-team", "services.0.name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 				),
 			},
 		},
@@ -53,7 +53,7 @@ func TestAccTeams(t *testing.T) {
 
 const testTeamConfigTemplate = `
 resource "firehydrant_team" "terraform-acceptance-test-team" {
-	name = "%s"
+	name = "test-team-%s"
 }
 `
 
@@ -63,11 +63,11 @@ func testTeamConfig(rName string) string {
 
 const testTeamWithService = `
 resource "firehydrant_service" "service" {
-	name = "test service from terraform"
+	name = "test-service-%s"
 }
 
 resource "firehydrant_team" "terraform-acceptance-test-team" {
-	name = "%s"
+	name = "test-team-%s"
 
 	services {
 		id = firehydrant_service.service.id
@@ -76,7 +76,7 @@ resource "firehydrant_team" "terraform-acceptance-test-team" {
 `
 
 func testTeamConfigWithService(rName string) string {
-	return fmt.Sprintf(testTeamWithService, rName)
+	return fmt.Sprintf(testTeamWithService, rName, rName)
 }
 
 func testTeamExists(resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
## Description

This PR makes sure all the test resources have unique identifiers. This will prevent tests from failing because of resource name collisions.

## Testing plan

1. Make sure tests all pass.

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.