### PR TITLE
Fix bug preventing the removal of labels in r/service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 
 * resource/service: Fixed bug that prevented the `description` attribute from being unset ([#51](https://github.com/firehydrant/terraform-provider-firehydrant/pull/51))
+* resource/service: Fixed bug that prevented `labels` from being removed from services ([#52](https://github.com/firehydrant/terraform-provider-firehydrant/pull/52))
 
 ENHANCEMENTS:
 

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -51,7 +51,7 @@ type ServiceTeam struct {
 type UpdateServiceRequest struct {
 	AlertOnAdd  bool              `json:"alert_on_add"`
 	Description string            `json:"description"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Labels      map[string]string `json:"labels"`
 	Name        string            `json:"name,omitempty"`
 	Owner       *ServiceTeam      `json:"owner,omitempty"`
 	RemoveOwner bool              `json:"remove_owner,omitempty"`

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -53,7 +53,7 @@ type UpdateServiceRequest struct {
 	Description string            `json:"description"`
 	Labels      map[string]string `json:"labels"`
 	Name        string            `json:"name,omitempty"`
-	Owner       *ServiceTeam      `json:"owner,omitempty"`
+	Owner       *ServiceTeam      `json:"owner"`
 	RemoveOwner bool              `json:"remove_owner,omitempty"`
 	ServiceTier int               `json:"service_tier,int"`
 }

--- a/provider/service_resource.go
+++ b/provider/service_resource.go
@@ -68,9 +68,11 @@ func readResourceFireHydrantService(ctx context.Context, d *schema.ResourceData,
 	}
 
 	// Process any attributes that could be nil
+	var ownerID string
 	if r.Owner != nil {
-		svc["owner_id"] = r.Owner.ID
+		ownerID = r.Owner.ID
 	}
+	svc["owner_id"] = ownerID
 
 	// Update the resource attributes to the values we got from the API
 	for key, val := range svc {
@@ -129,15 +131,12 @@ func updateResourceFireHydrantService(ctx context.Context, d *schema.ResourceDat
 		ServiceTier: d.Get("service_tier").(int),
 	}
 
-	// Process any optional attributes and add to the create request if necessary
-	// Only set ownerID if it has actually been changed
-	if d.HasChange("owner_id") {
-		ownerID, ownerIDSet := d.GetOk("owner_id")
-		if ownerIDSet {
-			r.Owner = &firehydrant.ServiceTeam{ID: ownerID.(string)}
-		} else {
-			r.RemoveOwner = true
-		}
+	// Process any optional attributes and add to the update request if necessary
+	ownerID, ownerIDSet := d.GetOk("owner_id")
+	if ownerIDSet {
+		r.Owner = &firehydrant.ServiceTeam{ID: ownerID.(string)}
+	} else {
+		r.RemoveOwner = true
 	}
 
 	// Update the service

--- a/provider/service_resource_test.go
+++ b/provider/service_resource_test.go
@@ -71,6 +71,8 @@ func TestAccServiceResource_update(t *testing.T) {
 						"firehydrant_service.test_service", "alert_on_add", "true"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rNameUpdated)),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
@@ -85,6 +87,75 @@ func TestAccServiceResource_update(t *testing.T) {
 						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "false"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceResource_updateLabels(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckServiceResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceResourceConfig_update(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_update("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rName)),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "1"),
+				),
+			},
+			{
+				Config: testAccServiceResourceConfig_updateChangeLabels(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_update("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "labels.test2", fmt.Sprintf("test-label2-%s", rNameUpdated)),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "1"),
+				),
+			},
+			{
+				Config: testAccServiceResourceConfig_basic(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_basic("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "false"),
+					// Make sure the labels are not set
+					resource.TestCheckNoResourceAttr(
+						"firehydrant_service.test_service", "labels.test1"),
+					resource.TestCheckNoResourceAttr(
+						"firehydrant_service.test_service", "labels.test2"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "5"),
 				),
@@ -112,6 +183,8 @@ func TestAccServiceResource_updateOwnerID(t *testing.T) {
 						"firehydrant_service.test_service", "alert_on_add", "true"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rName)),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
@@ -128,27 +201,27 @@ func TestAccServiceResource_updateOwnerID(t *testing.T) {
 						"firehydrant_service.test_service", "alert_on_add", "true"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rName)),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
 				),
 			},
 			{
-				Config: testAccServiceResourceConfig_updateRemoveOwnerID(rName),
+				Config: testAccServiceResourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServiceResourceExistsWithAttributes_updateRemoveOwnerID("firehydrant_service.test_service"),
+					testAccCheckServiceResourceExistsWithAttributes_basic("firehydrant_service.test_service"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
 					resource.TestCheckResourceAttr(
-						"firehydrant_service.test_service", "alert_on_add", "true"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+						"firehydrant_service.test_service", "alert_on_add", "false"),
 					// Make sure owner_id is not set
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "owner_id", ""),
 					resource.TestCheckResourceAttr(
-						"firehydrant_service.test_service", "service_tier", "1"),
+						"firehydrant_service.test_service", "service_tier", "5"),
 				),
 			},
 		},
@@ -209,9 +282,9 @@ func testAccCheckServiceResourceExistsWithAttributes_basic(resourceName string) 
 			return fmt.Errorf("Unexpected description. Expected no description, got: %s", serviceResponse.Description)
 		}
 
-		//if !reflect.DeepEqual(serviceResponse.Labels, []string{}) {
-		//	return fmt.Errorf("Bad labels: %v", serviceResponse.Labels)
-		//}
+		if len(serviceResponse.Labels) != 0 {
+			return fmt.Errorf("Unexpected number of labels. Expected no labels, got: %v", len(serviceResponse.Labels))
+		}
 
 		if serviceResponse.Owner != nil {
 			return fmt.Errorf("Unexpected owner. Expected no owner ID, got: %s", serviceResponse.Owner.ID)
@@ -261,9 +334,16 @@ func testAccCheckServiceResourceExistsWithAttributes_update(resourceName string)
 			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
 		}
 
-		//if !reflect.DeepEqual(serviceResponse.Labels, []string{}) {
-		//	return fmt.Errorf("Bad labels: %v", serviceResponse.Labels)
-		//}
+		if len(serviceResponse.Labels) == 0 {
+			return fmt.Errorf("Unexpected number of labels. Expected at least 1 label, got: %v", len(serviceResponse.Labels))
+		}
+
+		for labelKey, labelValue := range serviceResponse.Labels {
+			key := fmt.Sprintf("labels.%s", labelKey)
+			if serviceResource.Primary.Attributes[key] != labelValue {
+				return fmt.Errorf("Unexpected label. Expected %s:%s, got: %s:%s", labelKey, labelValue, labelKey, serviceResource.Primary.Attributes[key])
+			}
+		}
 
 		if serviceResponse.Owner == nil {
 			return fmt.Errorf("Unexpected owner. Expected owner to be set.")
@@ -271,58 +351,6 @@ func testAccCheckServiceResourceExistsWithAttributes_update(resourceName string)
 		expected, got = serviceResource.Primary.Attributes["owner_id"], serviceResponse.Owner.ID
 		if expected != got {
 			return fmt.Errorf("Unexpected owner ID. Expected:%s, got: %s", expected, got)
-		}
-
-		expected, got = serviceResource.Primary.Attributes["service_tier"], fmt.Sprintf("%d", serviceResponse.ServiceTier)
-		if expected != got {
-			return fmt.Errorf("Unexpected service_tier. Expected: %s, got: %s", expected, got)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckServiceResourceExistsWithAttributes_updateRemoveOwnerID(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		serviceResource, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		if serviceResource.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
-		if err != nil {
-			return err
-		}
-
-		serviceResponse, err := client.Services().Get(context.TODO(), serviceResource.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		expected, got := serviceResource.Primary.Attributes["name"], serviceResponse.Name
-		if expected != got {
-			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
-		}
-
-		expected, got = serviceResource.Primary.Attributes["alert_on_add"], fmt.Sprintf("%t", serviceResponse.AlertOnAdd)
-		if expected != got {
-			return fmt.Errorf("Unexpected alert_on_add. Expected: %s, got: %s", expected, got)
-		}
-
-		expected, got = serviceResource.Primary.Attributes["description"], serviceResponse.Description
-		if expected != got {
-			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
-		}
-
-		//if !reflect.DeepEqual(serviceResponse.Labels, []string{}) {
-		//	return fmt.Errorf("Bad labels: %v", serviceResponse.Labels)
-		//}
-
-		if serviceResponse.Owner != nil {
-			return fmt.Errorf("Unexpected owner. Expected owner to not be set, got: %s.", serviceResponse.Owner.ID)
 		}
 
 		expected, got = serviceResource.Primary.Attributes["service_tier"], fmt.Sprintf("%d", serviceResponse.ServiceTier)
@@ -377,9 +405,31 @@ resource "firehydrant_service" "test_service" {
   name         = "test-service-%s"
   alert_on_add = true
   description  = "test-description-%s"
+  labels = {
+    test1 = "test-label1-%s",
+  }
   owner_id     = firehydrant_team.test_team1.id
   service_tier = "1"
-}`, rName, rName, rName)
+}`, rName, rName, rName, rName)
+}
+
+func testAccServiceResourceConfig_updateChangeLabels(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_team" "test_team1" {
+  name = "test-team1-%s"
+}
+
+resource "firehydrant_service" "test_service" {
+  name         = "test-service-%s"
+  alert_on_add = true
+  description  = "test-description-%s"
+  labels = {
+    test1 = "test-label1-%s",
+    test2 = "test-label2-%s"
+  }
+  owner_id     = firehydrant_team.test_team1.id
+  service_tier = "1"
+}`, rName, rName, rName, rName, rName)
 }
 
 func testAccServiceResourceConfig_updateChangeOwnerID(rName string) string {
@@ -396,17 +446,10 @@ resource "firehydrant_service" "test_service" {
   name         = "test-service-%s"
   alert_on_add = true
   description  = "test-description-%s"
+  labels = {
+    test1 = "test-label1-%s",
+  }
   owner_id     = firehydrant_team.test_team2.id
   service_tier = "1"
-}`, rName, rName, rName, rName)
-}
-
-func testAccServiceResourceConfig_updateRemoveOwnerID(rName string) string {
-	return fmt.Sprintf(`
-resource "firehydrant_service" "test_service" {
-  name         = "test-service-%s"
-  alert_on_add = true
-  description  = "test-description-%s"
-  service_tier = "1"
-}`, rName, rName)
+}`, rName, rName, rName, rName, rName)
 }

--- a/provider/service_resource_test.go
+++ b/provider/service_resource_test.go
@@ -166,6 +166,7 @@ func TestAccServiceResource_updateLabels(t *testing.T) {
 
 func TestAccServiceResource_updateOwnerID(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testFireHydrantIsSetup(t) },
@@ -191,30 +192,48 @@ func TestAccServiceResource_updateOwnerID(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccServiceResourceConfig_updateChangeOwnerID(rName),
+				Config: testAccServiceResourceConfig_update(rNameUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckServiceResourceExistsWithAttributes_update("firehydrant_service.test_service"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
 					resource.TestCheckResourceAttr(
-						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "true"),
 					resource.TestCheckResourceAttr(
-						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
-						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rName)),
+						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rNameUpdated)),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
 				),
 			},
 			{
-				Config: testAccServiceResourceConfig_basic(rName),
+				Config: testAccServiceResourceConfig_updateChangeOwnerID(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceResourceExistsWithAttributes_update("firehydrant_service.test_service"),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rNameUpdated)),
+					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "service_tier", "1"),
+				),
+			},
+			{
+				Config: testAccServiceResourceConfig_basic(rNameUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckServiceResourceExistsWithAttributes_basic("firehydrant_service.test_service"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
 					resource.TestCheckResourceAttr(
-						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "false"),
 					// Make sure owner_id is not set


### PR DESCRIPTION
## Description

This PR fixes a bug that was preventing labels from being removed from r/service by removing the omitempty setting from the description field in the update service request. 

It also adds a workaround for a bug with the unreleased owner ID attribute that was causing the owner ID to be unset when the associated team resource was updated. This is ultimately due to a bug in the API that will be fixed soon.

Note: the alert_on_add and description tests will fail until the fix for those attributes in #51 is merged in.

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup:
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     #dev_overrides {
     #  "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     #}

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1. Save the following config as main.tf, replacing the base_url if necessary, to match the environment you're testing against.
   ```terraform
   terraform {
     required_providers {
       firehydrant = {
         source  = "firehydrant/firehydrant"
         version = "~> 0.1.4"
       }
     }
   }

   provider "firehydrant" {
     firehydrant_base_url = "https://api.local.firehydrant.io/v1/"
   }

   resource "firehydrant_service" "service1" {
     name = "service1"

     labels = {
       test1 = "test-label1"
     }
   }
   ```
1. Run `terraform init`.

#### Before:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and should create a service with a label in the UI.
1. Remove the labels from service1
   ```terraform
   resource "firehydrant_service" "service1" {
     name        = "service1"
   }
   ```
1. Run `terraform apply` again. This should succeed but if you check the UI, you should see that the labels are still there and if you run `terraform apply` again, it should show that labels still need to be removed.

#### Upgrade provider version to local build of this branch
1. Edit your ~/.terraformrc file and remove the comments in front of the dev_overrides block
   ```
   dev_overrides {
     "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   }
   ```
1. Run `terraform plan`. This time you should see a yellow warning block telling you that development overrides are in place. 

#### After:
1. Run `terraform apply`. This should succeed and if you check the UI, you should see that the labels have been removed. Running `terraform apply` again should no show any changes.

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/b3A6Njc2NzM1-update-a-service)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.