### PR TITLE
Remove services from r/team & add teams to r/service, d/service, & d/services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.0 (Unreleased)
 
+BREAKING CHANGES: 
+
+* resource/team: Removed `services` attribute. Use resource/service to associate teams with a service. See "Notes" for more information ([#54](https://github.com/firehydrant/terraform-provider-firehydrant/pull/54))
+
 BUG FIXES:
 
 * resource/functionality: Fixed bug that prevented the `description` attribute from being unset ([#49](https://github.com/firehydrant/terraform-provider-firehydrant/pull/49))
@@ -14,17 +18,20 @@ ENHANCEMENTS:
 * resource/functionality: Added deprecation warning to the `services` attribute, preferring `service_ids` instead ([#49](https://github.com/firehydrant/terraform-provider-firehydrant/pull/49))
 * resource/service: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
 * resource/service: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
-* resource/team: Added deprecation warning to the `services` attribute, preferring `service_ids` instead ([#31](https://github.com/firehydrant/terraform-provider-firehydrant/pull/31))
+* resource/service: Added the `team_ids` attribute to services ([#54](https://github.com/firehydrant/terraform-provider-firehydrant/pull/54))
 * data_source/functionality: Added the `service_ids` attribute to functionality ([#49](https://github.com/firehydrant/terraform-provider-firehydrant/pull/49))
 * data_source/service: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
 * data_source/service: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
+* data_source/service: Added the `team_ids` attribute to services ([#54](https://github.com/firehydrant/terraform-provider-firehydrant/pull/54))
 * data_source/services: Added the `alert_on_add` attribute to services ([#24](https://github.com/firehydrant/terraform-provider-firehydrant/pull/24))
 * data_source/services: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
+* data_source/services: Added the `team_ids` attribute to services ([#54](https://github.com/firehydrant/terraform-provider-firehydrant/pull/54))
+
 
 NOTES:
 
-* The deprecated attribute `services` will be removed from resource/team 3 months after the release of v0.2.0. You will have until May 31, 2022 to migrate to the preferred attribute.
-   More information about this deprecation can be found in the description of ([#31](https://github.com/firehydrant/terraform-provider-firehydrant/pull/31))
+* The services attribute has been removed from resource/team. If you need to add a team as an owner or responder to a service, use resource/service and specify `owner_id` or `team_ids`.
+   When upgrading to 0.2.0, you should remove the `services` attribute from any team resources and instead add `team_ids` to each service resource.
 * The deprecated attribute `services` will be removed from resource/functionality 3 months after the release of v0.2.0. You will have until May 31, 2022 to migrate to the preferred attribute.
   More information about this deprecation can be found in the description of ([#49](https://github.com/firehydrant/terraform-provider-firehydrant/pull/49))
 

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -32,3 +32,5 @@ data "firehydrant_service" "example-service" {
 - **owner_id** (String, Read-only) The ID of the team that owns this service.
 - **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
   Lower values represent higher criticality. Defaults to `5`.
+- **team_ids** (Set of String, Optional) A set of IDs of the teams responsible for this service's incident response.
+

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -54,3 +54,4 @@ data "firehydrant_services" "managed-true-labeled-services" {
 - **owner_id** (String, Read-only) The ID of the team that owns this service.
 - **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
   Lower values represent higher criticality. Defaults to `5`.
+- **team_ids** (Set of String, Optional) A set of IDs of the teams responsible for this service's incident response.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -12,10 +12,26 @@ description: |-
 Basic usage:
 
 ```hcl
+resource "firehydrant_team" "example-owner-team" {
+  name        = "my-example-owner-team"
+  description = "This is an example team that owns a service"
+}
+
+resource "firehydrant_team" "example-responder-team1" {
+  name        = "my-example-responder-team1"
+  description = "This is an example team that is responsible for responding to incidents for a service"
+}
+
+resource "firehydrant_team" "example-responder-team2" {
+  name        = "my-example-responder-team2"
+  description = "This is an example team that is responsible for responding to incidents for a service"
+}
+
 resource "firehydrant_service" "example-service" {
   name         = "my-example-service"
   add_on_alert = true
   description  = "The main service for our company"
+  
   labels = {
     language  = "ruby",
     lifecycle = "production"
@@ -23,7 +39,15 @@ resource "firehydrant_service" "example-service" {
     type      = "user"
     tags      = "foo; bar; baz"
   }
+  
+  owner_id = firehydrant_team.example-owner-team.id
+
   service_tier = 1
+
+  team_ids = [
+    firehydrant_team.example-responder-team1.id,
+    firehydrant_team.example-responder-team2.id
+  ]
 }
 ```
 
@@ -31,7 +55,7 @@ resource "firehydrant_service" "example-service" {
 
 ### Required
 
-- **name** (String, Required)
+- **name** (String, Required) The name of the service.
 
 ### Optional
 
@@ -44,6 +68,7 @@ resource "firehydrant_service" "example-service" {
 - **owner_id** (String, Optional) The ID of the team that owns this service.
 - **service_tier** (Integer, Optional) The service tier of this resource - between 1 - 5. 
    Lower values represent higher criticality. Defaults to `5`.
+- **team_ids** (Set of String, Optional) A set of IDs of the teams responsible for this service's incident response.
 
 ### Read-only
 

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -12,22 +12,9 @@ description: |-
 Basic usage:
 
 ```hcl
-resource "firehydrant_service" "example-service1" {
-  name = "my-example-service1"
-}
-
-resource "firehydrant_service" "example-service2" {
-  name = "my-example-service2"
-}
-
 resource "firehydrant_team" "example-team" {
   name        = "my-example-team"
   description = "This is an example team"
-  
-  service_ids = [
-    firehydrant_service.example-service1.id,
-    firehydrant_service.example-service2.id
-  ]
 }
 ```
 
@@ -40,25 +27,7 @@ resource "firehydrant_team" "example-team" {
 ### Optional
 
 - **description** (String, Optional) A description for the team.
-- **service_ids** (Set of String, Optional) A set of IDs of the services this team handles incident response for.
-  This value _must not_ be provided if `services` is provided.
-- **services** (Block List, Optional) **Deprecated** The services this team handles incident response for.
-   (see [below for nested schema](#nestedblock--services)). This value _must not_ be provided if 
-   `service_ids` is provided.
 
 ### Read-only
 
 - **id** (String, Read-only) The ID of the team.
-
-<a id="nestedblock--services"></a>
-### Nested Schema for `services` (Deprecated)
-
-Required:
-
-- **id** (String, Required) The ID of the service.
-
-Read-only:
-
-- **name** (String, Read-only) The name of the service
-
-

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -173,21 +173,21 @@ type UpdateFunctionalityRequest struct {
 // TeamResponse is the payload for a single environment
 // URL: GET https://api.firehydrant.io/v1/teams/{id}
 type TeamResponse struct {
-	ID          string            `json:"id"`
-	Name        string            `json:"name"`
-	Description string            `json:"description"`
-	Slug        string            `json:"slug"`
-	Services    []ServiceResponse `json:"services"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Description   string            `json:"description"`
+	Slug          string            `json:"slug"`
+	OwnedServices []ServiceResponse `json:"owned_services"`
+	Services      []ServiceResponse `json:"services"`
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
 }
 
 // CreateTeamRequest is the payload for creating a service
 // URL: POST https://api.firehydrant.io/v1/services
 type CreateTeamRequest struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	ServiceIDs  []string `json:"service_ids,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 }
 
 // TeamService represents a service when creating a functionality
@@ -198,9 +198,8 @@ type TeamService struct {
 // UpdateTeamRequest is the payload for updating a environment
 // URL: PATCH https://api.firehydrant.io/v1/environments/{id}
 type UpdateTeamRequest struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	ServiceIDs  []string `json:"service_ids"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 }
 
 // SeverityResponse is the payload for a single environment

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -33,6 +33,7 @@ type CreateServiceRequest struct {
 	Name        string            `json:"name"`
 	Owner       *ServiceTeam      `json:"owner,omitempty"`
 	ServiceTier int               `json:"service_tier,int,omitempty"`
+	Teams       []ServiceTeam     `json:"teams,omitempty"`
 }
 
 // ServiceTeam represents a team when creating a service
@@ -49,13 +50,15 @@ type ServiceTeam struct {
 // UpdateServiceRequest is the payload for updating a service
 // URL: PATCH https://api.firehydrant.io/v1/services/{id}
 type UpdateServiceRequest struct {
-	AlertOnAdd  bool              `json:"alert_on_add"`
-	Description string            `json:"description"`
-	Labels      map[string]string `json:"labels"`
-	Name        string            `json:"name,omitempty"`
-	Owner       *ServiceTeam      `json:"owner"`
-	RemoveOwner bool              `json:"remove_owner,omitempty"`
-	ServiceTier int               `json:"service_tier,int"`
+	AlertOnAdd           bool              `json:"alert_on_add"`
+	Description          string            `json:"description"`
+	Labels               map[string]string `json:"labels"`
+	Name                 string            `json:"name,omitempty"`
+	Owner                *ServiceTeam      `json:"owner"`
+	RemoveOwner          bool              `json:"remove_owner,omitempty"`
+	RemoveRemainingTeams bool              `json:"remove_remaining_teams,omitempty"`
+	ServiceTier          int               `json:"service_tier,int"`
+	Teams                []ServiceTeam     `json:"teams"`
 }
 
 // ServiceResponse is the payload for retrieving a service
@@ -69,6 +72,7 @@ type ServiceResponse struct {
 	Owner       *ServiceTeam      `json:"owner"`
 	ServiceTier int               `json:"service_tier"`
 	Slug        string            `json:"slug"`
+	Teams       []ServiceTeam     `json:"teams"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/provider/service_data.go
+++ b/provider/service_data.go
@@ -37,6 +37,13 @@ func dataSourceService() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"team_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -63,6 +70,12 @@ func dataFireHydrantService(ctx context.Context, d *schema.ResourceData, m inter
 	if r.Owner != nil {
 		svc["owner_id"] = r.Owner.ID
 	}
+
+	var teamIDs []interface{}
+	for _, team := range r.Teams {
+		teamIDs = append(teamIDs, team.ID)
+	}
+	svc["team_ids"] = teamIDs
 
 	// Set the data source attributes to the values we got from the API
 	for key, val := range svc {

--- a/provider/service_data_test.go
+++ b/provider/service_data_test.go
@@ -16,7 +16,7 @@ func TestAccServiceDataSource_basic(t *testing.T) {
 		ProviderFactories: defaultProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDataSourceConfig(rName),
+				Config: testAccServiceDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.firehydrant_service.test_service", "id"),
 					resource.TestCheckResourceAttr(
@@ -31,7 +31,34 @@ func TestAccServiceDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccServiceDataSourceConfig(rName string) string {
+func TestAccServiceDataSource_allAttributes(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDataSourceConfig_allAttributes(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_service.test_service", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttrSet("data.firehydrant_service.test_service", "owner_id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "service_tier", "1"),
+					resource.TestCheckResourceAttr("data.firehydrant_service.test_service", "team_ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccServiceDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "firehydrant_service" "test_service" {
   name = "test-service-%s"
@@ -40,4 +67,35 @@ resource "firehydrant_service" "test_service" {
 data "firehydrant_service" "test_service" {
   id = firehydrant_service.test_service.id
 }`, rName)
+}
+
+func testAccServiceDataSourceConfig_allAttributes(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_team" "test_team1" {
+  name = "test-team1-%s"
+}
+
+resource "firehydrant_team" "test_team2" {
+  name = "test-team2-%s"
+}
+
+resource "firehydrant_team" "test_team3" {
+  name = "test-team3-%s"
+}
+
+resource "firehydrant_service" "test_service" {
+  name         = "test-service-%s"
+  alert_on_add = true
+  description  = "test-description-%s"
+  owner_id     = firehydrant_team.test_team1.id
+  service_tier = "1"
+  team_ids = [
+    firehydrant_team.test_team2.id,
+    firehydrant_team.test_team3.id
+  ]
+}
+
+data "firehydrant_service" "test_service" {
+  id = firehydrant_service.test_service.id
+}`, rName, rName, rName, rName, rName)
 }

--- a/provider/service_resource_test.go
+++ b/provider/service_resource_test.go
@@ -32,6 +32,7 @@ func TestAccServiceResource_basic(t *testing.T) {
 						"firehydrant_service.test_service", "alert_on_add", "false"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "5"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "0"),
 				),
 			},
 		},
@@ -58,6 +59,7 @@ func TestAccServiceResource_update(t *testing.T) {
 						"firehydrant_service.test_service", "alert_on_add", "false"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "5"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "0"),
 				),
 			},
 			{
@@ -76,6 +78,7 @@ func TestAccServiceResource_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "2"),
 				),
 			},
 			{
@@ -89,6 +92,7 @@ func TestAccServiceResource_update(t *testing.T) {
 						"firehydrant_service.test_service", "alert_on_add", "false"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "5"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "0"),
 				),
 			},
 		},
@@ -120,6 +124,7 @@ func TestAccServiceResource_updateLabels(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "2"),
 				),
 			},
 			{
@@ -140,6 +145,7 @@ func TestAccServiceResource_updateLabels(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "2"),
 				),
 			},
 			{
@@ -158,13 +164,14 @@ func TestAccServiceResource_updateLabels(t *testing.T) {
 						"firehydrant_service.test_service", "labels.test2"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "5"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "0"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccServiceResource_updateOwnerID(t *testing.T) {
+func TestAccServiceResource_updateOwnerIDAndTeamIDs(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
@@ -189,6 +196,7 @@ func TestAccServiceResource_updateOwnerID(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "2"),
 				),
 			},
 			{
@@ -207,10 +215,11 @@ func TestAccServiceResource_updateOwnerID(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "2"),
 				),
 			},
 			{
-				Config: testAccServiceResourceConfig_updateChangeOwnerID(rNameUpdated),
+				Config: testAccServiceResourceConfig_updateChangeOwnerIDAndTeamIDs(rNameUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckServiceResourceExistsWithAttributes_update("firehydrant_service.test_service"),
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "id"),
@@ -225,6 +234,7 @@ func TestAccServiceResource_updateOwnerID(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_service.test_service", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "1"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "2"),
 				),
 			},
 			{
@@ -241,6 +251,7 @@ func TestAccServiceResource_updateOwnerID(t *testing.T) {
 						"firehydrant_service.test_service", "owner_id", ""),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "5"),
+					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "0"),
 				),
 			},
 		},
@@ -255,9 +266,27 @@ func TestAccServiceResourceImport_basic(t *testing.T) {
 		ProviderFactories: defaultProviderFactories(),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccServiceResourceConfig_basic(rName),
+			},
+			{
+				ResourceName:      "firehydrant_service.test_service",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccServiceResourceImport_allAttributes(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
 				Config: testAccServiceResourceConfig_update(rName),
 			},
-
 			{
 				ResourceName:      "firehydrant_service.test_service",
 				ImportState:       true,
@@ -312,6 +341,11 @@ func testAccCheckServiceResourceExistsWithAttributes_basic(resourceName string) 
 		expected, got = serviceResource.Primary.Attributes["service_tier"], fmt.Sprintf("%d", serviceResponse.ServiceTier)
 		if expected != got {
 			return fmt.Errorf("Unexpected service_tier. Expected: %s, got: %s", expected, got)
+		}
+
+		// TODO: Check the team ids
+		if len(serviceResponse.Teams) != 0 {
+			return fmt.Errorf("Unexpected number of teams. Expected: 0, got: %v", len(serviceResponse.Teams))
 		}
 
 		return nil
@@ -377,6 +411,11 @@ func testAccCheckServiceResourceExistsWithAttributes_update(resourceName string)
 			return fmt.Errorf("Unexpected service_tier. Expected: %s, got: %s", expected, got)
 		}
 
+		// TODO: Check the team ids
+		if len(serviceResponse.Teams) != 2 {
+			return fmt.Errorf("Unexpected number of teams. Expected: 2, got: %v", len(serviceResponse.Teams))
+		}
+
 		return nil
 	}
 }
@@ -420,6 +459,14 @@ resource "firehydrant_team" "test_team1" {
   name = "test-team1-%s"
 }
 
+resource "firehydrant_team" "test_team2" {
+  name = "test-team2-%s"
+}
+
+resource "firehydrant_team" "test_team3" {
+  name = "test-team3-%s"
+}
+
 resource "firehydrant_service" "test_service" {
   name         = "test-service-%s"
   alert_on_add = true
@@ -429,13 +476,25 @@ resource "firehydrant_service" "test_service" {
   }
   owner_id     = firehydrant_team.test_team1.id
   service_tier = "1"
-}`, rName, rName, rName, rName)
+  team_ids = [
+    firehydrant_team.test_team2.id,
+    firehydrant_team.test_team3.id
+  ]
+}`, rName, rName, rName, rName, rName, rName)
 }
 
 func testAccServiceResourceConfig_updateChangeLabels(rName string) string {
 	return fmt.Sprintf(`
 resource "firehydrant_team" "test_team1" {
   name = "test-team1-%s"
+}
+
+resource "firehydrant_team" "test_team2" {
+  name = "test-team2-%s"
+}
+
+resource "firehydrant_team" "test_team3" {
+  name = "test-team3-%s"
 }
 
 resource "firehydrant_service" "test_service" {
@@ -448,10 +507,14 @@ resource "firehydrant_service" "test_service" {
   }
   owner_id     = firehydrant_team.test_team1.id
   service_tier = "1"
-}`, rName, rName, rName, rName, rName)
+  team_ids = [
+    firehydrant_team.test_team2.id,
+    firehydrant_team.test_team3.id
+  ]
+}`, rName, rName, rName, rName, rName, rName, rName)
 }
 
-func testAccServiceResourceConfig_updateChangeOwnerID(rName string) string {
+func testAccServiceResourceConfig_updateChangeOwnerIDAndTeamIDs(rName string) string {
 	return fmt.Sprintf(`
 resource "firehydrant_team" "test_team1" {
   name = "test-team1-%s"
@@ -461,14 +524,22 @@ resource "firehydrant_team" "test_team2" {
   name = "test-team2-%s"
 }
 
+resource "firehydrant_team" "test_team3" {
+  name = "test-team3-%s"
+}
+
 resource "firehydrant_service" "test_service" {
   name         = "test-service-%s"
   alert_on_add = true
   description  = "test-description-%s"
   labels = {
-    test1 = "test-label1-%s",
+    test1 = "test-label1-%s"
   }
   owner_id     = firehydrant_team.test_team2.id
   service_tier = "1"
-}`, rName, rName, rName, rName, rName)
+  team_ids = [
+    firehydrant_team.test_team1.id,
+    firehydrant_team.test_team3.id
+  ]
+}`, rName, rName, rName, rName, rName, rName)
 }

--- a/provider/services_data.go
+++ b/provider/services_data.go
@@ -65,6 +65,12 @@ func dataFireHydrantServices(ctx context.Context, d *schema.ResourceData, m inte
 			values["owner_id"] = svc.Owner.ID
 		}
 
+		var teamIDs []interface{}
+		for _, team := range svc.Teams {
+			teamIDs = append(teamIDs, team.ID)
+		}
+		values["team_ids"] = teamIDs
+
 		services = append(services, values)
 	}
 	if err := d.Set("services", services); err != nil {

--- a/provider/services_data_test.go
+++ b/provider/services_data_test.go
@@ -18,7 +18,7 @@ func TestAccServicesDataSource_basic(t *testing.T) {
 		ProviderFactories: defaultProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServicesDataSourceConfig(rName),
+				Config: testAccServicesDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.firehydrant_services.all_services", "services.#"),
 					testAccCheckServicesSet("data.firehydrant_services.all_services"),
@@ -58,7 +58,7 @@ func testAccCheckServicesSet(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccServicesDataSourceConfig(rName string) string {
+func testAccServicesDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "firehydrant_service" "test_service" {
   name = "test-service-%s"

--- a/provider/team_resource.go
+++ b/provider/team_resource.go
@@ -18,39 +18,16 @@ func resourceTeam() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
+			// Required
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
+			// Optional
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-			},
-			"service_ids": {
-				Type:          schema.TypeSet,
-				ConflictsWith: []string{"services"},
-				Optional:      true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"services": {
-				Type:          schema.TypeList,
-				ConflictsWith: []string{"service_ids"},
-				Deprecated:    "Use service_ids instead. The services attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/firehydrant/terraform-provider-firehydrant/blob/v0.2.0/CHANGELOG.md",
-				Optional:      true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
 			},
 		},
 	}
@@ -61,46 +38,19 @@ func readResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, m 
 	firehydrantAPIClient := m.(firehydrant.Client)
 
 	// Get the team
-	r, err := firehydrantAPIClient.GetTeam(ctx, d.Id())
+	teamResponse, err := firehydrantAPIClient.GetTeam(ctx, d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	// Set values in state
-	svc := map[string]string{
-		"name":        r.Name,
-		"description": r.Description,
-	}
-	for key, val := range svc {
-		if err := d.Set(key, val); err != nil {
-			return diag.FromErr(err)
-		}
+	attributes := map[string]interface{}{
+		"name":        teamResponse.Name,
+		"description": teamResponse.Description,
 	}
 
-	// TODO: refactor this once deprecated attribute is removed
-	// Update service IDs in state
-	_, servicesSet := d.GetOk("services")
-	if servicesSet {
-		// If the config is using the services attribute, update the services attribute
-		// in state with the information we got from the API
-		var services []interface{}
-		for _, service := range r.Services {
-			services = append(services, map[string]interface{}{
-				"id":   service.ID,
-				"name": service.Name,
-			})
-		}
-		if err := d.Set("services", services); err != nil {
-			return diag.FromErr(err)
-		}
-	} else {
-		// Otherwise, default to the preferred service_ids attribute and update the
-		// service_ids attribute in state with the information we got from the API
-		serviceIDs := make([]string, 0)
-		for _, service := range r.Services {
-			serviceIDs = append(serviceIDs, service.ID)
-		}
-		if err := d.Set("service_ids", serviceIDs); err != nil {
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -115,35 +65,13 @@ func createResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 	// Construct the create team request
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
-	r := firehydrant.CreateTeamRequest{
+	createRequest := firehydrant.CreateTeamRequest{
 		Name:        name,
 		Description: description,
-		ServiceIDs:  []string{},
 	}
-
-	// TODO: refactor this once deprecated attribute is removed
-	// Add service IDs to the create request
-	services, servicesSet := d.GetOk("services")
-	serviceIDs, serviceIDsSet := d.GetOk("service_ids")
-	if servicesSet {
-		// If the services attribute is set, use the service IDs from that attribute
-		// to set the service IDs for the create team request
-		for _, service := range services.([]interface{}) {
-			serviceAttributes := service.(map[string]interface{})
-			r.ServiceIDs = append(r.ServiceIDs, serviceAttributes["id"].(string))
-		}
-	} else if serviceIDsSet {
-		// If the service_ids attribute is set, use the service IDs from that attribute
-		// to set the service IDs for the create team request
-		for _, serviceID := range serviceIDs.(*schema.Set).List() {
-			r.ServiceIDs = append(r.ServiceIDs, serviceID.(string))
-		}
-	}
-	// Otherwise, don't send any service IDs in the create team request,
-	// which will create a team with no services
 
 	// Create the new team
-	teamResponse, err := firehydrantAPIClient.CreateTeam(ctx, r)
+	teamResponse, err := firehydrantAPIClient.CreateTeam(ctx, createRequest)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -162,40 +90,14 @@ func updateResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 	// Construct the update team request
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
-	r := firehydrant.UpdateTeamRequest{
+	updateRequest := firehydrant.UpdateTeamRequest{
 		Name:        name,
 		Description: description,
 	}
 
-	// TODO: refactor this once deprecated attribute is removed
-	// Add service IDs to the update request
-	services, servicesSet := d.GetOk("services")
-	serviceIDs, serviceIDsSet := d.GetOk("service_ids")
-	updatedServiceIDs := make([]string, 0)
-	if servicesSet {
-		// If the services attribute is set, use the service IDs from that attribute
-		// to populate the list of service IDs for the update team request
-		for _, service := range services.([]interface{}) {
-			serviceAttributes := service.(map[string]interface{})
-			updatedServiceIDs = append(updatedServiceIDs, serviceAttributes["id"].(string))
-		}
-	} else if serviceIDsSet {
-		// If the service_ids attribute is set, use the service IDs from that attribute
-		// to populate the list of for service IDs for the update team request
-		for _, serviceID := range serviceIDs.(*schema.Set).List() {
-			updatedServiceIDs = append(updatedServiceIDs, serviceID.(string))
-		}
-	}
-	// Otherwise, neither attribute is set, so updatedServiceIDs remains empty,
-	// which will allow us to remove services from a team if either attribute
-	// has been removed from the config
-
-	// Set the service IDs for the update team request
-	r.ServiceIDs = updatedServiceIDs
-
 	// Update the team
 	teamID := d.Id()
-	_, err := firehydrantAPIClient.UpdateTeam(ctx, teamID, r)
+	_, err := firehydrantAPIClient.UpdateTeam(ctx, teamID, updateRequest)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/team_resource_test.go
+++ b/provider/team_resource_test.go
@@ -28,7 +28,6 @@ func TestAccTeamResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_team.test_team", "services.#", "0"),
 				),
 			},
 		},
@@ -51,7 +50,6 @@ func TestAccTeamResource_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_team.test_team", "services.#", "0"),
 				),
 			},
 			{
@@ -63,11 +61,6 @@ func TestAccTeamResource_update(t *testing.T) {
 						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_team.test_team", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "services.#", "1"),
-					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "services.0.id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "services.0.name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 				),
 			},
 			{
@@ -77,137 +70,6 @@ func TestAccTeamResource_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr("firehydrant_team.test_team", "services.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTeamResource_basicServiceIDs(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testFireHydrantIsSetup(t) },
-		ProviderFactories: defaultProviderFactories(),
-		CheckDestroy:      testAccCheckTeamResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTeamResourceConfig_basicServiceIDs(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTeamResourceExistsWithAttributes_basicServiceIDs("firehydrant_team.test_team"),
-					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_team.test_team", "service_ids.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTeamResource_updateServiceIDs(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testFireHydrantIsSetup(t) },
-		ProviderFactories: defaultProviderFactories(),
-		CheckDestroy:      testAccCheckTeamResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTeamResourceConfig_basicServiceIDs(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTeamResourceExistsWithAttributes_basicServiceIDs("firehydrant_team.test_team"),
-					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_team.test_team", "service_ids.#", "1"),
-				),
-			},
-			{
-				Config: testAccTeamResourceConfig_updateServiceIDs(rNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTeamResourceExistsWithAttributes_updateServiceIDs("firehydrant_team.test_team"),
-					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "service_ids.#", "2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTeamResource_updateServicesToServiceIDs(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testFireHydrantIsSetup(t) },
-		ProviderFactories: defaultProviderFactories(),
-		CheckDestroy:      testAccCheckTeamResourceDestroy(),
-		Steps: []resource.TestStep{
-			// Start with a config that has services
-			{
-				Config: testAccTeamResourceConfig_basicServices(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTeamResourceExistsWithAttributes_basicServices("firehydrant_team.test_team"),
-					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_team.test_team", "services.#", "1"),
-				),
-			},
-			// Update the config by changing services to service_ids
-			{
-				Config: testAccTeamResourceConfig_basicServiceIDs(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTeamResourceExistsWithAttributes_basicServiceIDs("firehydrant_team.test_team"),
-					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_team.test_team", "service_ids.#", "1"),
-				),
-			},
-			// Update the config by adding a new service id to service_ids
-			{
-				Config: testAccTeamResourceConfig_updateServiceIDs(rNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTeamResourceExistsWithAttributes_updateServiceIDs("firehydrant_team.test_team"),
-					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "service_ids.#", "2"),
-				),
-			},
-			// Update the config by removing a service id from service_ids
-			{
-				Config: testAccTeamResourceConfig_basicServiceIDs(rNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTeamResourceExistsWithAttributes_basicServiceIDs("firehydrant_team.test_team"),
-					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "service_ids.#", "1"),
-				),
-			},
-			// Update the config by removing service_ids
-			{
-				Config: testAccTeamResourceConfig_basic(rNameUpdated),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTeamResourceExistsWithAttributes_basic("firehydrant_team.test_team"),
-					resource.TestCheckResourceAttrSet("firehydrant_team.test_team", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_team.test_team", "name", fmt.Sprintf("test-team-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr("firehydrant_team.test_team", "services.#", "0"),
 				),
 			},
 		},
@@ -223,47 +85,6 @@ func TestAccTeamResourceImport_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTeamResourceConfig_basic(rName),
-			},
-
-			{
-				ResourceName:      "firehydrant_team.test_team",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccTeamResourceImport_services(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testFireHydrantIsSetup(t) },
-		ProviderFactories: defaultProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTeamResourceConfig_basicServices(rName),
-			},
-
-			{
-				ResourceName:            "firehydrant_team.test_team",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"services", "service_ids"},
-			},
-		},
-	})
-}
-
-func TestAccTeamResourceImport_serviceIDs(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testFireHydrantIsSetup(t) },
-		ProviderFactories: defaultProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTeamResourceConfig_basicServiceIDs(rName),
 			},
 
 			{
@@ -304,10 +125,6 @@ func testAccCheckTeamResourceExistsWithAttributes_basic(resourceName string) res
 			return fmt.Errorf("Unexpected description. Expected no description, got: %s", teamResponse.Description)
 		}
 
-		if len(teamResponse.Services) != 0 {
-			return fmt.Errorf("Unexpected number of services. Expected no services, got: %v", len(teamResponse.Services))
-		}
-
 		return nil
 	}
 }
@@ -340,126 +157,6 @@ func testAccCheckTeamResourceExistsWithAttributes_update(resourceName string) re
 		expected, got = teamResource.Primary.Attributes["description"], teamResponse.Description
 		if expected != got {
 			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
-		}
-
-		// TODO: Check the service ids
-		if len(teamResponse.Services) != 1 {
-			return fmt.Errorf("Unexpected number of services. Expected: 1, got: %v", len(teamResponse.Services))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckTeamResourceExistsWithAttributes_basicServices(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		teamResource, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		if teamResource.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
-		if err != nil {
-			return err
-		}
-
-		teamResponse, err := client.GetTeam(context.TODO(), teamResource.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		expected, got := teamResource.Primary.Attributes["name"], teamResponse.Name
-		if expected != got {
-			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
-		}
-
-		if teamResponse.Description != "" {
-			return fmt.Errorf("Unexpected description. Expected no description, got: %s", teamResponse.Description)
-		}
-
-		// TODO: Check the service ids
-		if len(teamResponse.Services) != 1 {
-			return fmt.Errorf("Unexpected number of services. Expected: 1, got: %v", len(teamResponse.Services))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckTeamResourceExistsWithAttributes_basicServiceIDs(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		teamResource, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		if teamResource.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
-		if err != nil {
-			return err
-		}
-
-		teamResponse, err := client.GetTeam(context.TODO(), teamResource.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		expected, got := teamResource.Primary.Attributes["name"], teamResponse.Name
-		if expected != got {
-			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
-		}
-
-		if teamResponse.Description != "" {
-			return fmt.Errorf("Unexpected description. Expected no description, got: %s", teamResponse.Description)
-		}
-
-		// TODO: Check the service ids
-		if len(teamResponse.Services) != 1 {
-			return fmt.Errorf("Unexpected number of services. Expected: 1, got: %v", len(teamResponse.Services))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckTeamResourceExistsWithAttributes_updateServiceIDs(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		teamResource, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		if teamResource.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
-		if err != nil {
-			return err
-		}
-
-		teamResponse, err := client.GetTeam(context.TODO(), teamResource.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		expected, got := teamResource.Primary.Attributes["name"], teamResponse.Name
-		if expected != got {
-			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
-		}
-
-		expected, got = teamResource.Primary.Attributes["description"], teamResponse.Description
-		if expected != got {
-			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
-		}
-
-		// TODO: Check the service ids
-		if len(teamResponse.Services) != 2 {
-			return fmt.Errorf("Unexpected number of services. Expected: 1, got: %v", len(teamResponse.Services))
 		}
 
 		return nil
@@ -501,65 +198,8 @@ resource "firehydrant_team" "test_team" {
 
 func testAccTeamResourceConfig_update(rName string) string {
 	return fmt.Sprintf(`
-resource "firehydrant_service" "test_service" {
-  name = "test-service-%s"
-}
-
 resource "firehydrant_team" "test_team" {
   name        = "test-team-%s"
   description = "test-description-%s"
-
-  services {
-    id = firehydrant_service.test_service.id
-  }
-}`, rName, rName, rName)
-}
-
-func testAccTeamResourceConfig_basicServiceIDs(rName string) string {
-	return fmt.Sprintf(`
-resource "firehydrant_service" "test_service1" {
-  name = "test-service1-%s"
-}
-
-resource "firehydrant_team" "test_team" {
-  name = "test-team-%s"
-
-  service_ids = [firehydrant_service.test_service1.id]
-}`, rName, rName)
-}
-
-func testAccTeamResourceConfig_updateServiceIDs(rName string) string {
-	return fmt.Sprintf(`
-resource "firehydrant_service" "test_service1" {
-  name = "test-service1-%s"
-}
-
-resource "firehydrant_service" "test_service2" {
-  name = "test-service2-%s"
-}
-
-resource "firehydrant_team" "test_team" {
-  name        = "test-team-%s"
-  description = "test-description-%s"
-
-  service_ids = [
-    firehydrant_service.test_service1.id,
-    firehydrant_service.test_service2.id
-  ]
-}`, rName, rName, rName, rName)
-}
-
-func testAccTeamResourceConfig_basicServices(rName string) string {
-	return fmt.Sprintf(`
-resource "firehydrant_service" "test_service1" {
-  name = "test-service1-%s"
-}
-
-resource "firehydrant_team" "test_team" {
-  name = "test-team-%s"
-
-  services {
-    id = firehydrant_service.test_service1.id
-  }
 }`, rName, rName)
 }


### PR DESCRIPTION
## Description

This PR moves the creation of the service-team relationship from r/team to r/service. It does this by:
1. **[Breaking change]** Removing the `services` attribute from r/team
1. Adding the `team_ids` attribute to r/services so that the service-team relationship can still be created.
1. Adding the `team_ids`attribute to d/service and d/services for consistency and completeness

Originally the owning team was specified on the r/service resource and the responding team was set on the r/team resource. However, this resulted in invalid Terraform configs with cycles if you wanted to specify the same team as an owning and responding team.
```terraform
resource "firehydrant_service" "test_service1" {
  name = "test-service1"
  owner_id = firehydrant_team.test_team.id
}

resource "firehydrant_service" "test_service2" {
  name = "test-service2"
}

resource "firehydrant_team" "test_team" {
  name        = "test-team"
  description = "test-description"
  service_ids = [
    firehydrant_service.test_service1.id,
    firehydrant_service.test_service2.id
  ]
}
```

So, to avoid this problem and make associating teams and services a little more straightforward, we're moving both the responding team relationship and the owning team relationship to r/service. 

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     #dev_overrides {
     #  "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     #}

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/8210072/terraform-config-teams-services.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. Make sure you replace the id in the ds-service data source with the id of an existing service you have access to.
1. Run `terraform init`.

#### Provision resources for r/service and r/team:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the services and teams you just created. Service2 should be listed under "Services for incident response" for team2 and team2 should be listed under "Responding teams" for service2.
1. Run `terraform plan`. There should be no changes aside from the spurious changes reported for the labels attribute.

#### Upgrade provider version to local build of this branch
1. Edit your ~/.terraformrc file and remove the comments in front of the dev_overrides block
   ```
   dev_overrides {
     "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   }
   ```
1. Run `terraform plan`. This time you should see a yellow warning block telling you that development overrides are in place and an error about the unsupported services block from the breaking change this PR makes. It should look like this:
   <img width="1167" alt="Screen Shot 2022-03-08 at 4 38 09 PM" src="https://user-images.githubusercontent.com/12189856/157337823-f895287f-213a-41f5-8d0d-7279ad28ef68.png">

#### Update config to deal with breaking change to r/team
1. Update your config by removing the `services` block from team2 and instead associate team2 and service2 by adding the `team_ids` attribute to service2
   ```
   resource "firehydrant_service" "service2" {
     name        = "service2"
     description = "description2"

     labels = {
       language  = "ruby",
       lifecycle = "production"
     }

     service_tier = 1

     team_ids = [
       firehydrant_team.team2.id
     ]
   }

   ...

   resource "firehydrant_team" "team2" {
     name        = "team2"
     description = "description2"
   }
   ```
1. Run `terraform plan`. You should see no changes aside from some attribute that need to be updated in state.
1. Go ahead and run `terraform apply -refresh-only` to pick up these state updates.
1. Run `terraform plan` again. You should see no changes. The same association should still exist between service2 and team2 if you check the UI.

#### Make sure you can still update services and teams:
1. Add team1 as an owner of service2, add team1 to the `team_ids` attribute, and update team1's name
   ```
   resource "firehydrant_service" "service2" {
     name        = "service2"
     description = "description2"

     labels = {
       language  = "ruby",
       lifecycle = "production"
     }

     owner_id = firehydrant_team.team1.id
     service_tier = 1

     team_ids = [
       firehydrant_team.team1.id,
       firehydrant_team.team2.id,
     ]
   }
   
   ...

   resource "firehydrant_team" "team1" {
     name = "team1-updated"
   }
   ```
1. Run `terraform apply`. The output should show `Plan: 0 to add, 2 to change, 0 to destroy`. You should see that an owner and another team will be added to service2 and that team1's name will update. You should see these changes reflected in the UI.
1.  Run `terraform plan`. Your plan should show no changes.
1. Remove all teams and the owner from service2
   ```
   resource "firehydrant_service" "service2" {
     name        = "service2"
     description = "description2"

     labels = {
       language  = "ruby",
       lifecycle = "production"
     }

     service_tier = 1
   }
   ```
1. Run `terraform apply`. The output should show `Plan: 0 to add, 1 to change, 0 to destroy.`. You should see that all teams and the owner will be removed from service2.
1. Confirm in the UI that all teams and the owner have been removed from service2.
1.  Run `terraform plan`. Your plan should show no changes.
1. Change your config back and run `terraform apply` again. This should succeed and your changes should be reflected in the UI.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

#### Make sure a fresh create on this new version works
1. Run `terraform apply`. This should succeed. 

#### Check the documentation and CHANGELOG:
1. Please read over the documentation updates and make sure they make sense. Please let me know if you have any suggestions or additions. 
1. Please read over the CHANGELOG entry and make sure it makes sense. Please let me know if you have any suggestions or additions. 

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/b3A6Njc2NzMy-create-a-service)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.