### PR TITLE
Add links to r/service and add links & labels to d/service, & d/services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,16 @@ ENHANCEMENTS:
 * resource/service: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
 * resource/service: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
 * resource/service: Added the `team_ids` attribute to services ([#54](https://github.com/firehydrant/terraform-provider-firehydrant/pull/54))
+* resource/service: Added the `links` attribute to services ([#30](https://github.com/firehydrant/terraform-provider-firehydrant/pull/30))
 * data_source/functionality: Added the `service_ids` attribute to functionality ([#49](https://github.com/firehydrant/terraform-provider-firehydrant/pull/49))
 * data_source/service: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
 * data_source/service: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
 * data_source/service: Added the `team_ids` attribute to services ([#54](https://github.com/firehydrant/terraform-provider-firehydrant/pull/54))
+* data_source/service: Added the `links` and `labels` attributes to services ([#30](https://github.com/firehydrant/terraform-provider-firehydrant/pull/30))
 * data_source/services: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
 * data_source/services: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
 * data_source/services: Added the `team_ids` attribute to services ([#54](https://github.com/firehydrant/terraform-provider-firehydrant/pull/54))
+* data_source/services: Added the `links` and `labels` attributes to services ([#30](https://github.com/firehydrant/terraform-provider-firehydrant/pull/30))
 
 
 NOTES:

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -28,9 +28,14 @@ data "firehydrant_service" "example-service" {
   an alert based on the integrations set up for this service, if this service is added to an
   active incident. Defaults to `false`.
 - **description** (String, Read-only) A description for the service.
+- **links** (Set of Map, Read-only) Links associated with the service (see [below for nested schema](#nestedatt--links)).
 - **name** (String, Read-only) The name of the service.
 - **owner_id** (String, Read-only) The ID of the team that owns this service.
 - **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
   Lower values represent higher criticality. Defaults to `5`.
 - **team_ids** (Set of String, Optional) A set of IDs of the teams responsible for this service's incident response.
+<a id="nestedatt--links"></a>
+### Nested Schema for `links`
 
+- **href_url** (String, Read-only) The URL to use for the link.
+- **name** (String, Read-only) The name of the link.

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -28,6 +28,8 @@ data "firehydrant_service" "example-service" {
   an alert based on the integrations set up for this service, if this service is added to an
   active incident. Defaults to `false`.
 - **description** (String, Read-only) A description for the service.
+- **labels** (Map of String, Read-only) Key-value pairs associated with the service. Useful for
+  supporting searching and filtering of the service catalog.
 - **links** (Set of Map, Read-only) Links associated with the service (see [below for nested schema](#nestedatt--links)).
 - **name** (String, Read-only) The name of the service.
 - **owner_id** (String, Read-only) The ID of the team that owns this service.

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -41,7 +41,6 @@ data "firehydrant_services" "managed-true-labeled-services" {
 ### Read-only
 
 - **services** (List of Object, Read-only) (see [below for nested schema](#nestedatt--services))
-
 <a id="nestedatt--services"></a>
 ### Nested Schema for `services`
 
@@ -50,8 +49,14 @@ data "firehydrant_services" "managed-true-labeled-services" {
   an alert based on the integrations set up for this service, if this service is added to an
   active incident. Defaults to `false`.
 - **description** (String, Read-only) A description for the service.
+- **links** (Set of Map, Read-only) Links associated with the service (see [below for nested schema](#nestedatt--links)).
 - **name** (String, Read-only) The name of the service.
 - **owner_id** (String, Read-only) The ID of the team that owns this service.
 - **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
   Lower values represent higher criticality. Defaults to `5`.
 - **team_ids** (Set of String, Optional) A set of IDs of the teams responsible for this service's incident response.
+<a id="nestedatt--links"></a>
+### Nested Schema for `links`
+
+- **href_url** (String, Read-only) The URL to use for the link.
+- **name** (String, Read-only) The name of the link.

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -49,6 +49,8 @@ data "firehydrant_services" "managed-true-labeled-services" {
   an alert based on the integrations set up for this service, if this service is added to an
   active incident. Defaults to `false`.
 - **description** (String, Read-only) A description for the service.
+- **labels** (Map of String, Read-only) Key-value pairs associated with the service. Useful for
+  supporting searching and filtering of the service catalog.
 - **links** (Set of Map, Read-only) Links associated with the service (see [below for nested schema](#nestedatt--links)).
 - **name** (String, Read-only) The name of the service.
 - **owner_id** (String, Read-only) The ID of the team that owns this service.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -31,7 +31,7 @@ resource "firehydrant_service" "example-service" {
   name         = "my-example-service"
   add_on_alert = true
   description  = "The main service for our company"
-  
+
   labels = {
     language  = "ruby",
     lifecycle = "production"
@@ -39,9 +39,13 @@ resource "firehydrant_service" "example-service" {
     type      = "user"
     tags      = "foo; bar; baz"
   }
-  
-  owner_id = firehydrant_team.example-owner-team.id
 
+  links {
+    href_url = "https://example.com/internal-dashboard"
+    name     = "Internal Dashboard"
+  }
+
+  owner_id     = firehydrant_team.example-owner-team.id
   service_tier = 1
 
   team_ids = [
@@ -60,15 +64,21 @@ resource "firehydrant_service" "example-service" {
 ### Optional
 
 - **add_on_alert** (Boolean, Optional) Indicates if FireHydrant should automatically create 
-   an alert based on the integrations set up for this service, if this service is added to an 
-   active incident. Defaults to `false`.
+  an alert based on the integrations set up for this service, if this service is added to an 
+  active incident. Defaults to `false`.
 - **description** (String, Optional) A description for the service.
 - **labels** (Map of String, Optional) Key-value pairs associated with the service. Useful for 
-   supporting searching and filtering of the service catalog.
+  supporting searching and filtering of the service catalog.
+- **links** (Set of Map, Optional) Links associated with the service (see [below for nested schema](#nestedatt--links)).
 - **owner_id** (String, Optional) The ID of the team that owns this service.
 - **service_tier** (Integer, Optional) The service tier of this resource - between 1 - 5. 
-   Lower values represent higher criticality. Defaults to `5`.
+  Lower values represent higher criticality. Defaults to `5`.
 - **team_ids** (Set of String, Optional) A set of IDs of the teams responsible for this service's incident response.
+<a id="nestedatt--links"></a>
+### Nested Schema for `links`
+
+- **href_url** (String, Required) The URL to use for the link.
+- **name** (String, Required) The name of the link.
 
 ### Read-only
 

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -30,6 +30,7 @@ type CreateServiceRequest struct {
 	AlertOnAdd  bool              `json:"alert_on_add,omitempty"`
 	Description string            `json:"description"`
 	Labels      map[string]string `json:"labels,omitempty"`
+	Links       []ServiceLink     `json:"links,omitempty"`
 	Name        string            `json:"name"`
 	Owner       *ServiceTeam      `json:"owner,omitempty"`
 	ServiceTier int               `json:"service_tier,int,omitempty"`
@@ -47,12 +48,20 @@ type ServiceTeam struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// ServiceLink represents a link when creating/updating a service
+type ServiceLink struct {
+	ID      string `json:"id,omitempty"`
+	Name    string `json:"name"`
+	HrefURL string `json:"href_url"`
+}
+
 // UpdateServiceRequest is the payload for updating a service
 // URL: PATCH https://api.firehydrant.io/v1/services/{id}
 type UpdateServiceRequest struct {
 	AlertOnAdd           bool              `json:"alert_on_add"`
 	Description          string            `json:"description"`
 	Labels               map[string]string `json:"labels"`
+	Links                []ServiceLink     `json:"links"`
 	Name                 string            `json:"name,omitempty"`
 	Owner                *ServiceTeam      `json:"owner"`
 	RemoveOwner          bool              `json:"remove_owner,omitempty"`
@@ -68,6 +77,7 @@ type ServiceResponse struct {
 	AlertOnAdd  bool              `json:"alert_on_add"`
 	Description string            `json:"description"`
 	Labels      map[string]string `json:"labels"`
+	Links       []ServiceLink     `json:"links"`
 	Name        string            `json:"name"`
 	Owner       *ServiceTeam      `json:"owner"`
 	ServiceTier int               `json:"service_tier"`

--- a/provider/service_data.go
+++ b/provider/service_data.go
@@ -13,10 +13,13 @@ func dataSourceService() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataFireHydrantService,
 		Schema: map[string]*schema.Schema{
+			// Required
 			"id": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
+			// Computed
 			"alert_on_add": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -24,6 +27,23 @@ func dataSourceService() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"links": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Computed
+						"href_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -54,37 +74,48 @@ func dataFireHydrantService(ctx context.Context, d *schema.ResourceData, m inter
 
 	// Get the service
 	serviceID := d.Get("id").(string)
-	r, err := firehydrantAPIClient.Services().Get(ctx, serviceID)
+	serviceResponse, err := firehydrantAPIClient.Services().Get(ctx, serviceID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	svc := map[string]interface{}{
-		"alert_on_add": r.AlertOnAdd,
-		"description":  r.Description,
-		"name":         r.Name,
-		"service_tier": r.ServiceTier,
+	// Set values in state
+	attributes := map[string]interface{}{
+		"alert_on_add": serviceResponse.AlertOnAdd,
+		"description":  serviceResponse.Description,
+		"name":         serviceResponse.Name,
+		"service_tier": serviceResponse.ServiceTier,
 	}
 
 	// Process any attributes that could be nil
-	if r.Owner != nil {
-		svc["owner_id"] = r.Owner.ID
+	var links []interface{}
+	for _, currentLink := range serviceResponse.Links {
+		links = append(links, map[string]interface{}{
+			"href_url": currentLink.HrefURL,
+			"name":     currentLink.Name,
+		})
+	}
+	attributes["links"] = links
+
+	if serviceResponse.Owner != nil {
+		attributes["owner_id"] = serviceResponse.Owner.ID
 	}
 
 	var teamIDs []interface{}
-	for _, team := range r.Teams {
+	for _, team := range serviceResponse.Teams {
 		teamIDs = append(teamIDs, team.ID)
 	}
-	svc["team_ids"] = teamIDs
+	attributes["team_ids"] = teamIDs
 
 	// Set the data source attributes to the values we got from the API
-	for key, val := range svc {
-		if err := d.Set(key, val); err != nil {
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	d.SetId(r.ID)
+	// Set the service's ID in state
+	d.SetId(serviceResponse.ID)
 
 	return diag.Diagnostics{}
 }

--- a/provider/service_data.go
+++ b/provider/service_data.go
@@ -28,6 +28,10 @@ func dataSourceService() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
 			"links": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -83,6 +87,7 @@ func dataFireHydrantService(ctx context.Context, d *schema.ResourceData, m inter
 	attributes := map[string]interface{}{
 		"alert_on_add": serviceResponse.AlertOnAdd,
 		"description":  serviceResponse.Description,
+		"labels":       serviceResponse.Labels,
 		"name":         serviceResponse.Name,
 		"service_tier": serviceResponse.ServiceTier,
 	}

--- a/provider/service_data_test.go
+++ b/provider/service_data_test.go
@@ -48,6 +48,14 @@ func TestAccServiceDataSource_allAttributes(t *testing.T) {
 						"data.firehydrant_service.test_service", "alert_on_add", "true"),
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "labels.test", fmt.Sprintf("test-label-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "links.#", "2"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "links.0.name", fmt.Sprintf("test-link1-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "links.0.href_url", fmt.Sprintf("https://example.com/test-link1-%s", rName)),
 					resource.TestCheckResourceAttrSet("data.firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_service.test_service", "service_tier", "1"),
@@ -87,6 +95,20 @@ resource "firehydrant_service" "test_service" {
   name         = "test-service-%s"
   alert_on_add = true
   description  = "test-description-%s"
+  
+  labels = {
+    test = "test-label-%s"
+  }
+
+  links {
+    href_url = "https://example.com/test-link1-%s"
+    name = "test-link1-%s"
+  }
+  links {
+    href_url = "https://example.com/test-link2-%s"
+    name = "test-link2-%s"
+  }
+
   owner_id     = firehydrant_team.test_team1.id
   service_tier = "1"
   team_ids = [
@@ -97,5 +119,5 @@ resource "firehydrant_service" "test_service" {
 
 data "firehydrant_service" "test_service" {
   id = firehydrant_service.test_service.id
-}`, rName, rName, rName, rName, rName)
+}`, rName, rName, rName, rName, rName, rName, rName, rName, rName, rName)
 }

--- a/provider/service_resource_test.go
+++ b/provider/service_resource_test.go
@@ -75,6 +75,8 @@ func TestAccServiceResource_update(t *testing.T) {
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "links.#", "2"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
@@ -121,6 +123,8 @@ func TestAccServiceResource_updateLabels(t *testing.T) {
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "links.#", "2"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
@@ -142,6 +146,8 @@ func TestAccServiceResource_updateLabels(t *testing.T) {
 						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "labels.test2", fmt.Sprintf("test-label2-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "links.#", "2"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
@@ -193,6 +199,8 @@ func TestAccServiceResource_updateOwnerIDAndTeamIDs(t *testing.T) {
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "links.#", "2"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
@@ -212,6 +220,8 @@ func TestAccServiceResource_updateOwnerIDAndTeamIDs(t *testing.T) {
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "links.#", "2"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
@@ -231,6 +241,8 @@ func TestAccServiceResource_updateOwnerIDAndTeamIDs(t *testing.T) {
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "links.#", "2"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
@@ -334,6 +346,10 @@ func testAccCheckServiceResourceExistsWithAttributes_basic(resourceName string) 
 			return fmt.Errorf("Unexpected number of labels. Expected no labels, got: %v", len(serviceResponse.Labels))
 		}
 
+		if len(serviceResponse.Links) != 0 {
+			return fmt.Errorf("Unexpected number of links. Expected no links, got: %v", len(serviceResponse.Links))
+		}
+
 		if serviceResponse.Owner != nil {
 			return fmt.Errorf("Unexpected owner. Expected no owner ID, got: %s", serviceResponse.Owner.ID)
 		}
@@ -396,6 +412,11 @@ func testAccCheckServiceResourceExistsWithAttributes_update(resourceName string)
 			if serviceResource.Primary.Attributes[key] != labelValue {
 				return fmt.Errorf("Unexpected label. Expected %s:%s, got: %s:%s", labelKey, labelValue, labelKey, serviceResource.Primary.Attributes[key])
 			}
+		}
+
+		// TODO: check link attributes
+		if len(serviceResponse.Links) == 0 {
+			return fmt.Errorf("Unexpected number of links. Expected at least 1 link, got: %v", len(serviceResponse.Links))
 		}
 
 		if serviceResponse.Owner == nil {
@@ -474,13 +495,21 @@ resource "firehydrant_service" "test_service" {
   labels = {
     test1 = "test-label1-%s",
   }
+  links {
+    href_url = "https://example.com/test-link1-%s"
+    name = "test-link1-%s"
+  }
+  links {
+    href_url = "https://example.com/test-link2-%s"
+    name = "test-link2-%s"
+  }
   owner_id     = firehydrant_team.test_team1.id
   service_tier = "1"
   team_ids = [
     firehydrant_team.test_team2.id,
     firehydrant_team.test_team3.id
   ]
-}`, rName, rName, rName, rName, rName, rName)
+}`, rName, rName, rName, rName, rName, rName, rName, rName, rName, rName)
 }
 
 func testAccServiceResourceConfig_updateChangeLabels(rName string) string {
@@ -505,13 +534,21 @@ resource "firehydrant_service" "test_service" {
     test1 = "test-label1-%s",
     test2 = "test-label2-%s"
   }
+  links {
+    href_url = "https://example.com/test-link1-%s"
+    name = "test-link1-%s"
+  }
+  links {
+    href_url = "https://example.com/test-link2-%s"
+    name = "test-link2-%s"
+  }
   owner_id     = firehydrant_team.test_team1.id
   service_tier = "1"
   team_ids = [
     firehydrant_team.test_team2.id,
     firehydrant_team.test_team3.id
   ]
-}`, rName, rName, rName, rName, rName, rName, rName)
+}`, rName, rName, rName, rName, rName, rName, rName, rName, rName, rName, rName)
 }
 
 func testAccServiceResourceConfig_updateChangeOwnerIDAndTeamIDs(rName string) string {
@@ -535,11 +572,19 @@ resource "firehydrant_service" "test_service" {
   labels = {
     test1 = "test-label1-%s"
   }
+  links {
+    href_url = "https://example.com/test-link1-%s"
+    name = "test-link1-%s"
+  }
+  links {
+    href_url = "https://example.com/test-link2-%s"
+    name = "test-link2-%s"
+  }
   owner_id     = firehydrant_team.test_team2.id
   service_tier = "1"
   team_ids = [
     firehydrant_team.test_team1.id,
     firehydrant_team.test_team3.id
   ]
-}`, rName, rName, rName, rName, rName, rName)
+}`, rName, rName, rName, rName, rName, rName, rName, rName, rName, rName)
 }

--- a/provider/services_data.go
+++ b/provider/services_data.go
@@ -59,6 +59,7 @@ func dataFireHydrantServices(ctx context.Context, d *schema.ResourceData, m inte
 			"id":           service.ID,
 			"alert_on_add": service.AlertOnAdd,
 			"description":  service.Description,
+			"labels":       service.Labels,
 			"name":         service.Name,
 			"service_tier": service.ServiceTier,
 		}


### PR DESCRIPTION
## Description

This PR adds the links attribute to the schema for r/service, d/service, and d/services and adds the labels attribute to d/service and d/service. It also updates relevant documentation and does some minor clean up to make things a little more consistent.

Closes #46 
Closes #18 

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-tfe /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     #dev_overrides {
     #  "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     #}

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/8336384/terraform-service-links.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In your FH org, create two services, one with at least one label and link and another with no labels or links. Copy their IDs and use them to replace the placeholder ID values for your service data sources.
1. Run `terraform init`.

#### Upgrading - Existing services with no links:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the service you just created.
1. Edit your ~/.terraformrc file and remove the comments in front of the dev_overrides block
   ```
   dev_overrides {
     "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   }
   ```
1.  Run `terraform plan`. This time you should see a yellow warning block telling you that development overrides are in place. Your plan should show no changes. Go ahead and run `terraform apply -refresh-only` to pick up state updates from some of the other unreleased attributes.
1. Run `terraform destroy`. This should succeed and should remove any services you created.
1. Edit your ~/.terraformrc file and comment out the dev_overrides block
   ```
   #dev_overrides {
   # "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   #}
   ```

#### Upgrading - Existing services with an owner set:
1. Run `terraform apply`. This should succeed and if you check in the UI, you should see the services you just created.
1. Update service1 to have an link in the UI.
1. Edit your ~/.terraformrc file and remove the comments in front of the dev_overrides block
   ```
   dev_overrides {
     "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   }
   ```
1.  Run `terraform plan`. This time you should see a yellow warning block telling you that development overrides are in place. Your plan should show that service1 has a link and it should show that the link will go from set to null if you apply this plan. 
1. Run `terraform apply -refresh-only` to pick up the link.
1. Set the link on service1 in your main.tf, replacing the link name an href_url with the values you used
   ```
   resource "firehydrant_service" "service4" {
     name         = "service1"
     links {
      href_url = "YOUR_URL"
      name     = "YOUR_LINK_NAME"
    }
   }
   ```
1. Run `terraform plan` again. This should show no changes.
1. Run `terraform destroy`. This should succeed and should remove the service you created.

#### Happy path - Create:
1. Run `terraform apply`. This should succeed and if you check in the UI, you should see the service you just created.

#### Happy path - Update:
1. Add more links by uncommenting the links blocks in your main.tf:
   ```
   resource "firehydrant_service" "service1" {
       name = "service1"

       links {
         href_url = "YOUR_URL"
         name     = "YOUR_LINK_NAME"
       }
       links {
           href_url = "https://example.com/internal-dashboard"
           name     = "Internal Dashboard"
       }
       links {
           href_url = "https://example.com/"
           name     = "example"
           icon_url = "https://example.com/icon"
       }
   }
   ```
1. Run `terraform apply`. This should show that the new links will be added. It should succeed and you should see these changes reflected in the UI.
1. Update a link by changing its name or href_url and run `terraform apply`. This should show that the only the link you updated will be deleted and recreated. It should succeed and you should see these changes reflected in the UI.
1. Remove all of the links from service1 and run `terraform apply` again. This should succeed and should remove the links from the UI. Running `terraform plan` should show no changes.

#### Happy path - Destroy:
1. Run `terraform destroy`. This should succeed and should remove any services you created.

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/b3A6Njc2NzMy-create-a-service)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.