### PR TITLE
Refactor documentation to match HashiCorp guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.1 (Unreleased)
 
+ENHANCEMENTS:
+
+* documentation: Refactored documentation to follow best practices, added descriptions for all arguments, and added configuration examples for all resources and data sources ([#69](https://github.com/firehydrant/terraform-provider-firehydrant/pull/69))
+
 ## 0.2.0
 
 BREAKING CHANGES: 

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -1,29 +1,34 @@
 ---
-page_title: "firehydrant_environment Data Source - terraform-provider-firehydrant"
+page_title: "FireHydrant Data Source: firehydrant_environment"
 subcategory: ""
-description: |-
-  
 ---
 
-# Data Source `firehydrant_environment`
+# firehydrant_environment Data Source
 
+Use this data source to get information on environments.
 
+FireHydrant environments let you break up your app by region (for example, "US East 1") 
+or development stage (for example, "Production").
 
+## Example Usage
 
+Basic usage:
+```hcl
+data "firehydrant_environment" "example-environment" {
+  environment_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **environment_id** (String, Required)
+* `environment_id` - (Required) The ID of the environment.
 
-### Optional
+## Attributes Reference
 
-- **id** (String, Optional) The ID of this resource.
+In addition to all arguments above, the following attributes are exported:
 
-### Read-only
-
-- **description** (String, Read-only)
-- **name** (String, Read-only)
-
-
+* `id` - The ID of the environment.
+* `description` - A description of the environment.
+* `name` - The name of the environment.

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "FireHydrant Data Source: firehydrant_environment"
-subcategory: ""
+subcategory: "Beta"
 ---
 
 # firehydrant_environment Data Source

--- a/docs/data-sources/functionality.md
+++ b/docs/data-sources/functionality.md
@@ -1,32 +1,36 @@
 ---
-page_title: "firehydrant_functionality Data Source - terraform-provider-firehydrant"
+page_title: "FireHydrant Data Source: firehydrant_functionality"
 subcategory: ""
-description: |-
-  
 ---
 
-# Data Source `firehydrant_functionality`
+# firehydrant_functionality Data Source
+
+Use this data source to get information on functionalities.
+
+A functionality (function) is a programming construct that performs a specific task. 
+FireHydrant functionalities let you associate backend services with the features your 
+end users interact with.
 
 ## Example Usage
 
 Basic usage:
-
 ```hcl
 data "firehydrant_functionality" "example-functionality" {
   functionality_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 }
 ```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **functionality_id** (String, Required) The ID of the functionality.
+* `functionality_id` - (Required) The ID of the functionality.
 
-### Read-only
+## Attributes Reference
 
-- **id** (String, Read-only) The ID of the functionality.
-- **description** (String, Read-only)
-- **name** (String, Read-only) The name of the functionality.
-- **description** (String, Read-only) A description for the functionality.
-- **service_ids** (Set of String, Read-only) A set of IDs of the services this functionality is associated with.
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the functionality.
+* `description` - A description of the functionality.
+* `name` - The name of the functionality.
+* `service_ids` - A set of IDs of the services this functionality is associated with.

--- a/docs/data-sources/functionality.md
+++ b/docs/data-sources/functionality.md
@@ -1,6 +1,6 @@
 ---
 page_title: "FireHydrant Data Source: firehydrant_functionality"
-subcategory: ""
+subcategory: "Beta"
 ---
 
 # firehydrant_functionality Data Source

--- a/docs/data-sources/runbook.md
+++ b/docs/data-sources/runbook.md
@@ -1,25 +1,38 @@
 ---
-page_title: "firehydrant_runbook Data Source - terraform-provider-firehydrant"
+page_title: "FireHydrant Data Source: firehydrant_runbook"
 subcategory: ""
-description: |-
-  
 ---
 
-# Data Source `firehydrant_runbook`
+# firehydrant_runbook Data Source
 
+Use this data source to get information on runbooks.
 
+FireHydrant runbooks allow you to configure and automate your incident response process by defining a workflow 
+to be followed when an incident occurs. Runbooks actually initiate actions that are fundamental steps to 
+resolving an incident. Such actions might be creating a Slack channel, starting a Zoom meeting, or opening 
+a Jira ticket. Think of a runbook as an incident response playbook that runs (or is activated) when
+an incident is declared. Using runbooks, you can equip your team with updated information and best practices 
+for mitigating incidents.
 
+## Example Usage
 
+Basic usage:
+```hcl
+data "firehydrant_runbook" "example-runbook" {
+  id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **id** (String, Required) The ID of this resource.
+* `id` - (Required) The ID of the runbook.
 
-### Read-only
+## Attributes Reference
 
-- **description** (String, Read-only)
-- **name** (String, Read-only)
+In addition to all arguments above, the following attributes are exported:
 
-
+* `id` - The ID of the runbook.
+* `description` - A description of the runbook.
+* `name` - The name of the runbook.

--- a/docs/data-sources/runbook.md
+++ b/docs/data-sources/runbook.md
@@ -1,6 +1,6 @@
 ---
 page_title: "FireHydrant Data Source: firehydrant_runbook"
-subcategory: ""
+subcategory: "Beta"
 ---
 
 # firehydrant_runbook Data Source

--- a/docs/data-sources/runbook_action.md
+++ b/docs/data-sources/runbook_action.md
@@ -1,11 +1,15 @@
 ---
-page_title: "firehydrant_runbook_action Data Source - terraform-provider-firehydrant"
+page_title: "FireHydrant Data Source: firehydrant_runbook_action"
 subcategory: ""
-description: |-
-  
 ---
 
-# Data Source `firehydrant_runbook_action`
+# firehydrant_runbook_action Data Source
+
+Use this data source to get information on runbook actions.
+
+FireHydrant runbook actions represent the different types of actions
+a runbook step can take. Some runbook actions require that you have the
+associated integration installed in FireHydrant.
 
 ## Example Usage
 
@@ -19,6 +23,12 @@ data "firehydrant_runbook_action" "confluence_cloud_export_retro" {
 }
 
 # FireHydrant
+data "firehydrant_runbook_action" "firehydrant_add_task_list" {
+  integration_slug = "patchy"
+  slug             = "add_task_list"
+  type             = "incident"
+}
+
 data "firehydrant_runbook_action" "firehydrant_assign_a_role" {
   integration_slug = "patchy"
   slug             = "assign_a_role"
@@ -98,8 +108,15 @@ data "firehydrant_runbook_action" "giphy_incident_channel_gif" {
   type             = "incident"
 }
 
-# Google
-data "firehydrant_runbook_action" "google_create_google_meet_link" {
+# Google Docs
+data "firehydrant_runbook_action" "google_docs_export_retro" {
+  integration_slug = "google_docs"
+  slug             = "export_retrospective"
+  type             = "incident"
+}
+
+# Google Meet
+data "firehydrant_runbook_action" "google_meet_create_google_meet_link" {
   integration_slug = "google_meet"
   slug             = "create_google_meet_link"
   type             = "incident"
@@ -116,6 +133,31 @@ data "firehydrant_runbook_action" "jira_cloud_create_incident_issue" {
 data "firehydrant_runbook_action" "jira_server_create_incident_issue" {
   integration_slug = "jira_onprem"
   slug             = "create_incident_issue"
+  type             = "incident"
+}
+
+# Microsoft Teams
+data "firehydrant_runbook_action" "microsoft_teams_create_incident_channel" {
+  integration_slug = "microsoft_teams"
+  slug             = "create_incident_channel"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "microsoft_teams_notify_channel" {
+  integration_slug = "microsoft_teams"
+  slug             = "notify_channel"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "microsoft_teams_notify_channel_custom" {
+  integration_slug = "microsoft_teams"
+  slug             = "notify_channel_custom_message"
+  type             = "incident"
+}
+
+data "firehydrant_runbook_action" "microsoft_teams_notify_incident_channel_custom" {
+  integration_slug = "microsoft_teams"
+  slug             = "notify_incident_channel_custom_message"
   type             = "incident"
 }
 
@@ -191,6 +233,13 @@ data "firehydrant_runbook_action" "victorops_create_new_incident" {
   type             = "incident"
 }
 
+# Webex
+data "firehydrant_runbook_action" "webex_create_meeting" {
+  integration_slug = "webex"
+  slug             = "create_meeting"
+  type             = "incident"
+}
+
 # Zoom 
 data "firehydrant_runbook_action" "zoom_create_meeting" {
   integration_slug = "zoom"
@@ -199,16 +248,18 @@ data "firehydrant_runbook_action" "zoom_create_meeting" {
 }
 ```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **integration_slug** (String, Required) The slug of the integration associated with the runbook action.
-- **slug** (String, Required) The slug of the runbook action.
-- **type** (String, Required) The type of runbook supported for the runbook action. 
-   Valid values are `incident`, `infrastructure`, and `incident_role`.
+* `integration_slug` - (Required) The slug of the integration associated with the runbook action.
+* `slug` - (Required) The slug of the runbook action.
+* `type` - (Required) The type of runbook supported for the runbook action. Valid values are `incident`, 
+  `infrastructure`, and `incident_role`.
 
-### Read-only
+## Attributes Reference
 
-- **id** (String, Read-only) The ID of the runbook action.
-- **name** (String, Read-only) The name of the runbook action.
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the runbook action.
+* `name` - The name of the runbook action.

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -1,11 +1,14 @@
 ---
-page_title: "firehydrant_service Data Source - terraform-provider-firehydrant"
+page_title: "FireHydrant Data Source: firehydrant_service"
 subcategory: ""
-description: |-
-
 ---
 
-# Data Source `firehydrant_service`
+# firehydrant_service Data Source
+
+Use this data source to get information on services.
+
+FireHydrant services are collections of functions that perform a targeted business operation. 
+A service can be a microservice, a mono-repository, or a library that you maintain. 
 
 ## Example Usage
 
@@ -16,28 +19,32 @@ data "firehydrant_service" "example-service" {
 }
 ```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **id** (String, Required) The ID of the service.
+* `id` - (Required) The ID of the service.
 
-### Read-only
+## Attributes Reference
 
-- **add_on_alert** (Boolean, Read-only) Indicates if FireHydrant should automatically create
-  an alert based on the integrations set up for this service, if this service is added to an
-  active incident. Defaults to `false`.
-- **description** (String, Read-only) A description for the service.
-- **labels** (Map of String, Read-only) Key-value pairs associated with the service. Useful for
-  supporting searching and filtering of the service catalog.
-- **links** (Set of Map, Read-only) Links associated with the service (see [below for nested schema](#nestedatt--links)).
-- **name** (String, Read-only) The name of the service.
-- **owner_id** (String, Read-only) The ID of the team that owns this service.
-- **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
-  Lower values represent higher criticality. Defaults to `5`.
-- **team_ids** (Set of String, Optional) A set of IDs of the teams responsible for this service's incident response.
-<a id="nestedatt--links"></a>
-### Nested Schema for `links`
+In addition to all arguments above, the following attributes are exported:
 
-- **href_url** (String, Read-only) The URL to use for the link.
-- **name** (String, Read-only) The name of the link.
+* `id` - The ID of the service.
+* `alert_on_add` - Indicates if FireHydrant should automatically create an alert 
+  based on the integrations set up for this service, if this service is added to 
+  an active incident.
+* `description` - A description of the service.
+* `labels` - Key-value pairs associated with the service. Useful for supporting 
+  searching and filtering of the service catalog.
+* `links` - Links associated with the service
+* `name` - The name of the service.
+* `owner_id` - The ID of the team that owns this service.
+* `service_tier` - The service tier of this resource - between 1 - 5.
+  Lower values represent higher criticality.
+* `team_ids` - A set of IDs of the teams responsible for this service's incident 
+  response.
+
+The `links` block contains:
+
+* `href_url` - The URL for the link.
+* `name` - The name of the link.

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -1,11 +1,14 @@
 ---
-page_title: "firehydrant_services Data Source - terraform-provider-firehydrant"
+page_title: "FireHydrant Data Source: firehydrant_services"
 subcategory: ""
-description: |-
-
 ---
 
-# Data Source `firehydrant_services`
+# firehydrant_services Data Source
+
+Use this data source to get information on all services matching the given criteria.
+
+FireHydrant services are collections of functions that perform a targeted business operation.
+A service can be a microservice, a mono-repository, or a library that you maintain.
 
 ## Example Usage
 
@@ -31,34 +34,37 @@ data "firehydrant_services" "managed-true-labeled-services" {
 }
 ```
 
-## Schema
+## Argument Reference
 
-### Optional
+The following arguments are supported:
 
-- **labels** (Map of String, Optional)
-- **query** (String, Optional)
+* `labels` - (Optional) Labels on the runbooks being searched for.
+* `query` - (Optional) A query to search for runbooks by their name.
 
-### Read-only
+## Attributes Reference
 
-- **services** (List of Object, Read-only) (see [below for nested schema](#nestedatt--services))
-<a id="nestedatt--services"></a>
-### Nested Schema for `services`
+In addition to all arguments above, the following attributes are exported:
 
-- **id** (String, Read-only) The ID of the service.
-- **add_on_alert** (Boolean, Read-only) Indicates if FireHydrant should automatically create
-  an alert based on the integrations set up for this service, if this service is added to an
-  active incident. Defaults to `false`.
-- **description** (String, Read-only) A description for the service.
-- **labels** (Map of String, Read-only) Key-value pairs associated with the service. Useful for
-  supporting searching and filtering of the service catalog.
-- **links** (Set of Map, Read-only) Links associated with the service (see [below for nested schema](#nestedatt--links)).
-- **name** (String, Read-only) The name of the service.
-- **owner_id** (String, Read-only) The ID of the team that owns this service.
-- **service_tier** (Integer, Read-only) The service tier of this resource - between 1 - 5.
-  Lower values represent higher criticality. Defaults to `5`.
-- **team_ids** (Set of String, Optional) A set of IDs of the teams responsible for this service's incident response.
-<a id="nestedatt--links"></a>
-### Nested Schema for `links`
+* `services` - All the services matching the criteria specified by `labels` and `query`.
 
-- **href_url** (String, Read-only) The URL to use for the link.
-- **name** (String, Read-only) The name of the link.
+The `services` block contains:
+
+* `id` - The ID of the service.
+* `alert_on_add` - Indicates if FireHydrant should automatically create an alert
+  based on the integrations set up for this service, if this service is added to
+  an active incident.
+* `description` - A description of the service.
+* `labels` - Key-value pairs associated with the service. Useful for supporting
+  searching and filtering of the service catalog.
+* `links` - Links associated with the service
+* `name` - The name of the service.
+* `owner_id` - The ID of the team that owns this service.
+* `service_tier` - The service tier of this resource - between 1 - 5.
+  Lower values represent higher criticality.
+* `team_ids` - A set of IDs of the teams responsible for this service's incident
+  response.
+
+The `links` block contains:
+
+* `href_url` - The URL for the link.
+* `name` - The name of the link.

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -1,24 +1,40 @@
 ---
-page_title: "firehydrant_environment Resource - terraform-provider-firehydrant"
+page_title: "FireHydrant Resource: firehydrant_environment"
 subcategory: ""
-description: |-
-  FireHydrant environments are used to tag incidents with where they are occurring.
 ---
 
-# Resource `firehydrant_environment`
+# firehydrant_environment Resource
 
-FireHydrant environments are used to tag incidents with where they are occurring.
+FireHydrant environments let you break up your app by region (for example, "US East 1")
+or development stage (for example, "Production").
 
+## Example Usage
 
+Basic usage:
+```hcl
+resource "firehydrant_environment" "example-environment" {
+  name        = "example-environment"
+  description = "This is an example environment"
+}
+```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **name** (String, Required)
+* `name` - (Required) The name the environment.
+* `description` - (Optional) A description of the environment.
 
-### Optional
+## Attributes Reference
 
-- **description** (String, Optional)
-- **id** (String, Optional) The ID of this resource.
+In addition to all arguments above, the following attributes are exported:
 
+* `id` - The ID of the environment.
+
+## Import
+
+Environments can be imported; use `<ENVIRONMENT ID>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_environment.test 3638b647-b99c-5051-b715-eda2c912c42e
+```

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "FireHydrant Resource: firehydrant_environment"
-subcategory: ""
+subcategory: "Beta"
 ---
 
 # firehydrant_environment Resource

--- a/docs/resources/functionality.md
+++ b/docs/resources/functionality.md
@@ -1,16 +1,17 @@
 ---
-page_title: "firehydrant_functionality Resource - terraform-provider-firehydrant"
+page_title: "FireHydrant Resource: firehydrant_functionality"
 subcategory: ""
-description: |-
-  
 ---
 
-# Resource `firehydrant_functionality`
+# firehydrant_functionality Resource
+
+A functionality (function) is a programming construct that performs a specific task.
+FireHydrant functionalities let you associate backend services with the features your
+end users interact with.
 
 ## Example Usage
 
 Basic usage:
-
 ```hcl
 resource "firehydrant_service" "example-service1" {
   name = "my-example-service1"
@@ -31,32 +32,35 @@ resource "firehydrant_functionality" "example-functionality" {
 }
 ```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **name** (String, Required) The name of the functionality.
-
-### Optional
-
-- **description** (String, Optional) A description for the functionality.
-- **service_ids** (Set of String, Optional) A set of IDs of the services this functionality is associated with.
+* `name` - (Required) The name of the functionality.
+* `description` - (Optional) A description of the functionality.
+* `service_ids` - (Optional) A set of IDs of the services this functionality is associated with.
   This value _must not_ be provided if `services` is provided.
-- **services** (Block List, Optional) **Deprecated** The services this functionality is associated with 
-   (see [below for nested schema](#nestedblock--services)). This value _must not_ be provided if
-  `service_ids` is provided.
+* `services` - **Deprecated** Use `service_ids` instead. The services this functionality is associated with. 
+  This value _must not_ be provided if `service_ids` is provided.
 
-### Read-only
+**Deprecated** The `services` block supports:
 
-- **id** (String, Read-only) The ID of the functionality.
+* `id` - (Required) The ID of the service.
 
-<a id="nestedblock--services"></a>
-### Nested Schema for `services` (Deprecated)
+## Attributes Reference
 
-Required:
+In addition to all arguments above, the following attributes are exported:
 
-- **id** (String, Required) The ID of the service.
+* `id` - The ID of the functionality.
 
-Read-only:
+**Deprecated** The `services` block contains:
 
-- **name** (String, Read-only) The name of the service.
+* `id` - The ID of the service.
+
+## Import
+
+Functionalities can be imported; use `<FUNCTIONALITY ID>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_functionality.test 3638b647-b99c-5051-b715-eda2c912c42e
+```

--- a/docs/resources/functionality.md
+++ b/docs/resources/functionality.md
@@ -1,6 +1,6 @@
 ---
 page_title: "FireHydrant Resource: firehydrant_functionality"
-subcategory: ""
+subcategory: "Beta"
 ---
 
 # firehydrant_functionality Resource

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -1,6 +1,6 @@
 ---
 page_title: "FireHydrant Resource: firehydrant_runbook"
-subcategory: ""
+subcategory: "Beta"
 ---
 
 # firehydrant_runbook Resource

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -1,56 +1,81 @@
 ---
-page_title: "firehydrant_runbook Resource - terraform-provider-firehydrant"
+page_title: "FireHydrant Resource: firehydrant_runbook"
 subcategory: ""
-description: |-
-  
 ---
 
-# Resource `firehydrant_runbook`
+# firehydrant_runbook Resource
 
+FireHydrant runbooks allow you to configure and automate your incident response process by defining a workflow
+to be followed when an incident occurs. Runbooks actually initiate actions that are fundamental steps to
+resolving an incident. Such actions might be creating a Slack channel, starting a Zoom meeting, or opening
+a Jira ticket. Think of a runbook as an incident response playbook that runs (or is activated) when
+an incident is declared. Using runbooks, you can equip your team with updated information and best practices
+for mitigating incidents.
 
+## Example Usage
 
+Basic usage:
+```hcl
+data "firehydrant_runbook_action" "notify-channel-action" {
+  slug             = "notify_channel"
+  integration_slug = "slack"
+  type             = "incident"
+}
 
+resource "firehydrant_runbook" "example-runbook" {
+  name        = "example-runbook"
+  type        = "incident"
+  description = "This is an example runbook"
+  
+  steps {
+    name    = "Notify Channel"
+    action_id = data.firehydrant_runbook_action.notify-channel-action.id
+    config = {
+      "channels" = "#incidents"
+    }
+  }
+}
+```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **name** (String, Required)
-- **type** (String, Required)
+* `name` - (Required) The name of the runbook.
+* `type` - (Required) The type of the runbook. Valid values are 
+  `incident`, `general`, `infrastructure`, and `incident_role`.
+* `description` - (Optional) A description of the runbook.
+* `severities` - (Optional) Severities to associate with the runbook.
+* `steps` - (Optional) Steps to add to the runbook.
 
-### Optional
+The `severities` block supports:
 
-- **description** (String, Optional)
-- **id** (String, Optional) The ID of this resource.
-- **severities** (Block List) (see [below for nested schema](#nestedblock--severities))
-- **steps** (Block List) (see [below for nested schema](#nestedblock--steps))
+* `id` - (Required) The ID of the severity.
 
-<a id="nestedblock--severities"></a>
-### Nested Schema for `severities`
+The `steps` block supports:
 
-Required:
+* `action_id` - (Required) The ID of the runbook action for the step.
+* `name` - (Required) The name of the step.
+* `automatic` - (Optional) Whether this step should be automatically execute.
+* `config` - (Optional) Config block for the step.
+* `delation_duration` - (Optional) How long this step should wait before executing.
+* `repeats` - (Optional) Whether this step should repeat.
+* `repeats_duration` - (Optional) How often this step should repeat.
 
-- **id** (String, Required) The ID of this resource.
+## Attributes Reference
 
+In addition to all arguments above, the following attributes are exported:
 
-<a id="nestedblock--steps"></a>
-### Nested Schema for `steps`
+* `id` - The ID of the runbook.
 
-Required:
+The `steps` block contains:
 
-- **action_id** (String, Required)
-- **name** (String, Required)
+* `step_id` - The ID of the step.
 
-Optional:
+## Import
 
-- **automatic** (Boolean, Optional)
-- **config** (Map of String, Optional)
-- **delation_duration** (String, Optional)
-- **repeats** (Boolean, Optional)
-- **repeats_duration** (String, Optional)
+Runbooks can be imported; use `<RUNBOOK ID>` as the import ID. For example:
 
-Read-only:
-
-- **step_id** (String, Read-only)
-
-
+```shell
+terraform import firehydrant_runbook.test 3638b647-b99c-5051-b715-eda2c912c42e
+```

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -1,16 +1,16 @@
 ---
-page_title: "firehydrant_service Resource - terraform-provider-firehydrant"
+page_title: "FireHydrant Resource: firehydrant_service"
 subcategory: ""
-description: |-
-
 ---
 
-# Resource `firehydrant_service`
+# firehydrant_service Resource
+
+FireHydrant services are collections of functions that perform a targeted business operation.
+A service can be a microservice, a mono-repository, or a library that you maintain.
 
 ## Example Usage
 
 Basic usage:
-
 ```hcl
 resource "firehydrant_team" "example-owner-team" {
   name        = "my-example-owner-team"
@@ -28,16 +28,13 @@ resource "firehydrant_team" "example-responder-team2" {
 }
 
 resource "firehydrant_service" "example-service" {
-  name         = "my-example-service"
-  add_on_alert = true
-  description  = "The main service for our company"
+  name         = "example-service"
+  alert_on_add = true
+  description  = "This is an example service"
 
   labels = {
-    language  = "ruby",
+    language  = "go",
     lifecycle = "production"
-    system    = "main"
-    type      = "user"
-    tags      = "foo; bar; baz"
   }
 
   links {
@@ -55,31 +52,39 @@ resource "firehydrant_service" "example-service" {
 }
 ```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **name** (String, Required) The name of the service.
-
-### Optional
-
-- **add_on_alert** (Boolean, Optional) Indicates if FireHydrant should automatically create 
-  an alert based on the integrations set up for this service, if this service is added to an 
+* `name` - (Required) The name of the service.
+* `alert_on_add` - (Optional) Indicates if FireHydrant should automatically create
+  an alert based on the integrations set up for this service, if this service is added to an
   active incident. Defaults to `false`.
-- **description** (String, Optional) A description for the service.
-- **labels** (Map of String, Optional) Key-value pairs associated with the service. Useful for 
+* `description` - (Optional) A description for the service.
+* `labels` - (Optional) Key-value pairs associated with the service. Useful for
   supporting searching and filtering of the service catalog.
-- **links** (Set of Map, Optional) Links associated with the service (see [below for nested schema](#nestedatt--links)).
-- **owner_id** (String, Optional) The ID of the team that owns this service.
-- **service_tier** (Integer, Optional) The service tier of this resource - between 1 - 5. 
+* `links` - (Optional) Links associated with the service
+* `owner_id` - (Optional) The ID of the team that owns this service.
+* `service_tier` - (Optional) The service tier of this resource - between 1 - 5.
   Lower values represent higher criticality. Defaults to `5`.
-- **team_ids** (Set of String, Optional) A set of IDs of the teams responsible for this service's incident response.
-<a id="nestedatt--links"></a>
-### Nested Schema for `links`
+* `team_ids` - (Optional) A set of IDs of the teams responsible for this service's incident
+  response.
 
-- **href_url** (String, Required) The URL to use for the link.
-- **name** (String, Required) The name of the link.
+The `links` block supports:
 
-### Read-only
+* `href_url` - (Required) The URL to use for the link.
+* `name` - (Required) The name of the link.
 
-- **id** (String, Read-only) The ID of the service.
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the service.
+
+## Import
+
+Services can be imported; use `<SERVICE ID>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_service.test 3638b647-b99c-5051-b715-eda2c912c42e
+```

--- a/docs/resources/severity.md
+++ b/docs/resources/severity.md
@@ -1,25 +1,40 @@
 ---
-page_title: "firehydrant_severity Resource - terraform-provider-firehydrant"
+page_title: "FireHydrant Resource: firehydrant_severity"
 subcategory: ""
-description: |-
-  
 ---
 
-# Resource `firehydrant_severity`
+# firehydrant_severity Resource
 
+FireHydrant severities represent different levels of severity for incidents.
 
+## Example Usage
 
+Basic usage:
+```hcl
+resource "firehydrant_severity" "example-severity" {
+  slug        = "EXAMPLESEVERITY"
+  description = "This is an example severity"
+}
+```
 
+## Argument Reference
 
-## Schema
+The following arguments are supported:
 
-### Required
+* `slug` - (Required) The slug representing the priority. It must be unique and only contain 
+  alphanumeric characters. The slug cannot be longer than 23 characters.
+* `description` - (Optional) A description for the severity.
 
-- **slug** (String, Required)
+## Attributes Reference
 
-### Optional
+In addition to all arguments above, the following attributes are exported:
 
-- **description** (String, Optional)
-- **id** (String, Optional) The ID of this resource.
+* `id` - The ID of the severity.
 
+## Import
 
+Severities can be imported; use `<SEVERITY ID>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_severity.test 3638b647-b99c-5051-b715-eda2c912c42e
+```

--- a/docs/resources/severity.md
+++ b/docs/resources/severity.md
@@ -1,6 +1,6 @@
 ---
 page_title: "FireHydrant Resource: firehydrant_severity"
-subcategory: ""
+subcategory: "Beta"
 ---
 
 # firehydrant_severity Resource

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -1,33 +1,40 @@
 ---
-page_title: "firehydrant_team Resource - terraform-provider-firehydrant"
+page_title: "FireHydrant Resource: firehydrant_team"
 subcategory: ""
-description: |-
-  
 ---
 
-# Resource `firehydrant_team`
+# firehydrant_team Resource
+
+FireHydrant teams are collections of people that can be assigned to incidents 
+and configured as owners of various resources, like services and runbooks.
 
 ## Example Usage
 
 Basic usage:
-
 ```hcl
 resource "firehydrant_team" "example-team" {
-  name        = "my-example-team"
+  name        = "example-team"
   description = "This is an example team"
 }
 ```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **name** (String, Required) The name of the team.
+* `name` - (Required) The name of the team.
+* `description` - (Optional) A description for the team.
 
-### Optional
+## Attributes Reference
 
-- **description** (String, Optional) A description for the team.
+In addition to all arguments above, the following attributes are exported:
 
-### Read-only
+* `id` - The ID of the team.
 
-- **id** (String, Read-only) The ID of the team.
+## Import
+
+Teams can be imported; use `<TEAM ID>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_team.test 3638b647-b99c-5051-b715-eda2c912c42e
+```


### PR DESCRIPTION
## Description

This PR refactors our documentation to match the [format outlined in HashiCorp's documentation](https://www.terraform.io/registry/providers/docs#format). It also moves all resources which haven't been refactored and tested to a "Beta" category in the docs. 

Fixes #34
Fixes #42 
Fixes #61 

## Testing plan

1. Read through the docs and make sure things make sense, have not typos, etc.
1. Run the markdown through the [doc preview tool](https://registry.terraform.io/tools/doc-preview) and make sure things look good. 
1. Test the examples in the docs if you can.

## Related links

- [HashiCorp's documentation](https://www.terraform.io/registry/providers/docs#format)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.