### PR TITLE
Duplicate names for web and frontend prevent example from running

### DIFF
--- a/examples/services.tf
+++ b/examples/services.tf
@@ -12,7 +12,7 @@ resource "firehydrant_service" "web" {
 }
 
 resource "firehydrant_service" "frontend" {
-    name   = "web"
+    name   = "frontend"
     description = "The main web UI for our company"
     labels = {
       language = "javascript",


### PR DESCRIPTION
## Description

The examples for terraform fail to produce a consistent output since both the `web` and `frontend` services both have the same `name` attribute. This was likely my cut/paste error when I last updated the examples.

## Testing plan

1. Create and apply a plan to the original examples -- note the error for the web service
1. Reset and run the updated example -- note no errors 😄 

## Related links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developers.firehydrant.io/docs/api/xxxx)
- [Related PR](https://github.com/firehydrant/firehydrant/pull/xxxx)

## PR readiness 

- [ ] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [ ] An entry has been added to the changelog, if necessary.