### PR TITLE
Add examples to the documentation for d/service, d/services, and r/service

### DIFF
--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -20,15 +20,14 @@ data "firehydrant_service" "example-service" {
 
 ### Required
 
-- **id** (String, Required) The ID of this resource.
+- **id** (String, Required) The ID of the service.
 
-### Optional
-
-- **service_tier** (Integer, Optional) The Service Tier of this resource - between 1 - 5.
-- **add_on_alert** (Boolean, Optional)
--
 ### Read-only
 
-- **description** (String, Read-only)
-- **name** (String, Read-only)
-- **add_on_alert** (Boolean, Optional)
+- **add_on_alert** (Boolean, Read-only) Indicates if FireHydrant should automatically create
+  an alert based on the integrations set up for this service, if this service is added to an
+  active incident. Defaults to `false`.
+- **description** (String, Read-only) A description for the service.
+- **name** (String, Read-only) The name of the service.
+- **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
+  Lower values represent higher criticality. Defaults to `5`.

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -7,9 +7,14 @@ description: |-
 
 # Data Source `firehydrant_service`
 
+## Example Usage
 
-
-
+Basic usage:
+```hcl
+data "firehydrant_service" "example-service" {
+  id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
 
 ## Schema
 
@@ -20,10 +25,10 @@ description: |-
 ### Optional
 
 - **service_tier** (Integer, Optional) The Service Tier of this resource - between 1 - 5.
-
+- **add_on_alert** (Boolean, Optional)
+-
 ### Read-only
 
 - **description** (String, Read-only)
 - **name** (String, Read-only)
 - **add_on_alert** (Boolean, Optional)
-

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -2,14 +2,34 @@
 page_title: "firehydrant_services Data Source - terraform-provider-firehydrant"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # Data Source `firehydrant_services`
 
+## Example Usage
 
+Basic usage:
+```hcl
+data "firehydrant_services" "all-services" {
+}
+```
 
+Getting all services with `database` in the name:
+```hcl
+data "firehydrant_services" "database-named-services" {
+  query = "database"
+}
+```
 
+Getting all services with the label `managed: true`:
+```hcl
+data "firehydrant_services" "managed-true-labeled-services" {
+  labels = {
+    managed = "true"
+  }
+}
+```
 
 ## Schema
 
@@ -29,5 +49,3 @@ description: |-
 - **description** (String)
 - **id** (String)
 - **name** (String)
-
-

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -46,6 +46,12 @@ data "firehydrant_services" "managed-true-labeled-services" {
 <a id="nestedatt--services"></a>
 ### Nested Schema for `services`
 
-- **description** (String)
-- **id** (String)
-- **name** (String)
+- **id** (String, Read-only) The ID of the service.
+- **add_on_alert** (Boolean, Read-only) Indicates if FireHydrant should automatically create
+  an alert based on the integrations set up for this service, if this service is added to an
+  active incident. Defaults to `false`.
+- **description** (String, Read-only) A description for the service.
+- **name** (String, Read-only) The name of the service.
+- **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
+  Lower values represent higher criticality. Defaults to `5`.
+

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -35,8 +35,15 @@ resource "firehydrant_service" "example-service" {
 
 ### Optional
 
-- **description** (String, Optional)
-- **id** (String, Optional) The ID of this resource.
-- **service_tier** (Integer, Optional) The Service Tier of this resource - between 1 - 5.
-- **labels** (Map of String, Optional)
-- **add_on_alert** (Boolean, Optional)
+- **add_on_alert** (Boolean, Optional) Indicates if FireHydrant should automatically create 
+   an alert based on the integrations set up for this service, if this service is added to an 
+   active incident. Defaults to `false`.
+- **description** (String, Optional) A description for the service.
+- **labels** (Map of String, Optional) Key-value pairs associated with the service. Useful for 
+   supporting searching and filtering of the service catalog.
+- **service_tier** (Integer, Optional) The service tier of this resource - between 1 - 5. 
+   Lower values represent higher criticality. Defaults to `5`.
+
+### Read-only
+
+- **id** (String, Read-only) The ID of the service.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -7,9 +7,25 @@ description: |-
 
 # Resource `firehydrant_service`
 
+## Example Usage
 
+Basic usage:
 
-
+```hcl
+resource "firehydrant_service" "example-service" {
+  name         = "my-example-service"
+  add_on_alert = true
+  description  = "The main service for our company"
+  labels = {
+    language  = "ruby",
+    lifecycle = "production"
+    system    = "main"
+    type      = "user"
+    tags      = "foo; bar; baz"
+  }
+  service_tier = 1
+}
+```
 
 ## Schema
 
@@ -23,6 +39,4 @@ description: |-
 - **id** (String, Optional) The ID of this resource.
 - **service_tier** (Integer, Optional) The Service Tier of this resource - between 1 - 5.
 - **labels** (Map of String, Optional)
-- - **add_on_alert** (Boolean, Optional)
-
-
+- **add_on_alert** (Boolean, Optional)


### PR DESCRIPTION
## Description

This PR adds working Terraform config examples to the service data sources and resource. This will help anyone using the provider understand how to get started configuring their resources.

## Testing plan

1. Read the docs to make sure there are no typos or anything
1. Run the examples in Terraform if you'd like

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.