### PR TITLE
Fix typo in service related documentation

### DIFF
--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -24,7 +24,7 @@ data "firehydrant_service" "example-service" {
 
 ### Read-only
 
-- **add_on_alert** (Boolean, Read-only) Indicates if FireHydrant should automatically create
+- **alert_on_add** (Boolean, Read-only) Indicates if FireHydrant should automatically create
   an alert based on the integrations set up for this service, if this service is added to an
   active incident. Defaults to `false`.
 - **description** (String, Read-only) A description for the service.

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -45,7 +45,7 @@ data "firehydrant_services" "managed-true-labeled-services" {
 ### Nested Schema for `services`
 
 - **id** (String, Read-only) The ID of the service.
-- **add_on_alert** (Boolean, Read-only) Indicates if FireHydrant should automatically create
+- **alert_on_add** (Boolean, Read-only) Indicates if FireHydrant should automatically create
   an alert based on the integrations set up for this service, if this service is added to an
   active incident. Defaults to `false`.
 - **description** (String, Read-only) A description for the service.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -29,7 +29,7 @@ resource "firehydrant_team" "example-responder-team2" {
 
 resource "firehydrant_service" "example-service" {
   name         = "my-example-service"
-  add_on_alert = true
+  alert_on_add = true
   description  = "The main service for our company"
 
   labels = {
@@ -63,7 +63,7 @@ resource "firehydrant_service" "example-service" {
 
 ### Optional
 
-- **add_on_alert** (Boolean, Optional) Indicates if FireHydrant should automatically create 
+- **alert_on_add** (Boolean, Optional) Indicates if FireHydrant should automatically create 
   an alert based on the integrations set up for this service, if this service is added to an 
   active incident. Defaults to `false`.
 - **description** (String, Optional) A description for the service.


### PR DESCRIPTION
## Description

This PR fixes a typo in all of the service related documentation so that the correct attribute, `alert_on_add`, is documented.

Fixes #61 

## Testing plan

1. Read documentation, looking for any typos

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/b3A6Njc2NzMy-create-a-service)

## PR readiness 

- [ ] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [ ] An entry has been added to the changelog, if necessary.