### PR TITLE
Miscellaneous runbook fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 BREAKING CHANGES:
 
 * resource/runbook: Changed the type of the `steps` `config` attribute to a JSON string ([#79](https://github.com/firehydrant/terraform-provider-firehydrant/pull/79))
+* resource/runbook: Removed deprecated `type` attribute ([#80](https://github.com/firehydrant/terraform-provider-firehydrant/pull/80))
+* resource/runbook: Removed deprecated `severities` attribute ([#80](https://github.com/firehydrant/terraform-provider-firehydrant/pull/80))
+* resource/runbook: Changed `steps` attribute to be required ([#80](https://github.com/firehydrant/terraform-provider-firehydrant/pull/80))
+
+BUG FIXES:
+
+* resource/runbook: Fixed bug that prevented the `description` attribute from being unset ([#80](https://github.com/firehydrant/terraform-provider-firehydrant/pull/80))
 
 FEATURES:
 

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -55,12 +55,7 @@ The following arguments are supported:
   `incident`, `general`, `infrastructure`, and `incident_role`.
 * `description` - (Optional) A description of the runbook.
 * `owner_id` - (Optional) The ID of the team that owns this runbook.
-* `severities` - (Optional) Severities to associate with the runbook.
 * `steps` - (Optional) Steps to add to the runbook.
-
-The `severities` block supports:
-
-* `id` - (Required) The ID of the severity.
 
 The `steps` block supports:
 

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -50,9 +50,9 @@ resource "firehydrant_runbook" "example-runbook" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the runbook.
+* `steps` - (Required) Steps to add to the runbook.
 * `description` - (Optional) A description of the runbook.
 * `owner_id` - (Optional) The ID of the team that owns this runbook.
-* `steps` - (Optional) Steps to add to the runbook.
 
 The `steps` block supports:
 

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -29,7 +29,6 @@ data "firehydrant_runbook_action" "notify-channel-action" {
 
 resource "firehydrant_runbook" "example-runbook" {
   name        = "example-runbook"
-  type        = "incident"
   description = "This is an example runbook"
   owner_id    = firehydrant_team.example-owner-team.id
 
@@ -51,8 +50,6 @@ resource "firehydrant_runbook" "example-runbook" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the runbook.
-* `type` - (Required) The type of the runbook. Valid values are 
-  `incident`, `general`, `infrastructure`, and `incident_role`.
 * `description` - (Optional) A description of the runbook.
 * `owner_id` - (Optional) The ID of the team that owns this runbook.
 * `steps` - (Optional) Steps to add to the runbook.

--- a/examples/runbooks.tf
+++ b/examples/runbooks.tf
@@ -36,7 +36,6 @@ data "firehydrant_runbook_action" "email_notification" {
 
 resource "firehydrant_runbook" "default" {
   name = "Default Incident Process"
-  type = "incident"
 
   steps {
     action_id = data.firehydrant_runbook_action.slack_channel.id

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -8,15 +8,22 @@ import (
 	"github.com/pkg/errors"
 )
 
+// RunbookType represents the type of the runbook.
+type RunbookType string
+
+// List of valid runbook types
+const (
+	RunbookTypeDefault RunbookType = "incident"
+)
+
 // CreateRunbookRequest is the payload for creating a service
 // URL: POST https://api.firehydrant.io/v1/runbooks
 type CreateRunbookRequest struct {
-	Name        string       `json:"name"`
-	Type        string       `json:"type"`
-	Description string       `json:"description"`
-	Owner       *RunbookTeam `json:"owner,omitempty"`
-
-	Steps []RunbookStep `json:"steps,omitempty"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Owner       *RunbookTeam  `json:"owner,omitempty"`
+	Steps       []RunbookStep `json:"steps"`
+	Type        string        `json:"type"`
 }
 
 // RunbookStep is a step inside of a runbook that can automate something (like creating a incident slack channel)
@@ -44,7 +51,6 @@ type UpdateRunbookRequest struct {
 type RunbookResponse struct {
 	ID          string        `json:"id"`
 	Name        string        `json:"name"`
-	Type        string        `json:"type"`
 	Description string        `json:"description"`
 	Owner       *RunbookTeam  `json:"owner"`
 	Steps       []RunbookStep `json:"steps"`
@@ -91,6 +97,9 @@ func (c *RESTRunbooksClient) Get(ctx context.Context, id string) (*RunbookRespon
 
 // Create creates a brand spankin new runbook in FireHydrant
 func (c *RESTRunbooksClient) Create(ctx context.Context, createReq CreateRunbookRequest) (*RunbookResponse, error) {
+	// Set the default type of the runbook
+	createReq.Type = string(RunbookTypeDefault)
+
 	runbookResponse := &RunbookResponse{}
 	apiError := &APIError{}
 	response, err := c.restClient().Post("runbooks").BodyJSON(&createReq).Receive(runbookResponse, apiError)

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -16,14 +16,7 @@ type CreateRunbookRequest struct {
 	Description string       `json:"description"`
 	Owner       *RunbookTeam `json:"owner,omitempty"`
 
-	Severities []RunbookRelation `json:"severities"`
-
 	Steps []RunbookStep `json:"steps,omitempty"`
-}
-
-// RunbookRelation associates a runbook to a type in FireHydrant (such as a severity)
-type RunbookRelation struct {
-	ID string `json:"id"`
 }
 
 // RunbookStep is a step inside of a runbook that can automate something (like creating a incident slack channel)
@@ -40,11 +33,10 @@ type RunbookStep struct {
 // UpdateRunbookRequest is the payload for updating a service
 // URL: PATCH https://api.firehydrant.io/v1/runbooks/{id}
 type UpdateRunbookRequest struct {
-	Name        string            `json:"name,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Owner       *RunbookTeam      `json:"owner,omitempty"`
-	Steps       []RunbookStep     `json:"steps,omitempty"`
-	Severities  []RunbookRelation `json:"severities"`
+	Name        string        `json:"name,omitempty"`
+	Description string        `json:"description,omitempty"`
+	Owner       *RunbookTeam  `json:"owner,omitempty"`
+	Steps       []RunbookStep `json:"steps,omitempty"`
 }
 
 // RunbookResponse is the payload for retrieving a service
@@ -56,8 +48,6 @@ type RunbookResponse struct {
 	Description string        `json:"description"`
 	Owner       *RunbookTeam  `json:"owner"`
 	Steps       []RunbookStep `json:"steps"`
-
-	Severities []RunbookRelation `json:"severities"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -41,7 +41,7 @@ type RunbookStep struct {
 // URL: PATCH https://api.firehydrant.io/v1/runbooks/{id}
 type UpdateRunbookRequest struct {
 	Name        string        `json:"name,omitempty"`
-	Description string        `json:"description,omitempty"`
+	Description string        `json:"description"`
 	Owner       *RunbookTeam  `json:"owner,omitempty"`
 	Steps       []RunbookStep `json:"steps,omitempty"`
 }

--- a/provider/runbook_data_test.go
+++ b/provider/runbook_data_test.go
@@ -59,7 +59,6 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 
 resource "firehydrant_runbook" "test_runbook" {
   name = "test-runbook-%s"
-  type = "incident"
 
   steps {
     name      = "Create Incident Channel"
@@ -90,7 +89,6 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 
 resource "firehydrant_runbook" "test_runbook" {
   name        = "test-runbook-%s"
-  type        = "incident"
   description = "test-description-%s"
   owner_id    = firehydrant_team.test_team1.id
 

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -31,19 +31,9 @@ func resourceRunbook() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			// Optional
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"steps": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						// Required
@@ -95,6 +85,16 @@ func resourceRunbook() *schema.Resource {
 						},
 					},
 				},
+			},
+
+			// Optional
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -31,10 +31,6 @@ func resourceRunbook() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
 
 			// Optional
 			"description": {
@@ -129,7 +125,6 @@ func readResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceData,
 	attributes := map[string]interface{}{
 		"name":        runbookResponse.Name,
 		"description": runbookResponse.Description,
-		"type":        runbookResponse.Type,
 	}
 
 	var ownerID string
@@ -179,7 +174,6 @@ func createResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceDat
 	createRequest := firehydrant.CreateRunbookRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
-		Type:        d.Get("type").(string),
 	}
 
 	// Process any optional attributes and add to the create request if necessary

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -45,18 +45,6 @@ func resourceRunbook() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"severities": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
 			"steps": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -173,14 +161,6 @@ func readResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceData,
 	}
 	attributes["steps"] = steps
 
-	severities := make([]interface{}, len(runbookResponse.Severities))
-	for index, currentSeverity := range runbookResponse.Severities {
-		severities[index] = map[string]interface{}{
-			"id": currentSeverity.ID,
-		}
-	}
-	attributes["severities"] = severities
-
 	// Set the resource attributes to the values we got from the API
 	for key, value := range attributes {
 		if err := d.Set(key, value); err != nil {
@@ -234,15 +214,6 @@ func createResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceDat
 			Config:          configMap,
 			Repeats:         step["repeats"].(bool),
 			RepeatsDuration: step["repeats_duration"].(string),
-		})
-	}
-
-	severities := d.Get("severities").([]interface{})
-	for _, severity := range severities {
-		currentSeverity := severity.(map[string]interface{})
-
-		createRequest.Severities = append(createRequest.Severities, firehydrant.RunbookRelation{
-			ID: currentSeverity["id"].(string),
 		})
 	}
 
@@ -305,15 +276,6 @@ func updateResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceDat
 			Config:          configMap,
 			Repeats:         step["repeats"].(bool),
 			RepeatsDuration: step["repeats_duration"].(string),
-		})
-	}
-
-	severities := d.Get("severities").([]interface{})
-	for _, currentSeverity := range severities {
-		severity := currentSeverity.(map[string]interface{})
-
-		updateRequest.Severities = append(updateRequest.Severities, firehydrant.RunbookRelation{
-			ID: severity["id"].(string),
 		})
 	}
 

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -30,8 +30,6 @@ func TestAccRunbookResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "name", fmt.Sprintf("test-runbook-%s", rName)),
 					resource.TestCheckResourceAttr(
-						"firehydrant_runbook.test_runbook", "type", "incident"),
-					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.#", "1"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.0.name", "Create Incident Channel"),
@@ -62,8 +60,6 @@ func TestAccRunbookResource_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "name", fmt.Sprintf("test-runbook-%s", rName)),
 					resource.TestCheckResourceAttr(
-						"firehydrant_runbook.test_runbook", "type", "incident"),
-					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.#", "1"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.0.name", "Create Incident Channel"),
@@ -80,8 +76,6 @@ func TestAccRunbookResource_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_runbook.test_runbook", "id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "name", fmt.Sprintf("test-runbook-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_runbook.test_runbook", "type", "incident"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 					resource.TestCheckResourceAttrSet("firehydrant_runbook.test_runbook", "owner_id"),
@@ -105,8 +99,6 @@ func TestAccRunbookResource_update(t *testing.T) {
 			//		resource.TestCheckResourceAttrSet("firehydrant_runbook.test_runbook", "id"),
 			//		resource.TestCheckResourceAttr(
 			//			"firehydrant_runbook.test_runbook", "name", fmt.Sprintf("test-runbook-%s", rNameUpdated)),
-			//		resource.TestCheckResourceAttr(
-			//			"firehydrant_runbook.test_runbook", "type", "incident"),
 			//		resource.TestCheckResourceAttr(
 			//			"firehydrant_runbook.test_runbook", "steps.#", "1"),
 			//		resource.TestCheckResourceAttr(
@@ -231,11 +223,6 @@ func testAccCheckRunbookResourceExistsWithAttributes_basic(resourceName string) 
 			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
 		}
 
-		expected, got = runbookResource.Primary.Attributes["type"], fmt.Sprintf("%s", runbookResponse.Type)
-		if expected != got {
-			return fmt.Errorf("Unexpected type. Expected: %s, got: %s", expected, got)
-		}
-
 		if runbookResponse.Description != "" {
 			return fmt.Errorf("Unexpected description. Expected no description, got: %s", runbookResponse.Description)
 		}
@@ -305,11 +292,6 @@ func testAccCheckRunbookResourceExistsWithAttributes_update(resourceName string)
 		expected, got := runbookResource.Primary.Attributes["name"], runbookResponse.Name
 		if expected != got {
 			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
-		}
-
-		expected, got = runbookResource.Primary.Attributes["type"], fmt.Sprintf("%s", runbookResponse.Type)
-		if expected != got {
-			return fmt.Errorf("Unexpected type. Expected: %s, got: %s", expected, got)
 		}
 
 		expected, got = runbookResource.Primary.Attributes["description"], runbookResponse.Description
@@ -399,7 +381,6 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 
 resource "firehydrant_runbook" "test_runbook" {
   name = "test-runbook-%s"
-  type = "incident"
 
   steps {
     name      = "Create Incident Channel"
@@ -432,7 +413,6 @@ data "firehydrant_runbook_action" "archive_channel" {
 
 resource "firehydrant_runbook" "test_runbook" {
   name        = "test-runbook-%s"
-  type        = "incident"
   description = "test-description-%s"
   owner_id    = firehydrant_team.test_team1.id
 
@@ -464,7 +444,6 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 
 resource "firehydrant_runbook" "test_runbook" {
   name = "test-runbook-%s"
-  type = "incident"
 
   steps {
     name      = "Create Incident Channel"
@@ -488,7 +467,6 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 
 resource "firehydrant_runbook" "test_runbook" {
   name = "test-runbook-%s"
-  type = "incident"
 
   steps {
     name             = "Create Incident Channel"
@@ -512,7 +490,6 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 
 resource "firehydrant_runbook" "test_runbook" {
   name = "test-runbook-%s"
-  type = "incident"
 
   steps {
     name      = "Create Incident Channel"

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -91,26 +91,23 @@ func TestAccRunbookResource_update(t *testing.T) {
 						"firehydrant_runbook.test_runbook", "steps.0.action_id"),
 				),
 			},
-			// TODO: fix error causing description to not be removed on update and then add this step back in
-			//{
-			//	Config: testAccRunbookResourceConfig_basic(rNameUpdated),
-			//	Check: resource.ComposeAggregateTestCheckFunc(
-			//		testAccCheckRunbookResourceExistsWithAttributes_basic("firehydrant_runbook.test_runbook"),
-			//		resource.TestCheckResourceAttrSet("firehydrant_runbook.test_runbook", "id"),
-			//		resource.TestCheckResourceAttr(
-			//			"firehydrant_runbook.test_runbook", "name", fmt.Sprintf("test-runbook-%s", rNameUpdated)),
-			//		resource.TestCheckResourceAttr(
-			//			"firehydrant_runbook.test_runbook", "steps.#", "1"),
-			//		resource.TestCheckResourceAttr(
-			//			"firehydrant_runbook.test_runbook", "steps.0.name", "Create Incident Channel"),
-			//    resource.TestCheckResourceAttr(
-			// 	    "firehydrant_runbook.test_runbook", "steps.0.repeats", "true"),
-			//    resource.TestCheckResourceAttr(
-			// 	    "firehydrant_runbook.test_runbook", "steps.0.repeats_duration", "PT15M"),
-			//		resource.TestCheckResourceAttrSet(
-			//			"firehydrant_runbook.test_runbook", "steps.0.action_id"),
-			//	),
-			//},
+			{
+				Config: testAccRunbookResourceConfig_basic(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRunbookResourceExistsWithAttributes_basic("firehydrant_runbook.test_runbook"),
+					resource.TestCheckResourceAttrSet("firehydrant_runbook.test_runbook", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_runbook.test_runbook", "name", fmt.Sprintf("test-runbook-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_runbook.test_runbook", "steps.#", "1"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_runbook.test_runbook", "steps.0.name", "Create Incident Channel"),
+					resource.TestCheckResourceAttrSet(
+						"firehydrant_runbook.test_runbook", "steps.0.action_id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_runbook.test_runbook", "steps.0.repeats", "false"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Description

This PR does a few different things. It:
1. removes the deprecated `type` attribute from r/runbook. 
   - All runbooks are now created with a type of "incident" in the UI so this just make the provider match that behavior.
1. removes the deprecated `severities` attribute from r/runbook. 
   - This attribute is no longer in use. Any runbook that should execute based on severity should use the attachment_rule field to control that behavior.
1. fixes a bug that prevented the `description` attribute from being removed on update if it was removed from the config in r/runbook.
1. changes the `steps` attribute to required in r/runbook, since you can't create runbooks with no steps.

fixes #68 

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9142902/terraform-runbook-steps-config.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a runbook. Then take the id of your runbook and replace the placeholder in the config with it. 

#### Provision resources and data sources:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should fail and you should see errors about unsupported arguments for type and severities and missing required steps attribute
   <img width="587" alt="Screen Shot 2022-07-19 at 11 15 18 AM" src="https://user-images.githubusercontent.com/12189856/179799237-1eb620cd-4593-4bff-a153-fb96945d6b9f.png">
1. Remove the invalid type and severities attributes, uncomment all the steps attributes, and run `terraform apply` again. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.

#### Make sure updating description works
1. Update your config by adding a description to your runbook.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Update your config again by removing the description from your runbook.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure updating things still works
1. Update your config by changing various things. Try removing steps, updating attributes, adding attributes, etc.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

#### Make sure importing works:
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Create a new runbook using out started template. Copy the ID
1. In your main.tf file, uncomment the imported_runbook resource
1. Run `terraform import firehydrant_runbook.imported_runbook YOUR_RUNBOOK_ID`. This should succeed and you should see accurate information in the statefile for this runbook.


## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/xxxx)
- [Related PR](https://github.com/firehydrant/firehydrant/pull/xxxx)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.