### PR TITLE
Add support for owner_id for runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ ENHANCEMENTS:
 
 * **New Resource:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
 * **New Data Source:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
+* data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
+* resource/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 
 ## 0.2.1
 

--- a/docs/data-sources/runbook.md
+++ b/docs/data-sources/runbook.md
@@ -35,4 +35,5 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the runbook.
 * `description` - A description of the runbook.
+* `owner_id` - The ID of the team that owns this runbook.
 * `name` - The name of the runbook.

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -16,6 +16,11 @@ for mitigating incidents.
 
 Basic usage:
 ```hcl
+resource "firehydrant_team" "example-owner-team" {
+  name        = "my-example-owner-team"
+  description = "This is an example team that owns a service"
+}
+
 data "firehydrant_runbook_action" "notify-channel-action" {
   slug             = "notify_channel"
   integration_slug = "slack"
@@ -26,6 +31,7 @@ resource "firehydrant_runbook" "example-runbook" {
   name        = "example-runbook"
   type        = "incident"
   description = "This is an example runbook"
+  owner_id    = firehydrant_team.example-owner-team.id
   
   steps {
     name    = "Notify Channel"

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -45,6 +45,7 @@ The following arguments are supported:
 * `type` - (Required) The type of the runbook. Valid values are 
   `incident`, `general`, `infrastructure`, and `incident_role`.
 * `description` - (Optional) A description of the runbook.
+* `owner_id` - (Optional) The ID of the team that owns this runbook.
 * `severities` - (Optional) Severities to associate with the runbook.
 * `steps` - (Optional) Steps to add to the runbook.
 

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -18,7 +18,7 @@ Basic usage:
 ```hcl
 resource "firehydrant_team" "example-owner-team" {
   name        = "my-example-owner-team"
-  description = "This is an example team that owns a service"
+  description = "This is an example team that owns a runbook"
 }
 
 data "firehydrant_runbook_action" "notify-channel-action" {

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -112,19 +112,6 @@ func (c *RESTRunbooksClient) Create(ctx context.Context, createReq CreateRunbook
 		return nil, err
 	}
 
-	runbookResponse, err = c.Update(ctx, runbookResponse.ID, UpdateRunbookRequest{
-		Steps:      createReq.Steps,
-		Severities: createReq.Severities,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "could not update created runbook")
-	}
-
-	err = checkResponseStatusCode(response)
-	if err != nil {
-		return nil, err
-	}
-
 	return runbookResponse, nil
 }
 

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -11,9 +11,10 @@ import (
 // CreateRunbookRequest is the payload for creating a service
 // URL: POST https://api.firehydrant.io/v1/runbooks
 type CreateRunbookRequest struct {
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Description string `json:"description"`
+	Name        string       `json:"name"`
+	Type        string       `json:"type"`
+	Description string       `json:"description"`
+	Owner       *RunbookTeam `json:"owner,omitempty"`
 
 	Severities []RunbookRelation `json:"severities"`
 
@@ -42,6 +43,7 @@ type RunbookStep struct {
 type UpdateRunbookRequest struct {
 	Name        string            `json:"name,omitempty"`
 	Description string            `json:"description,omitempty"`
+	Owner       *RunbookTeam      `json:"owner,omitempty"`
 	Steps       []RunbookStep     `json:"steps,omitempty"`
 	Severities  []RunbookRelation `json:"severities"`
 }
@@ -53,6 +55,7 @@ type RunbookResponse struct {
 	Name        string        `json:"name"`
 	Type        string        `json:"type"`
 	Description string        `json:"description"`
+	Owner       *RunbookTeam  `json:"owner"`
 	Steps       []RunbookStep `json:"steps"`
 
 	Severities []RunbookRelation `json:"severities"`

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -37,6 +37,17 @@ type CreateServiceRequest struct {
 	Teams       []ServiceTeam     `json:"teams,omitempty"`
 }
 
+// RunbookTeam represents a team when creating a runbook
+type RunbookTeam struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 // ServiceTeam represents a team when creating a service
 type ServiceTeam struct {
 	ID          string `json:"id"`

--- a/provider/runbook_data.go
+++ b/provider/runbook_data.go
@@ -29,6 +29,10 @@ func dataSourceRunbook() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -48,6 +52,10 @@ func dataFireHydrantRunbook(ctx context.Context, d *schema.ResourceData, m inter
 	attributes := map[string]interface{}{
 		"description": runbookResponse.Description,
 		"name":        runbookResponse.Name,
+	}
+
+	if runbookResponse.Owner != nil {
+		attributes["owner_id"] = runbookResponse.Owner.ID
 	}
 
 	// Set the data source attributes to the values we got from the API

--- a/provider/runbook_data_test.go
+++ b/provider/runbook_data_test.go
@@ -78,7 +78,7 @@ data "firehydrant_runbook" "test_runbook" {
 func testAccRunbookDataSourceConfig_allAttributes(rName string) string {
 	return fmt.Sprintf(`
 resource "firehydrant_team" "test_team1" {
-	name = "test-team1-%s"
+  name = "test-team1-%s"
 }
 
 data "firehydrant_runbook_action" "create_incident_channel" {

--- a/provider/runbook_data_test.go
+++ b/provider/runbook_data_test.go
@@ -91,7 +91,7 @@ resource "firehydrant_runbook" "test_runbook" {
   name        = "test-runbook-%s"
   type        = "incident"
   description = "test-description-%s"
-	owner_id = firehydrant_team.test_team1.id
+  owner_id    = firehydrant_team.test_team1.id
 
   steps {
     name      = "Create Incident Channel"

--- a/provider/runbook_data_test.go
+++ b/provider/runbook_data_test.go
@@ -42,6 +42,7 @@ func TestAccRunbookDataSource_allAttributes(t *testing.T) {
 						"data.firehydrant_runbook.test_runbook", "name", fmt.Sprintf("test-runbook-%s", rName)),
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_runbook.test_runbook", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttrSet("data.firehydrant_runbook.test_runbook", "owner_id"),
 				),
 			},
 		},
@@ -76,6 +77,10 @@ data "firehydrant_runbook" "test_runbook" {
 
 func testAccRunbookDataSourceConfig_allAttributes(rName string) string {
 	return fmt.Sprintf(`
+resource "firehydrant_team" "test_team1" {
+	name = "test-team1-%s"
+}
+
 data "firehydrant_runbook_action" "create_incident_channel" {
   slug             = "create_incident_channel"
   integration_slug = "slack"
@@ -86,6 +91,7 @@ resource "firehydrant_runbook" "test_runbook" {
   name        = "test-runbook-%s"
   type        = "incident"
   description = "test-description-%s"
+	owner_id = firehydrant_team.test_team1.id
 
   steps {
     name      = "Create Incident Channel"
@@ -98,5 +104,5 @@ resource "firehydrant_runbook" "test_runbook" {
 
 data "firehydrant_runbook" "test_runbook" {
   id = firehydrant_runbook.test_runbook.id
-}`, rName, rName)
+}`, rName, rName, rName)
 }

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -228,7 +228,6 @@ func updateResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceDat
 		updateRequest.Owner = &firehydrant.RunbookTeam{ID: ownerID.(string)}
 	}
 
-	// Process any optional attributes and add to the update request if necessary
 	steps := d.Get("steps").([]interface{})
 	for _, currentStep := range steps {
 		step := currentStep.(map[string]interface{})

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -173,11 +173,11 @@ func createResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceDat
 		Type:        d.Get("type").(string),
 	}
 
+	// Process any optional attributes and add to the create request if necessary
 	if ownerID, ok := d.GetOk("owner_id"); ok && ownerID.(string) != "" {
 		createRequest.Owner = &firehydrant.RunbookTeam{ID: ownerID.(string)}
 	}
 
-	// Process any optional attributes and add to the create request if necessary
 	steps := d.Get("steps").([]interface{})
 	for _, currentStep := range steps {
 		step := currentStep.(map[string]interface{})

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -330,7 +330,7 @@ resource "firehydrant_runbook" "test_runbook" {
   name        = "test-runbook-%s"
   type        = "incident"
   description = "test-description-%s"
-	owner_id     = firehydrant_team.test_team1.id
+  owner_id    = firehydrant_team.test_team1.id
 
   steps {
     name    = "Notify Channel"

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -181,6 +181,10 @@ func testAccCheckRunbookResourceExistsWithAttributes_basic(resourceName string) 
 			return fmt.Errorf("Unexpected description. Expected no description, got: %s", runbookResponse.Description)
 		}
 
+		if runbookResponse.Owner != nil {
+			return fmt.Errorf("Unexpected owner. Expected no owner ID, got: %s", runbookResponse.Owner.ID)
+		}
+
 		if len(runbookResponse.Steps) != 1 {
 			return fmt.Errorf("Unexpected number of steps. Expected 1 step, got: %v", len(runbookResponse.Steps))
 		}

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -78,6 +78,7 @@ func TestAccRunbookResource_update(t *testing.T) {
 						"firehydrant_runbook.test_runbook", "type", "incident"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
+					resource.TestCheckResourceAttrSet("firehydrant_runbook.test_runbook", "owner_id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -234,6 +235,14 @@ func testAccCheckRunbookResourceExistsWithAttributes_update(resourceName string)
 			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
 		}
 
+		if runbookResponse.Owner == nil {
+			return fmt.Errorf("Unexpected owner. Expected owner to be set.")
+		}
+		expected, got = runbookResource.Primary.Attributes["owner_id"], runbookResponse.Owner.ID
+		if expected != got {
+			return fmt.Errorf("Unexpected owner ID. Expected:%s, got: %s", expected, got)
+		}
+
 		if len(runbookResponse.Steps) != 1 {
 			return fmt.Errorf("Unexpected number of steps. Expected 1 step, got: %v", len(runbookResponse.Steps))
 		}
@@ -281,6 +290,7 @@ func testAccCheckRunbookResourceDestroy() resource.TestCheckFunc {
 
 func testAccRunbookResourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
+
 data "firehydrant_runbook_action" "create_incident_channel" {
   slug             = "create_incident_channel"
   integration_slug = "slack"
@@ -303,6 +313,9 @@ resource "firehydrant_runbook" "test_runbook" {
 
 func testAccRunbookResourceConfig_update(rName string) string {
 	return fmt.Sprintf(`
+resource "firehydrant_team" "test_team1" {
+	name = "test-team1-%s"
+}
 data "firehydrant_runbook_action" "notify_channel" {
   slug             = "notify_channel"
   integration_slug = "slack"
@@ -313,6 +326,7 @@ resource "firehydrant_runbook" "test_runbook" {
   name        = "test-runbook-%s"
   type        = "incident"
   description = "test-description-%s"
+	owner_id     = firehydrant_team.test_team1.id
 
   steps {
     name    = "Notify Channel"
@@ -321,5 +335,5 @@ resource "firehydrant_runbook" "test_runbook" {
       "channels" = "#incidents"
     }
   }
-}`, rName, rName)
+}`, rName, rName, rName)
 }

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -318,7 +318,7 @@ resource "firehydrant_runbook" "test_runbook" {
 func testAccRunbookResourceConfig_update(rName string) string {
 	return fmt.Sprintf(`
 resource "firehydrant_team" "test_team1" {
-	name = "test-team1-%s"
+  name = "test-team1-%s"
 }
 data "firehydrant_runbook_action" "notify_channel" {
   slug             = "notify_channel"


### PR DESCRIPTION
## Description

_Describe why you're making this change._
This PR adds the owner_id value for runbooks resource and data source. In addition it removes some unnecessary complexity where we were updating a runbook after creation which caused issues with fields being removed. Now that the creation API for runbooks can all be done in a single request this was an unnecessary call.

- Adding/changing it in the API client + tests in the /firehydrant directory
- Adding/changing in the provider + tests in the /provider directory
- Adding/changing it in the documentation in the /docs directory
- Adding an entry to the changelog


## Testing plan

1. Read through the docs and make sure things make sense, have not typos, etc.
1. Run the markdown through the [doc preview tool](https://registry.terraform.io/tools/doc-preview) and make sure things look good. 
1. Test the examples in the docs if you can.

Running the examples will require you to use a local build of the provider from this branch. You can do that by following these instructions:

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  Save the following as `main.tf` in your new directory
   ```hcl
   terraform {
     required_providers {
       firehydrant = {
         source  = "firehydrant/firehydrant"
         version = "~> 0.2.1"
       }
     }
   }
   
   provider "firehydrant" {
     firehydrant_base_url = "https://api.firehydrant.io/v1/"
   }
   

  data "firehydrant_runbook" "runbook1" {
    id = "existing runbook with owner"
  }

  # Team
  resource "firehydrant_team" "test_team_owner" {
    name = "test-team-owner"
  }

  # Runbook
  resource "firehydrant_runbook" "runbook-owner-test" {
    name        = "runbook-owner-test"
    type        = "incident"
    description = "this is just an example"
    owner_id    = firehydrant_team.test_team_owner.id
    steps {
      action_id = data.firehydrant_runbook_action.firehydrant_email_notification.id
      automatic = true
      config = {
        email_address = "YOUR_EMAIL"
      }
      name    = "Send me an email"
      repeats = false
    }
  }

  # Runbook Actions
  data "firehydrant_runbook_action" "firehydrant_email_notification" {
    integration_slug = "patchy"
    slug             = "email_notification"
    type             = "incident"
  }

   ```
1. Run `terraform init`.
1. Now you can run various Terraform commands and test things out. 



## Related links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developers.firehydrant.io/docs/api/6d750fbd2d88c-create-a-runbook)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.