### PR TITLE
Add logging and more detailed error messages to d/runbook_action, d/runbook, and r/runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 ## 0.3.0 (Unreleased)
 
-ENHANCEMENTS:
+FEATURES:
 
 * **New Resource:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
 * **New Data Source:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
-* data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
+
+ENHANCEMENTS:
+
+* resource/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * resource/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
+* data_source/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
+* data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
+* data_source/runbook_action: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 
 ## 0.2.1
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/go-hclog v1.0.0 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/hcl/v2 v2.11.1 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.2.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210816115301-cb2034eba045 // indirect
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 // indirect

--- a/provider/runbook_action_data.go
+++ b/provider/runbook_action_data.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -48,9 +50,14 @@ func dataFireHydrantRunbookAction(ctx context.Context, d *schema.ResourceData, m
 	runbookType := d.Get("type").(string)
 	actionSlug := d.Get("slug").(string)
 	integrationSlug := d.Get("integration_slug").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Read runbook action: %s:%s", integrationSlug, actionSlug), map[string]interface{}{
+		"type":             runbookType,
+		"slug":             actionSlug,
+		"integration_slug": integrationSlug,
+	})
 	runbookActionResponse, err := firehydrantAPIClient.RunbookActions().Get(ctx, runbookType, integrationSlug, actionSlug)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("Error reading runbook action %s:%s: %v", integrationSlug, actionSlug, err)
 	}
 
 	// Update the attributes in state to the values we got from the API
@@ -65,7 +72,7 @@ func dataFireHydrantRunbookAction(ctx context.Context, d *schema.ResourceData, m
 
 	for key, value := range attributes {
 		if err := d.Set(key, value); err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("Error setting %s for runbook action %s:%s: %v", key, integrationSlug, actionSlug, err)
 		}
 	}
 

--- a/provider/runbook_data.go
+++ b/provider/runbook_data.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -43,9 +45,12 @@ func dataFireHydrantRunbook(ctx context.Context, d *schema.ResourceData, m inter
 
 	// Get the runbook
 	runbookID := d.Get("id").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Read runbook: %s", runbookID), map[string]interface{}{
+		"id": runbookID,
+	})
 	runbookResponse, err := firehydrantAPIClient.Runbooks().Get(ctx, runbookID)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("Error reading runbook %s: %v", runbookID, err)
 	}
 
 	// Gather values from API response
@@ -61,7 +66,7 @@ func dataFireHydrantRunbook(ctx context.Context, d *schema.ResourceData, m inter
 	// Set the data source attributes to the values we got from the API
 	for key, value := range attributes {
 		if err := d.Set(key, value); err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("Error setting %s for runbook %s: %v", key, runbookID, err)
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR adds logging and more detailed error messages to d/runbook_action, d/runbook, and r/runbook. This follows the format [documented here](https://www.terraform.io/plugin/log/writing). This should not change the overall behavior of these resources and data sources.

### Log output

```
...
2022-07-06T15:02:27.269-0500 [DEBUG] provider.terraform-provider-firehydrant: Read runbook: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx: EXTRA_VALUE_AT_END=map[id:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx] tf_data_source_type=firehydrant_runbook tf_req_id=ebf02254-60c1-f49a-65f4-88d89a7d0854 @caller=/Users/lafentres/Code/go/src/github.com/firehydrant/terraform-provider-firehydrant/provider/runbook_data.go:44 @module=provider tf_provider_addr=provider tf_rpc=ReadDataSource timestamp=2022-07-06T15:02:27.269-0500
2022-07-06T15:02:27.269-0500 [DEBUG] provider.terraform-provider-firehydrant: Read runbook action: patchy:email_notification: @caller=/Users/lafentres/Code/go/src/github.com/firehydrant/terraform-provider-firehydrant/provider/runbook_action_data.go:53 @module=provider tf_provider_addr=provider tf_req_id=26160fd2-bdd3-12f4-bca9-9c14783a2896 tf_rpc=ReadDataSource EXTRA_VALUE_AT_END="map[integration_slug:patchy slug:email_notification type:incident]" tf_data_source_type=firehydrant_runbook_action timestamp=2022-07-06T15:02:27.269-0500
...
2022-07-06T15:03:06.001-0500 [DEBUG] provider.terraform-provider-firehydrant: Create runbook: my-runbook1: @caller=/Users/lafentres/Code/go/src/github.com/firehydrant/terraform-provider-firehydrant/provider/runbook_resource.go:198 tf_resource_type=firehydrant_runbook tf_rpc=ApplyResourceChange EXTRA_VALUE_AT_END=map[name:my-runbook1] tf_provider_addr=provider tf_req_id=dc3ae9d6-3164-3509-38ce-e56ee1feb754 @module=provider timestamp=2022-07-06T15:03:06.001-0500
2022-07-06T15:03:06.927-0500 [DEBUG] provider.terraform-provider-firehydrant: Read runbook: yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy: tf_req_id=dc3ae9d6-3164-3509-38ce-e56ee1feb754 @caller=/Users/lafentres/Code/go/src/github.com/firehydrant/terraform-provider-firehydrant/provider/runbook_resource.go:106 @module=provider tf_resource_type=firehydrant_runbook tf_rpc=ApplyResourceChange EXTRA_VALUE_AT_END=map[id:yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy] tf_provider_addr=provider timestamp=2022-07-06T15:03:06.927-0500
firehydrant_runbook.runbook1: Creation complete after 1s [id=yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy]
```

## Testing plan

Look at the new log output and see if it makes sense, has any typos, etc. [Documentation on managing log output and the various levels available are here](https://www.terraform.io/plugin/log/managing). TF_LOG_PROVIDER_FIREHYDRANT is not available at this time because we haven't implemented it but TF_LOG and TF_LOG_PROVIDER should work. Feel free to try different log levels if you'd like. 

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9022137/terraform-runbook-refactor-config.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a runbook (use the auto add services step). Then take the id of your runbook and replace the placeholder in the config with it. Make sure you replace the email field in the runbook1 resource with your email as well.  

#### Make sure things still work and logs makes sense for the happy path:
1. Run `TF_LOG_PROVIDER=DEBUG terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `TF_LOG_PROVIDER=DEBUG terraform plan`. There should be no changes.
1. Run `TF_LOG_PROVIDER=DEBUG terraform destroy`. This should succeed. 

#### Try to create some errors to see if the logs make sense
1. Update your config to try and create an error. This could be something like providing an invalid attribute in your data sources and resources, removing the steps attribute from your runbook resource, etc. 
1. Run `TF_LOG_PROVIDER=DEBUG terraform apply` and check out the logs you get.
1. Repeat but with different invalid attributes. 

## Related links

- [Writing logs](https://www.terraform.io/plugin/log/writing)
- [Managing logs](https://www.terraform.io/plugin/log/managing)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.