### PR TITLE
Add validation for runbook action slugs and integration slugs for d/runbook_action and r/runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ ENHANCEMENTS:
 * provider: Improved error messages by adding details from the API response ([#75](https://github.com/firehydrant/terraform-provider-firehydrant/pull/75))
 * resource/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * resource/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
+* resource/runbook: Added `action_slug` and `action_integration_slug` attributes to runbook `steps` attributes ([#77](https://github.com/firehydrant/terraform-provider-firehydrant/pull/77))
 * data_source/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
+* data_source/runbook: Added `action_slug` and `action_integration_slug` attributes to runbook `steps` attributes ([#77](https://github.com/firehydrant/terraform-provider-firehydrant/pull/77))
 * data_source/runbook_action: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
+* data_source/runbook_action: Added validation for `slug` and `integration_slug` attributes ([#77](https://github.com/firehydrant/terraform-provider-firehydrant/pull/77))
 
 ## 0.2.1
 

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -32,10 +32,13 @@ resource "firehydrant_runbook" "example-runbook" {
   type        = "incident"
   description = "This is an example runbook"
   owner_id    = firehydrant_team.example-owner-team.id
-  
+
   steps {
-    name    = "Notify Channel"
-    action_id = data.firehydrant_runbook_action.notify-channel-action.id
+    name                    = "Notify Channel"
+    action_id               = data.firehydrant_runbook_action.notify-channel-action.id
+    action_integration_slug = data.firehydrant_runbook_action.notify-channel-action.integration_slug
+    action_slug             = data.firehydrant_runbook_action.notify-channel-action.slug
+
     config = {
       "channels" = "#incidents"
     }
@@ -62,6 +65,8 @@ The `severities` block supports:
 The `steps` block supports:
 
 * `action_id` - (Required) The ID of the runbook action for the step.
+* `action_integration_slug` - (Required) The slug of the integration associated with the runbook action for the step.
+* `action_slug` - (Required) The slug of the runbook action for the step.
 * `name` - (Required) The name of the step.
 * `automatic` - (Optional) Whether this step should be automatically execute.
 * `config` - (Optional) Config block for the step.

--- a/examples/runbooks.tf
+++ b/examples/runbooks.tf
@@ -1,4 +1,3 @@
-
 data "firehydrant_runbook_action" "slack_channel" {
   integration_slug = "slack"
   slug             = "create_incident_channel"
@@ -10,11 +9,13 @@ data "firehydrant_runbook_action" "notify_channel" {
   slug             = "notify_channel"
   type             = "incident"
 }
+
 data "firehydrant_runbook_action" "notify_channel_custom" {
   integration_slug = "slack"
   slug             = "notify_incident_channel_custom_message"
   type             = "incident"
 }
+
 data "firehydrant_runbook_action" "create_incident_ticket" {
   integration_slug = "patchy"
   slug             = "create_incident_ticket"
@@ -33,24 +34,29 @@ data "firehydrant_runbook_action" "email_notification" {
   type             = "incident"
 }
 
-
-
 resource "firehydrant_runbook" "default" {
-  name = "Default Incident Process WOOHOO"
+  name = "Default Incident Process"
   type = "incident"
 
   steps {
-    action_id = data.firehydrant_runbook_action.slack_channel.id
-    automatic = true
+    action_id               = data.firehydrant_runbook_action.slack_channel.id
+    action_integration_slug = data.firehydrant_runbook_action.slack_channel.integration_slug
+    action_slug             = data.firehydrant_runbook_action.slack_channel.slug
+    name                    = "Create incident channel in Slack"
+
     config = {
       "channel_name_format" = "inc-{{ number }}"
     }
-    name    = "Create incident channel in Slack"
-    repeats = false
-  }
-  steps {
-    action_id = data.firehydrant_runbook_action.notify_channel_custom.id
     automatic = true
+    repeats   = false
+  }
+
+  steps {
+    action_id               = data.firehydrant_runbook_action.notify_channel_custom.id
+    action_integration_slug = data.firehydrant_runbook_action.notify_channel_custom.integration_slug
+    action_slug             = data.firehydrant_runbook_action.notify_channel_custom.slug
+    name                    = "Incident Preamble"
+
     config = {
       "message" = <<EOT
             Here's the documentation on successfully running an incident with FireHydrant's Slack bot: https://help.firehydrant.io/en/articles/3050697-incident-response-w-slack
@@ -58,41 +64,61 @@ resource "firehydrant_runbook" "default" {
             Don't worry all of your messages and actions here are tracked into your incident on the FireHydrant UI.
         EOT
     }
-    name    = "Incident Preamble"
-    repeats = false
-  }
-  steps {
-    action_id = data.firehydrant_runbook_action.email_notification.id
+
     automatic = true
+    repeats   = false
+  }
+
+  steps {
+    action_id               = data.firehydrant_runbook_action.email_notification.id
+    action_integration_slug = data.firehydrant_runbook_action.email_notification.integration_slug
+    action_slug             = data.firehydrant_runbook_action.email_notification.slug
+    name                    = "Email stakeholders"
+
     config = {
       "email_address" = "stakeholders@example.com"
       "subject"       = "{{ incident.severity }} - {{ incident.name }} incident has been started"
     }
-    name    = "Email stakeholders"
-    repeats = false
-  }
-  steps {
-    action_id = data.firehydrant_runbook_action.notify_channel.id
+
     automatic = true
+    repeats   = false
+  }
+
+  steps {
+    action_id               = data.firehydrant_runbook_action.notify_channel.id
+    action_integration_slug = data.firehydrant_runbook_action.notify_channel.integration_slug
+    action_slug             = data.firehydrant_runbook_action.notify_channel.slug
+    name                    = "Notify incidents channel that a new incident has been opened"
+
     config = {
       "channels" = "#fh-incidents"
     }
-    name    = "Notify incidents channel that a new incident has been opened"
-    repeats = false
-  }
-  steps {
-    action_id = data.firehydrant_runbook_action.create_incident_ticket.id
+
     automatic = true
+    repeats   = false
+  }
+
+  steps {
+    action_id               = data.firehydrant_runbook_action.create_incident_ticket.id
+    action_integration_slug = data.firehydrant_runbook_action.create_incident_ticket.integration_slug
+    action_slug             = data.firehydrant_runbook_action.create_incident_ticket.slug
+    name                    = "Create an incident ticket in Jira"
+
     config = {
       "ticket_description" = "{{ incident.description }}"
       "ticket_summary"     = "{{ incident.name }}"
     }
-    name    = "Create an incident ticket in Jira"
-    repeats = false
-  }
-  steps {
-    action_id = data.firehydrant_runbook_action.notify_channel_custom.id
+
     automatic = true
+    repeats   = false
+  }
+
+  steps {
+    action_id               = data.firehydrant_runbook_action.notify_channel_custom.id
+    action_integration_slug = data.firehydrant_runbook_action.notify_channel_custom.integration_slug
+    action_slug             = data.firehydrant_runbook_action.notify_channel_custom.slug
+    name                    = "Remind Slack channel to update stakeholders"
+
     config = {
       "message" = <<EOT
               Please check-in with your current status on this {{ incident.severity }} incident
@@ -102,14 +128,17 @@ resource "firehydrant_runbook" "default" {
               ```
           EOT
     }
-    name    = "Remind Slack channel to update stakeholders"
-    repeats = false
-  }
-  steps {
-    action_id = data.firehydrant_runbook_action.archive_channel.id
+
     automatic = true
-    config    = {}
-    name      = "Archive incident channel after retrospective completion"
     repeats   = false
+  }
+
+  steps {
+    action_id               = data.firehydrant_runbook_action.archive_channel.id
+    action_integration_slug = data.firehydrant_runbook_action.notify_channel_custom.integration_slug
+    action_slug             = data.firehydrant_runbook_action.notify_channel_custom.slug
+    name                    = "Archive incident channel after retrospective completion"
+    automatic               = true
+    repeats                 = false
   }
 }

--- a/firehydrant/runbook_actions.go
+++ b/firehydrant/runbook_actions.go
@@ -9,6 +9,66 @@ import (
 	"github.com/pkg/errors"
 )
 
+// RunbookActionIntegrationSlug represents the integration slug of the integration
+// associated with a runbook action
+type RunbookActionIntegrationSlug string
+
+// List of valid integration slugs
+const (
+	RunbookActionIntegrationSlugConfluenceCloud RunbookActionIntegrationSlug = "confluence_cloud"
+	RunbookActionIntegrationSlugFireHydrant     RunbookActionIntegrationSlug = "patchy"
+	RunbookActionIntegrationSlugFireHydrantNunc RunbookActionIntegrationSlug = "nunc"
+	RunbookActionIntegrationSlugGiphy           RunbookActionIntegrationSlug = "giphy"
+	RunbookActionIntegrationSlugGoogleDocs      RunbookActionIntegrationSlug = "google_docs"
+	RunbookActionIntegrationSlugGoogleMeet      RunbookActionIntegrationSlug = "google_meet"
+	RunbookActionIntegrationSlugJiraCloud       RunbookActionIntegrationSlug = "jira_cloud"
+	RunbookActionIntegrationSlugJiraServer      RunbookActionIntegrationSlug = "jira_server"
+	RunbookActionIntegrationSlugMicrosoftTeams  RunbookActionIntegrationSlug = "microsoft_teams"
+	RunbookActionIntegrationSlugOpsgenie        RunbookActionIntegrationSlug = "opsgenie"
+	RunbookActionIntegrationSlugPagerDuty       RunbookActionIntegrationSlug = "pager_duty"
+	RunbookActionIntegrationSlugShortcut        RunbookActionIntegrationSlug = "shortcut"
+	RunbookActionIntegrationSlugSlack           RunbookActionIntegrationSlug = "slack"
+	RunbookActionIntegrationSlugStatuspage      RunbookActionIntegrationSlug = "statuspage"
+	RunbookActionIntegrationSlugVictorOps       RunbookActionIntegrationSlug = "victorops"
+	RunbookActionIntegrationSlugWebex           RunbookActionIntegrationSlug = "webex"
+	RunbookActionIntegrationSlugZoom            RunbookActionIntegrationSlug = "zoom"
+)
+
+// RunbookActionSlug represents the runbook action's slug
+type RunbookActionSlug string
+
+// List of valid action slugs
+const (
+	RunbookActionSlugAddServicesRelatedToFunctionality  RunbookActionSlug = "add_services_related_to_functionality"
+	RunbookActionSlugAddTaskList                        RunbookActionSlug = "add_task_list"
+	RunbookActionSlugArchiveIncidentChannel             RunbookActionSlug = "archive_incident_channel"
+	RunbookActionSlugAssignARole                        RunbookActionSlug = "assign_a_role"
+	RunbookActionSlugAssignATeam                        RunbookActionSlug = "assign_a_team"
+	RunbookActionSlugAttachARunbook                     RunbookActionSlug = "attach_a_runbook"
+	RunbookActionSlugCreateGoogleMeetLink               RunbookActionSlug = "create_google_meet_link"
+	RunbookActionSlugCreateIncidentChannel              RunbookActionSlug = "create_incident_channel"
+	RunbookActionSlugCreateIncidentIssue                RunbookActionSlug = "create_incident_issue"
+	RunbookActionSlugCreateIncidentTicket               RunbookActionSlug = "create_incident_ticket"
+	RunbookActionSlugCreateMeeting                      RunbookActionSlug = "create_meeting"
+	RunbookActionSlugCreateNewOpsgenieIncident          RunbookActionSlug = "create_new_opsgenie_incident"
+	RunbookActionSlugCreateNewPagerDutyIncident         RunbookActionSlug = "create_new_pager_duty_incident"
+	RunbookActionSlugCreateNunc                         RunbookActionSlug = "create_nunc"
+	RunbookActionSlugCreateStatuspage                   RunbookActionSlug = "create_statuspage"
+	RunbookActionSlugEmailNotification                  RunbookActionSlug = "email_notification"
+	RunbookActionSlugExportRetrospective                RunbookActionSlug = "export_retrospective"
+	RunbookActionSlugFreeformText                       RunbookActionSlug = "freeform_text"
+	RunbookActionSlugIncidentChannelGif                 RunbookActionSlug = "incident_channel_gif"
+	RunbookActionSlugIncidentUpdate                     RunbookActionSlug = "incident_update"
+	RunbookActionSlugNotifyChannel                      RunbookActionSlug = "notify_channel"
+	RunbookActionSlugNotifyChannelCustomMessage         RunbookActionSlug = "notify_channel_custom_message"
+	RunbookActionSlugNotifyIncidentChannelCustomMessage RunbookActionSlug = "notify_incident_channel_custom_message"
+	RunbookActionSlugScript                             RunbookActionSlug = "script"
+	RunbookActionSlugSendWebhook                        RunbookActionSlug = "send_webhook"
+	RunbookActionSlugSetLinkedAlertsStatus              RunbookActionSlug = "set_linked_alerts_status"
+	RunbookActionSlugUpdateStatuspage                   RunbookActionSlug = "update_statuspage"
+	RunbookActionSlugVictorOpsCreateNewIncident         RunbookActionSlug = "victorops_create_new_incident"
+)
+
 type RunbookActionsResponse struct {
 	Actions []RunbookAction `json:"data"`
 }

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -29,6 +29,7 @@ type RunbookRelation struct {
 // RunbookStep is a step inside of a runbook that can automate something (like creating a incident slack channel)
 type RunbookStep struct {
 	Name            string            `json:"name"`
+	Action          *RunbookAction    `json:"action"`
 	ActionID        string            `json:"action_id"`
 	StepID          string            `json:"step_id,omitempty"`
 	Config          map[string]string `json:"config,omitempty"`

--- a/provider/runbook_action_data.go
+++ b/provider/runbook_action_data.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceRunbookAction() *schema.Resource {
@@ -19,10 +20,65 @@ func dataSourceRunbookAction() *schema.Resource {
 			"integration_slug": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(firehydrant.RunbookActionIntegrationSlugConfluenceCloud),
+						string(firehydrant.RunbookActionIntegrationSlugFireHydrant),
+						string(firehydrant.RunbookActionIntegrationSlugFireHydrantNunc),
+						string(firehydrant.RunbookActionIntegrationSlugGiphy),
+						string(firehydrant.RunbookActionIntegrationSlugGoogleDocs),
+						string(firehydrant.RunbookActionIntegrationSlugGoogleMeet),
+						string(firehydrant.RunbookActionIntegrationSlugJiraCloud),
+						string(firehydrant.RunbookActionIntegrationSlugJiraServer),
+						string(firehydrant.RunbookActionIntegrationSlugMicrosoftTeams),
+						string(firehydrant.RunbookActionIntegrationSlugOpsgenie),
+						string(firehydrant.RunbookActionIntegrationSlugPagerDuty),
+						string(firehydrant.RunbookActionIntegrationSlugShortcut),
+						string(firehydrant.RunbookActionIntegrationSlugSlack),
+						string(firehydrant.RunbookActionIntegrationSlugStatuspage),
+						string(firehydrant.RunbookActionIntegrationSlugVictorOps),
+						string(firehydrant.RunbookActionIntegrationSlugWebex),
+						string(firehydrant.RunbookActionIntegrationSlugZoom),
+					},
+					false,
+				),
 			},
 			"slug": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(firehydrant.RunbookActionSlugAddServicesRelatedToFunctionality),
+						string(firehydrant.RunbookActionSlugAddTaskList),
+						string(firehydrant.RunbookActionSlugArchiveIncidentChannel),
+						string(firehydrant.RunbookActionSlugAssignARole),
+						string(firehydrant.RunbookActionSlugAssignATeam),
+						string(firehydrant.RunbookActionSlugAttachARunbook),
+						string(firehydrant.RunbookActionSlugCreateGoogleMeetLink),
+						string(firehydrant.RunbookActionSlugCreateIncidentChannel),
+						string(firehydrant.RunbookActionSlugCreateIncidentIssue),
+						string(firehydrant.RunbookActionSlugCreateIncidentTicket),
+						string(firehydrant.RunbookActionSlugCreateMeeting),
+						string(firehydrant.RunbookActionSlugCreateNewOpsgenieIncident),
+						string(firehydrant.RunbookActionSlugCreateNewPagerDutyIncident),
+						string(firehydrant.RunbookActionSlugCreateNunc),
+						string(firehydrant.RunbookActionSlugCreateStatuspage),
+						string(firehydrant.RunbookActionSlugEmailNotification),
+						string(firehydrant.RunbookActionSlugExportRetrospective),
+						string(firehydrant.RunbookActionSlugFreeformText),
+						string(firehydrant.RunbookActionSlugIncidentChannelGif),
+						string(firehydrant.RunbookActionSlugIncidentUpdate),
+						string(firehydrant.RunbookActionSlugNotifyChannel),
+						string(firehydrant.RunbookActionSlugNotifyChannelCustomMessage),
+						string(firehydrant.RunbookActionSlugNotifyIncidentChannelCustomMessage),
+						string(firehydrant.RunbookActionSlugScript),
+						string(firehydrant.RunbookActionSlugSendWebhook),
+						string(firehydrant.RunbookActionSlugSetLinkedAlertsStatus),
+						string(firehydrant.RunbookActionSlugUpdateStatuspage),
+						string(firehydrant.RunbookActionSlugVictorOpsCreateNewIncident),
+					},
+					false,
+				),
 			},
 			"type": {
 				Type:     schema.TypeString,

--- a/provider/runbook_action_data_test.go
+++ b/provider/runbook_action_data_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -47,6 +48,32 @@ func TestAccRunbookActionDataSource_multipleActionsForSlug(t *testing.T) {
 	})
 }
 
+func TestAccRunbookActionDataSource_validateSchemaAttributesSlug(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRunbookActionDataSourceConfig_slugInvalid(),
+				ExpectError: regexp.MustCompile(`expected slug to be one of`),
+			},
+		},
+	})
+}
+
+func TestAccRunbookActionDataSource_validateSchemaAttributesIntegrationSlug(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRunbookActionDataSourceConfig_integrationSlugInvalid(),
+				ExpectError: regexp.MustCompile(`expected integration_slug to be one of`),
+			},
+		},
+	})
+}
+
 func testAccRunbookActionDataSourceConfig_basic() string {
 	return fmt.Sprintf(`
 data "firehydrant_runbook_action" "test_runbook_action" {
@@ -60,6 +87,24 @@ func testAccRunbookActionDataSourceConfig_multipleActionsForSlug() string {
 	return fmt.Sprintf(`
 data "firehydrant_runbook_action" "test_runbook_action" {
   integration_slug = "shortcut"
+  slug             = "create_incident_issue"
+  type             = "incident"
+}`)
+}
+
+func testAccRunbookActionDataSourceConfig_slugInvalid() string {
+	return fmt.Sprintf(`
+data "firehydrant_runbook_action" "test_runbook_action" {
+  integration_slug = "shortcut"
+  slug             = "slug_invalid"
+  type             = "incident"
+}`)
+}
+
+func testAccRunbookActionDataSourceConfig_integrationSlugInvalid() string {
+	return fmt.Sprintf(`
+data "firehydrant_runbook_action" "test_runbook_action" {
+  integration_slug = "integration_slug_invalid"
   slug             = "create_incident_issue"
   type             = "incident"
 }`)

--- a/provider/runbook_data_test.go
+++ b/provider/runbook_data_test.go
@@ -58,12 +58,15 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 }
 
 resource "firehydrant_runbook" "test_runbook" {
-  name        = "test-runbook-%s"
-  type        = "incident"
+  name = "test-runbook-%s"
+  type = "incident"
 
   steps {
-    name      = "Create Incident Channel"
-    action_id = data.firehydrant_runbook_action.create_incident_channel.id
+    name                    = "Create Incident Channel"
+    action_id               = data.firehydrant_runbook_action.create_incident_channel.id
+    action_integration_slug = data.firehydrant_runbook_action.create_incident_channel.integration_slug
+    action_slug             = data.firehydrant_runbook_action.create_incident_channel.slug
+
     config = {
       channel_name_format = "-inc-{{ number }}"
     }
@@ -94,8 +97,11 @@ resource "firehydrant_runbook" "test_runbook" {
   owner_id    = firehydrant_team.test_team1.id
 
   steps {
-    name      = "Create Incident Channel"
-    action_id = data.firehydrant_runbook_action.create_incident_channel.id
+    name                    = "Create Incident Channel"
+    action_id               = data.firehydrant_runbook_action.create_incident_channel.id
+    action_integration_slug = data.firehydrant_runbook_action.create_incident_channel.integration_slug
+    action_slug             = data.firehydrant_runbook_action.create_incident_channel.slug
+
     config = {
       channel_name_format = "-inc-{{ number }}"
     }

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceRunbook() *schema.Resource {
@@ -62,6 +63,69 @@ func resourceRunbook() *schema.Resource {
 						"action_id": {
 							Type:     schema.TypeString,
 							Required: true,
+						},
+						"action_slug": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(firehydrant.RunbookActionSlugAddServicesRelatedToFunctionality),
+									string(firehydrant.RunbookActionSlugAddTaskList),
+									string(firehydrant.RunbookActionSlugArchiveIncidentChannel),
+									string(firehydrant.RunbookActionSlugAssignARole),
+									string(firehydrant.RunbookActionSlugAssignATeam),
+									string(firehydrant.RunbookActionSlugAttachARunbook),
+									string(firehydrant.RunbookActionSlugCreateGoogleMeetLink),
+									string(firehydrant.RunbookActionSlugCreateIncidentChannel),
+									string(firehydrant.RunbookActionSlugCreateIncidentIssue),
+									string(firehydrant.RunbookActionSlugCreateIncidentTicket),
+									string(firehydrant.RunbookActionSlugCreateMeeting),
+									string(firehydrant.RunbookActionSlugCreateNewOpsgenieIncident),
+									string(firehydrant.RunbookActionSlugCreateNewPagerDutyIncident),
+									string(firehydrant.RunbookActionSlugCreateNunc),
+									string(firehydrant.RunbookActionSlugCreateStatuspage),
+									string(firehydrant.RunbookActionSlugEmailNotification),
+									string(firehydrant.RunbookActionSlugExportRetrospective),
+									string(firehydrant.RunbookActionSlugFreeformText),
+									string(firehydrant.RunbookActionSlugIncidentChannelGif),
+									string(firehydrant.RunbookActionSlugIncidentUpdate),
+									string(firehydrant.RunbookActionSlugNotifyChannel),
+									string(firehydrant.RunbookActionSlugNotifyChannelCustomMessage),
+									string(firehydrant.RunbookActionSlugNotifyIncidentChannelCustomMessage),
+									string(firehydrant.RunbookActionSlugScript),
+									string(firehydrant.RunbookActionSlugSendWebhook),
+									string(firehydrant.RunbookActionSlugSetLinkedAlertsStatus),
+									string(firehydrant.RunbookActionSlugUpdateStatuspage),
+									string(firehydrant.RunbookActionSlugVictorOpsCreateNewIncident),
+								},
+								false,
+							),
+						},
+						"action_integration_slug": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(firehydrant.RunbookActionIntegrationSlugConfluenceCloud),
+									string(firehydrant.RunbookActionIntegrationSlugFireHydrant),
+									string(firehydrant.RunbookActionIntegrationSlugFireHydrantNunc),
+									string(firehydrant.RunbookActionIntegrationSlugGiphy),
+									string(firehydrant.RunbookActionIntegrationSlugGoogleDocs),
+									string(firehydrant.RunbookActionIntegrationSlugGoogleMeet),
+									string(firehydrant.RunbookActionIntegrationSlugJiraCloud),
+									string(firehydrant.RunbookActionIntegrationSlugJiraServer),
+									string(firehydrant.RunbookActionIntegrationSlugMicrosoftTeams),
+									string(firehydrant.RunbookActionIntegrationSlugOpsgenie),
+									string(firehydrant.RunbookActionIntegrationSlugPagerDuty),
+									string(firehydrant.RunbookActionIntegrationSlugShortcut),
+									string(firehydrant.RunbookActionIntegrationSlugSlack),
+									string(firehydrant.RunbookActionIntegrationSlugStatuspage),
+									string(firehydrant.RunbookActionIntegrationSlugVictorOps),
+									string(firehydrant.RunbookActionIntegrationSlugWebex),
+									string(firehydrant.RunbookActionIntegrationSlugZoom),
+								},
+								false,
+							),
 						},
 						"name": {
 							Type:     schema.TypeString,
@@ -144,11 +208,13 @@ func readResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceData,
 		}
 
 		steps[index] = map[string]interface{}{
-			"step_id":   currentStep.StepID,
-			"name":      currentStep.Name,
-			"action_id": currentStep.ActionID,
-			"config":    stepConfig,
-			"automatic": currentStep.Automatic,
+			"step_id":                 currentStep.StepID,
+			"name":                    currentStep.Name,
+			"action_id":               currentStep.ActionID,
+			"action_integration_slug": currentStep.Action.Integration.Slug,
+			"action_slug":             currentStep.Action.Slug,
+			"config":                  stepConfig,
+			"automatic":               currentStep.Automatic,
 		}
 	}
 	attributes["steps"] = steps


### PR DESCRIPTION
## Description

This PR adds the required attributes `action_slug` and `action_integration_slug` to the `steps` attribute in r/runbook. This is information that we will need in order to validate configs for each available step, which will come in a later PR. It also adds validation to the `integration_slug` and `slug` attributes in d/runbook_action. 

## Testing plan

1. Double-check that the list of action slugs and integration slugs is complete and accurate. There are so, so many and I might have missed some.
1. Then test that the new attributes and validations work as expected, get updated when they should, etc. 

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     #dev_overrides {
     #  "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     #}

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9113103/terraform-runbook.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a runbook. Then take the id of your runbook and replace the placeholder in the config with it. Make sure you replace the email field in the runbook1 resource with your email as well.  
1. Run `terraform init`.

#### Provision resources and data sources:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.

#### Upgrade provider version to local build of this branch
1. Edit your ~/.terraformrc file and remove the comments in front of the dev_overrides block
   ```
   dev_overrides {
     "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
   }
   ```
1. Run `terraform plan`. You should see no changes. You should see some errors telling you about the new required attributes
   <img width="703" alt="Screen Shot 2022-07-14 at 10 07 37 AM" src="https://user-images.githubusercontent.com/12189856/179015117-fe87a22c-6102-4da7-9fb5-d86180936e17.png">
1. Add the new required attributes to your config and run `terraform plan` again. You should see no changes.
1. Run `terraform apply --refresh-only` so that action_slug and action_integration_slug get added to your statefile. 

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

#### Make sure a fresh create on this new version works
1. Run `terraform apply`. This should succeed. Your created resources should be reflected in your terraform.tfstate file and in the UI.
1. Run `terraform plan`. You should see no changes.

#### Make sure invalid slugs/integration_slugs don't work:
1. Update your config to have invalid slugs/integration_slugs/action_slugs/action_integration_slugs and run `terraform apply`. This should fail and should show error for the invalid slugs.
1. Change your config back.

#### Make sure updating things still works
1. Update your config by changing your runbook action id/slug/integration slug to the slack_archive_channel action, remove the config attribute, and run `terraform apply`. This should succeed. Your changes should be reflected in your terraform.tfstate file and in the UI.
1. Run `terraform plan`. You should see no changes.

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/427a691500647-retrieve-a-runbook)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.