### PR TITLE
Fix bug getting correct runbook action in d/runbook_action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BUG FIXES:
 
 * resource/service: Fixed bug that prevented the `description` attribute from being unset ([#51](https://github.com/firehydrant/terraform-provider-firehydrant/pull/51))
 * resource/service: Fixed bug that prevented `labels` from being removed from services ([#52](https://github.com/firehydrant/terraform-provider-firehydrant/pull/52))
+* data_source/runbook_action: Fixed bug that caused the wrong action to be returned when multiple actions existed for the same slug ([#56](https://github.com/firehydrant/terraform-provider-firehydrant/pull/56))
 
 ENHANCEMENTS:
 

--- a/docs/data-sources/runbook_action.md
+++ b/docs/data-sources/runbook_action.md
@@ -7,21 +7,208 @@ description: |-
 
 # Data Source `firehydrant_runbook_action`
 
+## Example Usage
 
+Basic usage:
+```hcl
+# Confluence Cloud
+data "firehydrant_runbook_action" "confluence_cloud_export_retro" {
+  integration_slug = "confluence_cloud"
+  slug             = "export_retrospective"
+  type             = "incident"
+}
 
+# FireHydrant
+data "firehydrant_runbook_action" "firehydrant_assign_a_role" {
+  integration_slug = "patchy"
+  slug             = "assign_a_role"
+  type             = "incident"
+}
 
+data "firehydrant_runbook_action" "firehydrant_assign_a_team" {
+  integration_slug = "patchy"
+  slug             = "assign_a_team"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_attach_a_runbook" {
+  integration_slug = "patchy"
+  slug             = "attach_a_runbook"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_add_services_related_to_functionality" {
+  integration_slug = "patchy"
+  slug             = "add_services_related_to_functionality"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_create_incident_ticket" {
+  integration_slug = "patchy"
+  slug             = "create_incident_ticket"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_email_notification" {
+  integration_slug = "patchy"
+  slug             = "email_notification"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_freeform_text" {
+  integration_slug = "patchy"
+  slug             = "freeform_text"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_incident_update" {
+  integration_slug = "patchy"
+  slug             = "incident_update"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_resolve_linked_alerts" {
+  integration_slug = "patchy"
+  slug             = "set_linked_alerts_status"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_script" {
+  integration_slug = "patchy"
+  slug             = "script"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_send_webhook" {
+  integration_slug = "patchy"
+  slug             = "send_webhook"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "firehydrant_publish_to_statuspage" {
+  integration_slug = "nunc"
+  slug             = "create_nunc"
+  type             = "incident"
+}
+
+# Giphy
+data "firehydrant_runbook_action" "giphy_incident_channel_gif" {
+  integration_slug = "giphy"
+  slug             = "incident_channel_gif"
+  type             = "incident"
+}
+
+# Google
+data "firehydrant_runbook_action" "google_create_google_meet_link" {
+  integration_slug = "google_meet"
+  slug             = "create_google_meet_link"
+  type             = "incident"
+}
+
+# Jira Cloud
+data "firehydrant_runbook_action" "jira_cloud_create_incident_issue" {
+  integration_slug = "jira_cloud"
+  slug             = "create_incident_issue"
+  type             = "incident"
+}
+
+# Jira Server
+data "firehydrant_runbook_action" "jira_server_create_incident_issue" {
+  integration_slug = "jira_onprem"
+  slug             = "create_incident_issue"
+  type             = "incident"
+}
+
+# OpsGenie
+data "firehydrant_runbook_action" "opsgenie_create_new_incident" {
+  integration_slug = "opsgenie"
+  slug             = "create_new_opsgenie_incident"
+  type             = "incident"
+}
+
+# PagerDuty
+data "firehydrant_runbook_action" "pagerduty_create_new_incident" {
+  integration_slug = "pager_duty"
+  slug             = "create_new_pager_duty_incident"
+  type             = "incident"
+}
+
+# Shortcut
+data "firehydrant_runbook_action" "shortcut_create_incident_issue" {
+  integration_slug = "shortcut"
+  slug             = "create_incident_issue"
+  type             = "incident"
+}
+
+# Slack
+data "firehydrant_runbook_action" "slack_archive_channel" {
+  integration_slug = "slack"
+  slug             = "archive_incident_channel"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "slack_create_incident_channel" {
+  integration_slug = "slack"
+  slug             = "create_incident_channel"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "slack_notify_channel" {
+  integration_slug = "slack"
+  slug             = "notify_channel"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "slack_notify_channel_custom" {
+  integration_slug = "slack"
+  slug             = "notify_channel_custom_message"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "slack_notify_incident_channel_custom" {
+  integration_slug = "slack"
+  slug             = "notify_incident_channel_custom_message"
+  type             = "incident"
+}
+
+# Statuspage.io
+data "firehydrant_runbook_action" "statuspage_create_statuspage" {
+  integration_slug = "statuspage"
+  slug             = "create_statuspage"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "statuspage_update_statuspage" {
+  integration_slug = "statuspage"
+  slug             = "update_statuspage"
+  type             = "incident"
+}
+
+# VictorOps
+data "firehydrant_runbook_action" "victorops_create_new_incident" {
+  integration_slug = "victorops"
+  slug             = "create_new_victorops_incident"
+  type             = "incident"
+}
+
+# Zoom 
+data "firehydrant_runbook_action" "zoom_create_meeting" {
+  integration_slug = "zoom"
+  slug             = "create_meeting"
+  type             = "incident"
+}
+```
 
 ## Schema
 
 ### Required
 
-- **integration_slug** (String, Required)
-- **slug** (String, Required)
-- **type** (String, Required)
+- **integration_slug** (String, Required) The slug of the integration associated with the runbook action.
+- **slug** (String, Required) The slug of the runbook action.
+- **type** (String, Required) The type of runbook supported for the runbook action. 
+   Valid values are `incident`, `infrastructure`, and `incident_role`.
 
 ### Read-only
 
-- **id** (String, Read-only) The ID of this resource.
-- **name** (String, Read-only)
-
-
+- **id** (String, Read-only) The ID of the runbook action.
+- **name** (String, Read-only) The name of the runbook action.

--- a/firehydrant/runbook_actions.go
+++ b/firehydrant/runbook_actions.go
@@ -3,7 +3,6 @@ package firehydrant
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/dghubble/sling"
@@ -17,11 +16,17 @@ type RunbookActionsResponse struct {
 // RunbookResponse is the payload for retrieving a service
 // URL: GET https://api.firehydrant.io/v1/runbooks/{id}
 type RunbookAction struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	Slug      string    `json:"slug"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID          string       `json:"id"`
+	Integration *Integration `json:"integration"`
+	Name        string       `json:"name"`
+	Slug        string       `json:"slug"`
+	CreatedAt   time.Time    `json:"created_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
+}
+
+type Integration struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`
 }
 
 type RunbookActionsQuery struct {
@@ -31,7 +36,7 @@ type RunbookActionsQuery struct {
 
 // RunbooksClient is an interface for interacting with runbooks on FireHydrant
 type RunbookActionsClient interface {
-	Get(ctx context.Context, typ, integrationAndSlug string) (*RunbookAction, error)
+	Get(ctx context.Context, runbookType string, integrationSlug string, actionSlug string) (*RunbookAction, error)
 }
 
 // RESTRunbooksClient implements the RunbooksClient interface
@@ -46,20 +51,17 @@ func (c *RESTRunbookActionsClient) restClient() *sling.Sling {
 }
 
 // Get returns a runbook action from the FireHydrant API
-func (c *RESTRunbookActionsClient) Get(ctx context.Context, typ, integrationAndSlug string) (*RunbookAction, error) {
+func (c *RESTRunbookActionsClient) Get(ctx context.Context, runbookType string, integrationSlug string, actionSlug string) (*RunbookAction, error) {
 	res := &RunbookActionsResponse{}
-	query := RunbookActionsQuery{Type: typ, Items: 100}
+	query := RunbookActionsQuery{Type: runbookType, Items: 100}
 	_, err := c.restClient().Get("runbooks/actions").QueryStruct(query).Receive(res, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get runbook")
 	}
 
-	split := strings.Split(integrationAndSlug, ".")
-	_, slug := split[0], split[1]
-
-	for _, v := range res.Actions {
-		if v.Slug == slug {
-			return &v, nil
+	for _, action := range res.Actions {
+		if action.Slug == actionSlug && action.Integration.Slug == integrationSlug {
+			return &action, nil
 		}
 	}
 

--- a/provider/runbook_action_data_test.go
+++ b/provider/runbook_action_data_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccRunbookActionDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRunbookActionDataSourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_runbook_action.test_runbook_action", "id"),
+					resource.TestCheckResourceAttrSet("data.firehydrant_runbook_action.test_runbook_action", "name"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_runbook_action.test_runbook_action", "slug", "create_incident_channel"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_runbook_action.test_runbook_action", "integration_slug", "slack"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRunbookActionDataSource_multipleActionsForSlug(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRunbookActionDataSourceConfig_multipleActionsForSlug(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_runbook_action.test_runbook_action", "id"),
+					resource.TestCheckResourceAttrSet("data.firehydrant_runbook_action.test_runbook_action", "name"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_runbook_action.test_runbook_action", "slug", "create_incident_issue"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_runbook_action.test_runbook_action", "integration_slug", "shortcut"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRunbookActionDataSourceConfig_basic() string {
+	return fmt.Sprintf(`
+data "firehydrant_runbook_action" "test_runbook_action" {
+  integration_slug = "slack"
+  slug             = "create_incident_channel"
+  type             = "incident"
+}`)
+}
+
+func testAccRunbookActionDataSourceConfig_multipleActionsForSlug() string {
+	return fmt.Sprintf(`
+data "firehydrant_runbook_action" "test_runbook_action" {
+  integration_slug = "shortcut"
+  slug             = "create_incident_issue"
+  type             = "incident"
+}`)
+}


### PR DESCRIPTION
## Description

This PR fixes a bug where the wrong runbook action would sometimes be returned when multiple runbook actions existed with the same slug. The problem was that we were only using the slug to look up runbook actions but we needed to use both the slug and the integration slug. 

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup:
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1. [Save this config](https://github.com/firehydrant/terraform-provider-firehydrant/files/8208622/terraform_runbook_actions.txt) as main.tf, replacing the base_url if necessary, to match the environment you're testing against.
1. Run `terraform init`.
1. Run `terraform apply`. This should succeed.
1. Check through all the data sources in your terraform.tfstate file to make sure the slug, integration slug, and name all match to the correct integration and runbook action you'd expect. 

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/b3A6Njc2ODM0-list-all-runbook-actions)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.