### PR TITLE
Refactor d/runbook & r/runbook for clarity and consistency

### DIFF
--- a/provider/runbook_data.go
+++ b/provider/runbook_data.go
@@ -14,15 +14,18 @@ func dataSourceRunbook() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataFireHydrantRunbook,
 		Schema: map[string]*schema.Schema{
+			// Required
 			"id": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"name": {
+
+			// Computed
+			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"description": {
+			"name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -31,27 +34,31 @@ func dataSourceRunbook() *schema.Resource {
 }
 
 func dataFireHydrantRunbook(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	ac := m.(firehydrant.Client)
-	serviceID := d.Get("id").(string)
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
 
-	r, err := ac.Runbooks().Get(ctx, serviceID)
+	// Get the runbook
+	runbookID := d.Get("id").(string)
+	runbookResponse, err := firehydrantAPIClient.Runbooks().Get(ctx, runbookID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	var ds diag.Diagnostics
-	svc := map[string]string{
-		"name":        r.Name,
-		"description": r.Description,
+	// Gather values from API response
+	attributes := map[string]interface{}{
+		"description": runbookResponse.Description,
+		"name":        runbookResponse.Name,
 	}
 
-	for key, val := range svc {
-		if err := d.Set(key, val); err != nil {
+	// Set the data source attributes to the values we got from the API
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	d.SetId(r.ID)
+	// Set the runbook's ID in state
+	d.SetId(runbookResponse.ID)
 
-	return ds
+	return diag.Diagnostics{}
 }


### PR DESCRIPTION
## Description

This PR refactors the runbook resource and data source to be more consistent, to have clearer named variables, and to have comments explaining what is happening. None of this should change the functionality.

## Testing plan

Nothing should have changed about how these resources/data sources function, so this test plan just walks through making sure things work the way they did before. 

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     #dev_overrides {
     #  "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     #}

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9022137/terraform-runbook-refactor-config.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a runbook (use the auto add services step). Then take the id of your runbook and replace the placeholder in the config with it. Make sure you replace the email field in the runbook1 resource with your email as well.  
1. Run `terraform init`.

#### Provision resources and data sources:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.

#### Upgrade provider version to local build of this branch
1. Edit your ~/.terraformrc file and remove the comments in front of the dev_overrides block
   ```
   dev_overrides {
     "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   }
   ```
1. Run `terraform plan`. You should see no changes.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

#### Make sure a fresh create on this new version works
1. Run `terraform apply`. This should succeed. Your created resources should be reflected in your terraform.tfstate file and in the UI.
1. Run `terraform plan`. You should see no changes.

#### Make sure updating things still works
1. Update your config by changing your runbook name and description and run `terraform apply`. This should succeed. Your changes should be reflected in your terraform.tfstate file and in the UI.
1. Run `terraform plan`. You should see no changes.

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.