### PR TITLE
Add basic error handling to API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ BREAKING CHANGES:
 
 BUG FIXES:
 
+* provider: Fixed bug where errors weren't being checked or handled for various API requests ([#58](https://github.com/firehydrant/terraform-provider-firehydrant/pull/58))
 * resource/functionality: Fixed bug that prevented the `description` attribute from being unset ([#49](https://github.com/firehydrant/terraform-provider-firehydrant/pull/49))
 * resource/functionality: Fixed bug that prevented the `services` attribute from being unset ([#49](https://github.com/firehydrant/terraform-provider-firehydrant/pull/49))
+* resource/functionality: Fixed bug that prevented functionalities from being removed from state when they had been deleted outside of Terraform ([#58](https://github.com/firehydrant/terraform-provider-firehydrant/pull/58))
 * resource/service: Fixed bug that prevented the `description` attribute from being unset ([#51](https://github.com/firehydrant/terraform-provider-firehydrant/pull/51))
 * resource/service: Fixed bug that prevented `labels` from being removed from services ([#52](https://github.com/firehydrant/terraform-provider-firehydrant/pull/52))
+* resource/service: Fixed bug that prevented services from being removed from state when they had been deleted outside of Terraform ([#58](https://github.com/firehydrant/terraform-provider-firehydrant/pull/58))
+* resource/team: Fixed bug that prevented teams from being removed from state when they had been deleted outside of Terraform ([#58](https://github.com/firehydrant/terraform-provider-firehydrant/pull/58))
 * data_source/runbook_action: Fixed bug that caused the wrong action to be returned when multiple actions existed for the same slug ([#56](https://github.com/firehydrant/terraform-provider-firehydrant/pull/56))
 
 ENHANCEMENTS:

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -168,49 +168,64 @@ func (c *APIClient) RunbookActions() RunbookActionsClient {
 	return &RESTRunbookActionsClient{client: c}
 }
 
-// GetEnvironment retrieves an environment from the FireHydrant API
+// GetEnvironment retrieves an environment from FireHydrant
 func (c *APIClient) GetEnvironment(ctx context.Context, id string) (*EnvironmentResponse, error) {
-	var env EnvironmentResponse
-
-	resp, err := c.client().Get("environments/"+id).Receive(&env, nil)
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("status code was not a 200, got %d", resp.StatusCode)
-	}
-
+	envResponse := &EnvironmentResponse{}
+	response, err := c.client().Get("environments/"+id).Receive(envResponse, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve environment")
+		return nil, errors.Wrap(err, "could not get environment")
 	}
 
-	return &env, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return envResponse, nil
 }
 
-// CreateEnvironment creates an environment
+// CreateEnvironment creates an environment in FireHydrant
 func (c *APIClient) CreateEnvironment(ctx context.Context, req CreateEnvironmentRequest) (*EnvironmentResponse, error) {
-	res := &EnvironmentResponse{}
-
-	if _, err := c.client().Post("environments").BodyJSON(&req).Receive(res, nil); err != nil {
+	envResponse := &EnvironmentResponse{}
+	response, err := c.client().Post("environments").BodyJSON(&req).Receive(envResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not create environment")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return envResponse, nil
 }
 
 // UpdateEnvironment updates a environment in FireHydrant
 func (c *APIClient) UpdateEnvironment(ctx context.Context, id string, req UpdateEnvironmentRequest) (*EnvironmentResponse, error) {
-	res := &EnvironmentResponse{}
-
-	if _, err := c.client().Patch("environments/"+id).BodyJSON(&req).Receive(res, nil); err != nil {
+	envResponse := &EnvironmentResponse{}
+	response, err := c.client().Patch("environments/"+id).BodyJSON(&req).Receive(envResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not update environment")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return envResponse, nil
 }
 
-// DeleteEnvironment deletes a environment record from FireHydrant
+// DeleteEnvironment deletes a environment from FireHydrant
 func (c *APIClient) DeleteEnvironment(ctx context.Context, id string) error {
-	if _, err := c.client().Delete("environments/"+id).Receive(nil, nil); err != nil {
-		return errors.Wrap(err, "could not delete service")
+	response, err := c.client().Delete("environments/"+id).Receive(nil, nil)
+	if err != nil {
+		return errors.Wrap(err, "could not delete environment")
+	}
+
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -163,28 +163,6 @@ func (c *APIClient) RunbookActions() RunbookActionsClient {
 	return &RESTRunbookActionsClient{client: c}
 }
 
-// UpdateService updates a old spankin service in FireHydrant
-// TODO: Check failure case
-func (c *APIClient) UpdateService(ctx context.Context, serviceID string, updateReq UpdateServiceRequest) (*ServiceResponse, error) {
-	res := &ServiceResponse{}
-
-	if _, err := c.client().Patch("services/"+serviceID).BodyJSON(&updateReq).Receive(res, nil); err != nil {
-		return nil, errors.Wrap(err, "could not update service")
-	}
-
-	return res, nil
-}
-
-// DeleteService updates a old spankin service in FireHydrant
-// TODO: Check failure case
-func (c *APIClient) DeleteService(ctx context.Context, serviceID string) error {
-	if _, err := c.client().Delete("services/"+serviceID).Receive(nil, nil); err != nil {
-		return errors.Wrap(err, "could not delete service")
-	}
-
-	return nil
-}
-
 // GetEnvironment retrieves an environment from the FireHydrant API
 func (c *APIClient) GetEnvironment(ctx context.Context, id string) (*EnvironmentResponse, error) {
 	var env EnvironmentResponse

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -294,49 +294,64 @@ func (c *APIClient) DeleteFunctionality(ctx context.Context, id string) error {
 	return nil
 }
 
-// GetTeam retrieves an team from the FireHydrant API
+// GetTeam retrieves a team from FireHydrant
 func (c *APIClient) GetTeam(ctx context.Context, id string) (*TeamResponse, error) {
-	var fun TeamResponse
-
-	resp, err := c.client().Get("teams/"+id).Receive(&fun, nil)
-
-	if resp.StatusCode == 404 {
-		return nil, NotFound(fmt.Sprintf("Could not find team with ID %s", id))
-	}
-
+	teamResponse := &TeamResponse{}
+	response, err := c.client().Get("teams/"+id).Receive(teamResponse, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve team")
+		return nil, errors.Wrap(err, "could not get team")
 	}
 
-	return &fun, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return teamResponse, nil
 }
 
-// CreateTeam creates an team
+// CreateTeam creates a team in FireHydrant
 func (c *APIClient) CreateTeam(ctx context.Context, req CreateTeamRequest) (*TeamResponse, error) {
-	res := &TeamResponse{}
-
-	if _, err := c.client().Post("teams").BodyJSON(&req).Receive(res, nil); err != nil {
+	teamResponse := &TeamResponse{}
+	response, err := c.client().Post("teams").BodyJSON(&req).Receive(teamResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not create team")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return teamResponse, nil
 }
 
 // UpdateTeam updates a team in FireHydrant
 func (c *APIClient) UpdateTeam(ctx context.Context, id string, req UpdateTeamRequest) (*TeamResponse, error) {
-	res := &TeamResponse{}
-
-	if _, err := c.client().Patch("teams/"+id).BodyJSON(&req).Receive(res, nil); err != nil {
+	teamResponse := &TeamResponse{}
+	response, err := c.client().Patch("teams/"+id).BodyJSON(&req).Receive(teamResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not update team")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return teamResponse, nil
 }
 
-// DeleteTeam deletes a team record from FireHydrant
+// DeleteTeam deletes a team from FireHydrant
 func (c *APIClient) DeleteTeam(ctx context.Context, id string) error {
-	if _, err := c.client().Delete("teams/"+id).Receive(nil, nil); err != nil {
-		return errors.Wrap(err, "could not delete service")
+	response, err := c.client().Delete("teams/"+id).Receive(nil, nil)
+	if err != nil {
+		return errors.Wrap(err, "could not delete team")
+	}
+
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -357,54 +357,64 @@ func (c *APIClient) DeleteTeam(ctx context.Context, id string) error {
 	return nil
 }
 
-// GetSeverity retrieves an severity from the FireHydrant API
+// GetSeverity retrieves a severity from FireHydrant
 func (c *APIClient) GetSeverity(ctx context.Context, slug string) (*SeverityResponse, error) {
-	var fun SeverityResponse
-
-	resp, err := c.client().Get("severities/"+slug).Receive(&fun, nil)
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, NotFound(fmt.Sprintf("Could not find severity with ID %s", slug))
-	}
-
+	sevResponse := &SeverityResponse{}
+	response, err := c.client().Get("severities/"+slug).Receive(sevResponse, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve severity")
+		return nil, errors.Wrap(err, "could not get severity")
 	}
 
-	return &fun, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return sevResponse, nil
 }
 
-// CreateSeverity creates an severity
+// CreateSeverity creates a severity
 func (c *APIClient) CreateSeverity(ctx context.Context, req CreateSeverityRequest) (*SeverityResponse, error) {
-	res := &SeverityResponse{}
-
-	resp, err := c.client().Post("severities").BodyJSON(&req).Receive(res, nil)
+	sevResponse := &SeverityResponse{}
+	response, err := c.client().Post("severities").BodyJSON(&req).Receive(sevResponse, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create severity")
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("Could not create severity %s", req.Slug)
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
 	}
 
-	return res, nil
+	return sevResponse, nil
 }
 
 // UpdateSeverity updates a severity in FireHydrant
 func (c *APIClient) UpdateSeverity(ctx context.Context, slug string, req UpdateSeverityRequest) (*SeverityResponse, error) {
-	res := &SeverityResponse{}
-
-	if _, err := c.client().Patch("severities/"+slug).BodyJSON(&req).Receive(res, nil); err != nil {
+	sevResponse := &SeverityResponse{}
+	response, err := c.client().Patch("severities/"+slug).BodyJSON(&req).Receive(sevResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not update severity")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return sevResponse, nil
 }
 
-// DeleteSeverity deletes a severity record from FireHydrant
+// DeleteSeverity deletes a severity from FireHydrant
 func (c *APIClient) DeleteSeverity(ctx context.Context, slug string) error {
-	if _, err := c.client().Delete("severities/"+slug).Receive(nil, nil); err != nil {
-		return errors.Wrap(err, "could not delete service")
+	response, err := c.client().Delete("severities/"+slug).Receive(nil, nil)
+	if err != nil {
+		return errors.Wrap(err, "could not delete severity")
+	}
+
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -231,49 +231,64 @@ func (c *APIClient) DeleteEnvironment(ctx context.Context, id string) error {
 	return nil
 }
 
-// GetFunctionality retrieves an functionality from the FireHydrant API
+// GetFunctionality retrieves a functionality from FireHydrant
 func (c *APIClient) GetFunctionality(ctx context.Context, id string) (*FunctionalityResponse, error) {
-	var fun FunctionalityResponse
-
-	resp, err := c.client().Get("functionalities/"+id).Receive(&fun, nil)
-
-	if resp.StatusCode == 404 {
-		return nil, NotFound(fmt.Sprintf("Could not find functionality with ID %s", id))
-	}
-
+	funcResponse := &FunctionalityResponse{}
+	response, err := c.client().Get("functionalities/"+id).Receive(funcResponse, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve functionality")
+		return nil, errors.Wrap(err, "could not get functionality")
 	}
 
-	return &fun, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return funcResponse, nil
 }
 
-// CreateFunctionality creates an functionality
+// CreateFunctionality creates a functionality in FireHydrant
 func (c *APIClient) CreateFunctionality(ctx context.Context, req CreateFunctionalityRequest) (*FunctionalityResponse, error) {
-	res := &FunctionalityResponse{}
-
-	if _, err := c.client().Post("functionalities").BodyJSON(&req).Receive(res, nil); err != nil {
+	funcResponse := &FunctionalityResponse{}
+	response, err := c.client().Post("functionalities").BodyJSON(&req).Receive(funcResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not create functionality")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return funcResponse, nil
 }
 
 // UpdateFunctionality updates a functionality in FireHydrant
 func (c *APIClient) UpdateFunctionality(ctx context.Context, id string, req UpdateFunctionalityRequest) (*FunctionalityResponse, error) {
-	res := &FunctionalityResponse{}
-
-	if _, err := c.client().Patch("functionalities/"+id).BodyJSON(&req).Receive(res, nil); err != nil {
+	funcResponse := &FunctionalityResponse{}
+	response, err := c.client().Patch("functionalities/"+id).BodyJSON(&req).Receive(funcResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not update functionality")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return funcResponse, nil
 }
 
-// DeleteFunctionality deletes a functionality record from FireHydrant
+// DeleteFunctionality deletes a functionality from FireHydrant
 func (c *APIClient) DeleteFunctionality(ctx context.Context, id string) error {
-	if _, err := c.client().Delete("functionalities/"+id).Receive(nil, nil); err != nil {
-		return errors.Wrap(err, "could not delete service")
+	response, err := c.client().Delete("functionalities/"+id).Receive(nil, nil)
+	if err != nil {
+		return errors.Wrap(err, "could not delete functionality")
+	}
+
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -138,15 +138,19 @@ func (c *APIClient) client() *sling.Sling {
 }
 
 // Ping hits and verifies the HTTP of FireHydrant
-// TODO: Check failure case
 func (c *APIClient) Ping(ctx context.Context) (*PingResponse, error) {
-	res := &PingResponse{}
-
-	if _, err := c.client().Get("ping").Receive(res, nil); err != nil {
+	pingResponse := &PingResponse{}
+	response, err := c.client().Get("ping").Receive(pingResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not ping")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return pingResponse, nil
 }
 
 // Services returns a ServicesClient interface for interacting with services in FireHydrant
@@ -159,6 +163,7 @@ func (c *APIClient) Runbooks() RunbooksClient {
 	return &RESTRunbooksClient{client: c}
 }
 
+// RunbookActions returns a RunbookActionsClient interface for interacting with runbook actions in FireHydrant
 func (c *APIClient) RunbookActions() RunbookActionsClient {
 	return &RESTRunbookActionsClient{client: c}
 }

--- a/firehydrant/runbook_actions.go
+++ b/firehydrant/runbook_actions.go
@@ -52,14 +52,19 @@ func (c *RESTRunbookActionsClient) restClient() *sling.Sling {
 
 // Get returns a runbook action from the FireHydrant API
 func (c *RESTRunbookActionsClient) Get(ctx context.Context, runbookType string, integrationSlug string, actionSlug string) (*RunbookAction, error) {
-	res := &RunbookActionsResponse{}
+	runbookActionResponse := &RunbookActionsResponse{}
 	query := RunbookActionsQuery{Type: runbookType, Items: 100}
-	_, err := c.restClient().Get("runbooks/actions").QueryStruct(query).Receive(res, nil)
+	response, err := c.restClient().Get("runbooks/actions").QueryStruct(query).Receive(runbookActionResponse, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get runbook")
 	}
 
-	for _, action := range res.Actions {
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, action := range runbookActionResponse.Actions {
 		if action.Slug == actionSlug && action.Integration.Slug == integrationSlug {
 			return &action, nil
 		}

--- a/firehydrant/services.go
+++ b/firehydrant/services.go
@@ -2,8 +2,6 @@ package firehydrant
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/dghubble/sling"
 	"github.com/pkg/errors"
 )
@@ -29,61 +27,79 @@ func (c *RESTServicesClient) restClient() *sling.Sling {
 }
 
 // Get retrieves a service from the FireHydrant API
-// TODO: Check failure case
 func (c *RESTServicesClient) Get(ctx context.Context, id string) (*ServiceResponse, error) {
-	res := &ServiceResponse{}
-	resp, err := c.restClient().Get("services/"+id).Receive(res, nil)
+	serviceResponse := &ServiceResponse{}
+	response, err := c.restClient().Get("services/"+id).Receive(serviceResponse, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get service")
 	}
 
-	if resp.StatusCode == 404 {
-		return nil, NotFound(fmt.Sprintf("Could not find service with ID %s", id))
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
 	}
 
-	return res, nil
+	return serviceResponse, nil
 }
 
 // List retrieves a list of services based on a service query
 func (c *RESTServicesClient) List(ctx context.Context, req *ServiceQuery) (*ServicesResponse, error) {
-	res := &ServicesResponse{}
-	_, err := c.restClient().Get("services").QueryStruct(req).Receive(res, nil)
+	servicesResponse := &ServicesResponse{}
+	response, err := c.restClient().Get("services").QueryStruct(req).Receive(servicesResponse, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get service")
+		return nil, errors.Wrap(err, "could not get services")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return servicesResponse, nil
 }
 
 // Create creates a brand spankin new service in FireHydrant
-// TODO: Check failure case
 func (c *RESTServicesClient) Create(ctx context.Context, createReq CreateServiceRequest) (*ServiceResponse, error) {
-	res := &ServiceResponse{}
-
-	if _, err := c.restClient().Post("services").BodyJSON(&createReq).Receive(res, nil); err != nil {
+	serviceResponse := &ServiceResponse{}
+	response, err := c.restClient().Post("services").BodyJSON(&createReq).Receive(serviceResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not create service")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return serviceResponse, nil
 }
 
 // UpdateService updates a old spankin service in FireHydrant
-// TODO: Check failure case
 func (c *RESTServicesClient) Update(ctx context.Context, serviceID string, updateReq UpdateServiceRequest) (*ServiceResponse, error) {
-	res := &ServiceResponse{}
-
-	if _, err := c.restClient().Patch("services/"+serviceID).BodyJSON(&updateReq).Receive(res, nil); err != nil {
+	serviceResponse := &ServiceResponse{}
+	response, err := c.restClient().Patch("services/"+serviceID).BodyJSON(&updateReq).Receive(serviceResponse, nil)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not update service")
 	}
 
-	return res, nil
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return serviceResponse, nil
 }
 
 // DeleteService updates a old spankin service in FireHydrant
-// TODO: Check failure case
 func (c *RESTServicesClient) Delete(ctx context.Context, serviceID string) error {
-	if _, err := c.restClient().Delete("services/"+serviceID).Receive(nil, nil); err != nil {
+	response, err := c.restClient().Delete("services/"+serviceID).Receive(nil, nil)
+	if err != nil {
 		return errors.Wrap(err, "could not delete service")
+	}
+
+	err = checkResponseStatusCode(response)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/provider/functionality_resource.go
+++ b/provider/functionality_resource.go
@@ -66,6 +66,11 @@ func readResourceFireHydrantFunctionality(ctx context.Context, d *schema.Resourc
 	// Get the functionality
 	r, err := firehydrantAPIClient.GetFunctionality(ctx, d.Id())
 	if err != nil {
+		_, isNotFoundError := err.(firehydrant.NotFound)
+		if isNotFoundError {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 
@@ -225,6 +230,11 @@ func deleteResourceFireHydrantFunctionality(ctx context.Context, d *schema.Resou
 	functionalityID := d.Id()
 	err := firehydrantAPIClient.DeleteFunctionality(ctx, functionalityID)
 	if err != nil {
+		_, isNotFoundError := err.(firehydrant.NotFound)
+		if isNotFoundError {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/provider/service_resource.go
+++ b/provider/service_resource.go
@@ -64,6 +64,11 @@ func readResourceFireHydrantService(ctx context.Context, d *schema.ResourceData,
 	serviceID := d.Id()
 	r, err := firehydrantAPIClient.Services().Get(ctx, serviceID)
 	if err != nil {
+		_, isNotFoundError := err.(firehydrant.NotFound)
+		if isNotFoundError {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 
@@ -181,6 +186,11 @@ func deleteResourceFireHydrantService(ctx context.Context, d *schema.ResourceDat
 	serviceID := d.Id()
 	err := firehydrantAPIClient.Services().Delete(ctx, serviceID)
 	if err != nil {
+		_, isNotFoundError := err.(firehydrant.NotFound)
+		if isNotFoundError {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/provider/team_resource.go
+++ b/provider/team_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -40,6 +39,11 @@ func readResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, m 
 	// Get the team
 	teamResponse, err := firehydrantAPIClient.GetTeam(ctx, d.Id())
 	if err != nil {
+		_, isNotFoundError := err.(firehydrant.NotFound)
+		if isNotFoundError {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 
@@ -114,6 +118,10 @@ func deleteResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 	teamID := d.Id()
 	err := firehydrantAPIClient.DeleteTeam(ctx, teamID)
 	if err != nil {
+		_, isNotFoundError := err.(firehydrant.NotFound)
+		if isNotFoundError {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
## Description

This PR adds missing error checking to the API client and checks for 404s in r/team, r/service, and r/functionality. We should eventually add this 404 check to the rest of the provider but I'm starting with the resources we've been working on lately. 

Previously we were only checking for errors returned from the API in a few places, which was causing the provider to tell a user resources had been created when they really hadn't. 

In the future it would be good to parse more error messages from the API and return them in the provider output but that was beyond the scope of this PR, as our error messages don't always come back from the API in the same format.

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     #dev_overrides {
     #  "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     #}

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/8327429/terraform-error-handling-config.txt)
 as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a service, functionality, runbook (use the auto add services step), and environment. Make sure each one has the name prefix of "ds-".
1. Take the ids for the things you just created and replace the placeholders in the config with them. Make sure you replace the email field in the runbook1 resource with your email as well.
1. Run `terraform init`.

#### Provision resources and data sources:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.

#### Upgrade provider version to local build of this branch
1. Edit your ~/.terraformrc file and remove the comments in front of the dev_overrides block
   ```
   dev_overrides {
     "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   }
   ```
1. Run `terraform plan`. This time you should see a yellow warning block telling you that development overrides are in place. You should see no changes aside from some attributes that need to be updated in state because there are unreleased.
1. Go ahead and run `terraform apply -refresh-only` to pick up these state updates.

#### Error handling: bad api key
1. Change your API key to an invalid key and try to run `terraform plan`. This should fail and you should see an error that looks something like this:
   <img width="498" alt="Screen Shot 2022-03-22 at 2 59 04 PM" src="https://user-images.githubusercontent.com/12189856/159565561-43155fdd-fd39-4999-85df-1af339cb40a7.png">
1. Change your API key back

#### Error handling: teams, services, and functionalities
1. Delete your team2, service2, and functionality2 in the UI and run `terraform plan`. This should show that all three have been deleted outside of Terraform and need to be created.
1. Run `terraform apply` to recreate them all and run `terraform apply -refresh-only` to pick up the unreleased attributes.

#### Error handling: providing bad data
1. Add a severity3 resource to your config with an invalid severity slug
   ```
   resource "firehydrant_severity" "severity3" {
     slug = "PROVIDER-SEVERITY3"
   }
   ```
1. Run `terraform apply`. This should fail. You shouldn't see severity3 in the UI or in your terraform.tfstate file and you should see an error that looks something like this:
   <img width="521" alt="Screen Shot 2022-03-22 at 3 21 38 PM" src="https://user-images.githubusercontent.com/12189856/159569023-daeea24e-3861-4c9c-8431-26c08c877807.png">
1. Remove severity3 from you config.

#### Make sure you can still update various resources:
1. Update the attributes on your various resources (name or description tend to be simple ones change or add)
1. Run `terraform apply`. This should succeed and you should see these changes reflected in the UI.
1.  Run `terraform plan`. Your plan should show no changes.
1. Remove all teams and the owner from service2
   ```
   resource "firehydrant_service" "service2" {
     name        = "service2"
     description = "description2"

     labels = {
       language  = "ruby",
       lifecycle = "production"
     }

     service_tier = 1
   }
   ```
1. Run `terraform apply`. The output should show `Plan: 0 to add, 1 to change, 0 to destroy.`. You should see that all teams and the owner will be removed from service2.
1. Confirm in the UI that all teams and the owner have been removed from service2.
1.  Run `terraform plan`. Your plan should show no changes except for the step_id that will change on your runbook resource.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

#### Make sure a fresh create on this new version works
1. Run `terraform apply`. This should succeed. 

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.