### PR TITLE
r/priority & d/priority cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.0 (Unreleased)
+
+ENHANCEMENTS:
+
+* **New Resource:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
+* **New Data Source:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
+
 ## 0.2.1
 
 ENHANCEMENTS:
@@ -39,7 +46,6 @@ ENHANCEMENTS:
 * data_source/services: Added the `owner_id` attribute to services ([#23](https://github.com/firehydrant/terraform-provider-firehydrant/pull/23))
 * data_source/services: Added the `team_ids` attribute to services ([#54](https://github.com/firehydrant/terraform-provider-firehydrant/pull/54))
 * data_source/services: Added the `links` and `labels` attributes to services ([#30](https://github.com/firehydrant/terraform-provider-firehydrant/pull/30))
-
 
 NOTES:
 

--- a/docs/data-sources/priority.md
+++ b/docs/data-sources/priority.md
@@ -1,0 +1,32 @@
+---
+page_title: "FireHydrant Data Source: firehydrant_priority"
+---
+
+# firehydrant_priority Data Source
+
+Use this data source to get information on priorities.
+
+FireHydrant priorities define when an incident should be addressed.
+
+## Example Usage
+
+Basic usage:
+```hcl
+data "firehydrant_priority" "example-priority" {
+  slug = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `slug` - (Required) The slug representing the priority.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the priority. This is the same as the slug.
+* `default` - Indicates whether the priority should be the default priority for incidents.
+* `description` - A description of the priority.

--- a/docs/resources/priority.md
+++ b/docs/resources/priority.md
@@ -1,16 +1,14 @@
 ---
-page_title: "firehydrant_priority Resource - terraform-provider-firehydrant"
-subcategory: ""
-description: |-
-
+page_title: "FireHydrant Resource: firehydrant_priority"
 ---
 
-# Resource `firehydrant_priority`
+# firehydrant_priority Resource
+
+FireHydrant priorities define when an incident should be addressed.
 
 ## Example Usage
 
 Basic usage:
-
 ```hcl
 resource "firehydrant_priority" "example-priority" {
   slug        = "MYEXAMPLEPRIORITY"
@@ -19,18 +17,28 @@ resource "firehydrant_priority" "example-priority" {
 }
 ```
 
-## Schema
+## Argument Reference
 
-### Required
+The following arguments are supported:
 
-- **slug** (String, Required) The slug representing the priority. It must be unique and only contain alphanumeric characters. The slug cannot be longer than 23 characters.
+* `slug` - (Required) The slug representing the priority. It must be unique and only contain
+  alphanumeric characters. The slug cannot be longer than 23 characters.
+* `default` - (Optional) Indicates whether the priority should be the default priority for incidents. 
+  At most one resource can have default set to `true`. Setting default to `true` for multiple priority 
+  resources will result in inconsistent plans in Terraform. Defaults to `false`.
+* `description` - (Optional) A description for the priority.
 
-### Optional
+## Attributes Reference
 
-- **default** (Boolean, Optional) Indicates whether the priority should be the default 
-  priority for incidents. At most one resource can have default set to `true`. Setting default to `true` for multiple priority resources will result in inconsistent plans in Terraform. Defaults to `false`.
-- **description** (String, Optional) A description for the priority.
+In addition to all arguments above, the following attributes are exported:
 
-### Read-only
+* `id` - The ID of the priority. This is the same as the slug.
 
-- **id** (String, Read-only) The ID of the priority. This is the same as the slug.
+## Import
+
+Priorities can be imported; use `<PRIORITY SLUG>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_priority.test P1
+```
+

--- a/docs/resources/severity.md
+++ b/docs/resources/severity.md
@@ -21,7 +21,7 @@ resource "firehydrant_severity" "example-severity" {
 
 The following arguments are supported:
 
-* `slug` - (Required) The slug representing the priority. It must be unique and only contain 
+* `slug` - (Required) The slug representing the severity. It must be unique and only contain 
   alphanumeric characters. The slug cannot be longer than 23 characters.
 * `description` - (Optional) A description for the severity.
 

--- a/provider/priority_resource.go
+++ b/provider/priority_resource.go
@@ -41,7 +41,7 @@ func resourcePriority() *schema.Resource {
 					),
 				),
 			},
-			
+
 			// Optional
 			"default": {
 				Type:     schema.TypeBool,
@@ -144,7 +144,6 @@ func deleteResourceFireHydrantPriority(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		_, isNotFoundError := err.(firehydrant.NotFound)
 		if isNotFoundError {
-			d.SetId("")
 			return nil
 		}
 		return diag.FromErr(err)


### PR DESCRIPTION
## Description

This PR takes care of a few loose ends for the new priority resource and data source. It refactors the documentation to match the new format and adds an entry to the changelog for it. It also fixes a small typo in the severity documentation.

## Testing plan

1. Read through the docs and make sure things make sense, have not typos, etc.
1. Run the markdown through the [doc preview tool](https://registry.terraform.io/tools/doc-preview) and make sure things look good. 
1. Test the examples in the docs if you can.

Running the examples will require you to use a local build of the provider from this branch. You can do that by following these instructions:

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  Save the following as `main.tf` in your new directory
   ```hcl
   terraform {
     required_providers {
       firehydrant = {
         source  = "firehydrant/firehydrant"
         version = "~> 0.2.1"
       }
     }
   }
   
   provider "firehydrant" {
     firehydrant_base_url = "https://api.firehydrant.io/v1/"
   }
   
   resource "firehydrant_priority" "example-priority" {
     slug        = "MYEXAMPLEPRIORITY"
     description = "This is an example priority"
     default     = true
   }
   
   data "firehydrant_priority" "P1" {
     slug = "P1"
   }
   ```
1. Run `terraform init`.
1. Now you can run various Terraform commands and test things out. 


## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/b401e869bcf6b-create-priority)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.