### PR TITLE
Change r/runbook step config attribute type to a JSON string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.3.0 (Unreleased)
 
+BREAKING CHANGES:
+
+* resource/runbook: Changed the type of the `steps` `config` attribute to a JSON string ([#79](https://github.com/firehydrant/terraform-provider-firehydrant/pull/79))
+
 FEATURES:
 
 * **New Resource:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -32,15 +32,16 @@ resource "firehydrant_runbook" "example-runbook" {
   type        = "incident"
   description = "This is an example runbook"
   owner_id    = firehydrant_team.example-owner-team.id
-  
+
   steps {
     name             = "Notify Channel"
     action_id        = data.firehydrant_runbook_action.notify-channel-action.id
     repeats          = true
     repeats_duration = "PT15M"
-    config = {
-      "channels" = "#incidents"
-    }
+
+    config = jsonencode({
+      channels = "#incidents"
+    })
   }
 }
 ```
@@ -66,9 +67,12 @@ The `steps` block supports:
 * `action_id` - (Required) The ID of the runbook action for the step.
 * `name` - (Required) The name of the step.
 * `automatic` - (Optional) Whether this step should be automatically execute.
-* `config` - (Optional) Config block for the step.
+* `config` - (Optional) JSON string representing the configuration settings for the step. 
+  Use [Terraform's jsonencode](https://www.terraform.io/language/functions/jsonencode) 
+  function so that [Terraform can guarantee valid JSON syntax](https://www.terraform.io/language/expressions/strings#generating-json-or-yaml).
 * `repeats` - (Optional) Whether this step should repeat.
-* `repeats_duration` - (Optional) How often this step should repeat in ISO8601. Example: PT10M [Format Spec](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)
+* `repeats_duration` - (Optional) How often this step should repeat in ISO8601. 
+  Example: PT10M [Format Spec](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)
 
 ## Attributes Reference
 

--- a/examples/runbooks.tf
+++ b/examples/runbooks.tf
@@ -1,4 +1,3 @@
-
 data "firehydrant_runbook_action" "slack_channel" {
   integration_slug = "slack"
   slug             = "create_incident_channel"
@@ -10,11 +9,13 @@ data "firehydrant_runbook_action" "notify_channel" {
   slug             = "notify_channel"
   type             = "incident"
 }
+
 data "firehydrant_runbook_action" "notify_channel_custom" {
   integration_slug = "slack"
   slug             = "notify_incident_channel_custom_message"
   type             = "incident"
 }
+
 data "firehydrant_runbook_action" "create_incident_ticket" {
   integration_slug = "patchy"
   slug             = "create_incident_ticket"
@@ -33,83 +34,94 @@ data "firehydrant_runbook_action" "email_notification" {
   type             = "incident"
 }
 
-
-
 resource "firehydrant_runbook" "default" {
-  name = "Default Incident Process WOOHOO"
+  name = "Default Incident Process"
   type = "incident"
 
   steps {
     action_id = data.firehydrant_runbook_action.slack_channel.id
+    name      = "Create incident channel in Slack"
+
+    config = jsonencode({
+      channel_name_format = "inc-{{ number }}"
+    })
+
     automatic = true
-    config = {
-      "channel_name_format" = "inc-{{ number }}"
-    }
-    name    = "Create incident channel in Slack"
-    repeats = false
+    repeats   = false
   }
+
   steps {
     action_id = data.firehydrant_runbook_action.notify_channel_custom.id
-    automatic = true
-    config = {
-      "message" = <<EOT
-            Here's the documentation on successfully running an incident with FireHydrant's Slack bot: https://help.firehydrant.io/en/articles/3050697-incident-response-w-slack
+    name      = "Incident Preamble"
 
-            Don't worry all of your messages and actions here are tracked into your incident on the FireHydrant UI.
-        EOT
-    }
-    name    = "Incident Preamble"
-    repeats = false
+    config = jsonencode({
+      message = "Here's the documentation on successfully running an incident with FireHydrant's Slack bot: https://help.firehydrant.io/en/articles/3050697-incident-response-w-slack\n\nDon't worry all of your messages and actions here are tracked into your incident on the FireHydrant UI."
+    })
+
+    automatic = true
+    repeats   = false
   }
+
   steps {
     action_id = data.firehydrant_runbook_action.email_notification.id
+    name      = "Email stakeholders"
+
+    config = jsonencode({
+      email_address = "stakeholders@example.com"
+      subject       = "{{ incident.severity }} - {{ incident.name }} incident has been started"
+    })
+
     automatic = true
-    config = {
-      "email_address" = "stakeholders@example.com"
-      "subject"       = "{{ incident.severity }} - {{ incident.name }} incident has been started"
-    }
-    name    = "Email stakeholders"
-    repeats = false
+    repeats   = false
   }
+
   steps {
     action_id = data.firehydrant_runbook_action.notify_channel.id
+    name      = "Notify incidents channel that a new incident has been opened"
+
+    config = jsonencode({
+      channels = "#fh-incidents"
+    })
+
     automatic = true
-    config = {
-      "channels" = "#fh-incidents"
-    }
-    name    = "Notify incidents channel that a new incident has been opened"
-    repeats = false
+    repeats   = false
   }
+
   steps {
     action_id = data.firehydrant_runbook_action.create_incident_ticket.id
+    name      = "Create an incident ticket in Jira"
+
+    config = jsonencode({
+      ticket_description = "{{ incident.description }}"
+      ticket_summary     = "{{ incident.name }}"
+    })
+
     automatic = true
-    config = {
-      "ticket_description" = "{{ incident.description }}"
-      "ticket_summary"     = "{{ incident.name }}"
-    }
-    name    = "Create an incident ticket in Jira"
-    repeats = false
+    repeats   = false
   }
+
   steps {
     action_id = data.firehydrant_runbook_action.notify_channel_custom.id
-    automatic = true
-    config = {
-      "message" = <<EOT
+    name      = "Remind Slack channel to update stakeholders"
+
+    config = jsonencode({
+      message = <<EOT
               Please check-in with your current status on this {{ incident.severity }} incident
 
               ```
               /firehydrant add note I'm calculating the power required by the flux capacitor
               ```
           EOT
-    }
-    name    = "Remind Slack channel to update stakeholders"
-    repeats = false
+    })
+
+    automatic = true
+    repeats   = false
   }
+
   steps {
     action_id = data.firehydrant_runbook_action.archive_channel.id
-    automatic = true
-    config    = {}
     name      = "Archive incident channel after retrospective completion"
+    automatic = true
     repeats   = false
   }
 }

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -28,13 +28,13 @@ type RunbookRelation struct {
 
 // RunbookStep is a step inside of a runbook that can automate something (like creating a incident slack channel)
 type RunbookStep struct {
-	Name            string            `json:"name"`
-	ActionID        string            `json:"action_id"`
-	StepID          string            `json:"step_id,omitempty"`
-	Config          map[string]string `json:"config,omitempty"`
-	Automatic       bool              `json:"automatic,omitempty"`
-	Repeats         bool              `json:"repeats,omitempty"`
-	RepeatsDuration string            `json:"repeats_duration,omitempty"`
+	Name            string                 `json:"name"`
+	ActionID        string                 `json:"action_id"`
+	StepID          string                 `json:"step_id,omitempty"`
+	Config          map[string]interface{} `json:"config,omitempty"`
+	Automatic       bool                   `json:"automatic,omitempty"`
+	Repeats         bool                   `json:"repeats,omitempty"`
+	RepeatsDuration string                 `json:"repeats_duration,omitempty"`
 }
 
 // UpdateRunbookRequest is the payload for updating a service

--- a/provider/runbook_data_test.go
+++ b/provider/runbook_data_test.go
@@ -58,15 +58,16 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 }
 
 resource "firehydrant_runbook" "test_runbook" {
-  name        = "test-runbook-%s"
-  type        = "incident"
+  name = "test-runbook-%s"
+  type = "incident"
 
   steps {
     name      = "Create Incident Channel"
     action_id = data.firehydrant_runbook_action.create_incident_channel.id
-    config = {
+
+    config = jsonencode({
       channel_name_format = "-inc-{{ number }}"
-    }
+    })
   }
 }
 
@@ -96,9 +97,10 @@ resource "firehydrant_runbook" "test_runbook" {
   steps {
     name      = "Create Incident Channel"
     action_id = data.firehydrant_runbook_action.create_incident_channel.id
-    config = {
+
+    config = jsonencode({
       channel_name_format = "-inc-{{ number }}"
-    }
+    })
   }
 }
 


### PR DESCRIPTION
## Description

This PR changes the type of the steps config attribute to a JSON string to fix various error preventing some runbook steps from being imported or created successfully.

All valid options for the steps config attribute will be documented in a separate PR.

## Testing plan

The goal of this test plan is to check that that the updates and new validations work as expected, get updated when they should, etc. 

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9135473/terraform-runbook-steps-config.txt)as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a runbook. Then take the id of your runbook and replace the placeholder in the config with it. 
1. Run `terraform init`.

#### Provision resources and data sources:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.

#### Make sure updating things still works
1. Update your config by changing something in a step config. Try removing steps, updating fields, etc.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

#### Make sure importing works:
Previously importing didn't work consistently, especially with our runbook templates.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Create a new runbook using out started template. Copy the ID
1. In your main.tf file, uncomment the imported_runbook resource
1. Run `terraform import firehydrant_runbook.imported_runbook YOUR_RUNBOOK_ID`. This should succeed and you should see accurate information in the statefile for this runbook.

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/6d750fbd2d88c-create-a-runbook)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.