### PR TITLE
Update CHANGELOG.md for 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,69 @@ NOTES:
 
 * The services attribute has been removed from resource/team. If you need to add a team as an owner or responder to a service, use resource/service and specify `owner_id` or `team_ids`.
    When upgrading to 0.2.0, you should remove the `services` attribute from any team resources and instead add `team_ids` to each service resource.
-* The deprecated attribute `services` will be removed from resource/functionality 3 months after the release of v0.2.0. You will have until May 31, 2022 to migrate to the preferred attribute.
+   As an example, the configuration below was valid in 0.1.4.
+   ```hcl
+   # An example of a valid 0.1.4 configuration
+   resource "firehydrant_service" "service1" {
+     name        = "service1"
+     description = "description1"
+
+     labels = {
+       language  = "ruby",
+       lifecycle = "production"
+     }
+
+     service_tier = 1
+   }
+
+   resource "firehydrant_team" "team1" {
+     name = "team1"
+
+     services {
+       id = firehydrant_service.service1.id
+     }
+   }
+
+   resource "firehydrant_team" "team2" {
+     name        = "team2"
+     description = "description2"
+
+     services {
+       id = firehydrant_service.service1.id
+     }
+   }
+   ```
+   To upgrade to 0.2.0, that configuration would have to change to the following:
+   ```hcl
+   # The same configuration as above, updated to be valid for 0.2.0
+   resource "firehydrant_service" "service1" {
+     name        = "service1"
+     description = "description1"
+
+     labels = {
+       language  = "ruby",
+       lifecycle = "production"
+     }
+
+     service_tier = 1
+
+     team_ids = [
+       firehydrant_team.team1.id,
+       firehydrant_team.team2.id
+     ]
+   }
+
+
+   resource "firehydrant_team" "team1" {
+     name = "team1"
+   }
+
+   resource "firehydrant_team" "team2" {
+     name        = "team2"
+     description = "description2"
+   }
+   ```
+* The deprecated attribute `services` will be removed from resource/functionality 3 months after the release of v0.2.0. You will have until June 30, 2022 to migrate to the preferred attribute.
   More information about this deprecation can be found in the description of ([#49](https://github.com/firehydrant/terraform-provider-firehydrant/pull/49))
 
 ## 0.1.4


### PR DESCRIPTION
## Description

This PR adds an example of upgrading to 0.2.0 to deal with the breaking change it introduces to the changelog. It also updates the deprecation date in the changelog. 

## Testing plan

1. Look for any typos 

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.