### PR TITLE
runbook add support for runbook attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ ENHANCEMENTS:
 * resource/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * resource/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 * resource/runbook: Added the `repeats` and `repeat_duration` attribute to runbook step ([#78](https://github.com/firehydrant/terraform-provider-firehydrant/pull/78))
+* resource/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))
 * data_source/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
+* data_source/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))
 * data_source/runbook_action: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 
 ## 0.2.1

--- a/docs/data-sources/runbook.md
+++ b/docs/data-sources/runbook.md
@@ -34,6 +34,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the runbook.
+* `attachment_rule` - JSON string representing the attachment rule configuration for the runbook.
 * `description` - A description of the runbook.
-* `owner_id` - The ID of the team that owns this runbook.
 * `name` - The name of the runbook.
+* `owner_id` - The ID of the team that owns this runbook.

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -70,8 +70,8 @@ resource "firehydrant_runbook" "example-runbook" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the runbook.
-* `attachment_rule` - (Optional) JSON string representing the attachment rule configuration for the runbook.
 * `steps` - (Required) Steps to add to the runbook.
+* `attachment_rule` - (Optional) JSON string representing the attachment rule configuration for the runbook.
 * `description` - (Optional) A description of the runbook.
 * `owner_id` - (Optional) The ID of the team that owns this runbook.
 

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -52,7 +52,6 @@ resource "firehydrant_runbook" "example-runbook" {
     }
     }
   )
-}
 
   steps {
     name             = "Notify Channel"

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -32,7 +32,28 @@ resource "firehydrant_runbook" "example-runbook" {
   type        = "incident"
   description = "This is an example runbook"
   owner_id    = firehydrant_team.example-owner-team.id
-  
+  attachment_rule = jsonencode({
+    "logic" = {
+      "eq" = [
+        {
+          "var" = "incident_current_milestone",
+        },
+        {
+          "var" = "usr.1"
+        }
+      ]
+    },
+    "user_data" = {
+      "1" = {
+        "type"  = "Milestone",
+        "value" = "started",
+        "label" = "Started"
+      }
+    }
+    }
+  )
+}
+
   steps {
     name             = "Notify Channel"
     action_id        = data.firehydrant_runbook_action.notify-channel-action.id
@@ -52,6 +73,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the runbook.
 * `type` - (Required) The type of the runbook. Valid values are 
   `incident`, `general`, `infrastructure`, and `incident_role`.
+* `attachment_rule` - (Optional) JSON string representing the attachment rule configuration for the runbook.
 * `description` - (Optional) A description of the runbook.
 * `owner_id` - (Optional) The ID of the team that owns this runbook.
 * `severities` - (Optional) Severities to associate with the runbook.

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the runbook.
 * `steps` - (Required) Steps to add to the runbook.
-* `attachment_rule` - (Optional) JSON string representing the attachment rule configuration for the runbook.
+* `attachment_rule` - (Optional) JSON string representing the attachment rule configuration for the runbook. This will default to attaching automatically if attachment rule is not specified.
 * `description` - (Optional) A description of the runbook.
 * `owner_id` - (Optional) The ID of the team that owns this runbook.
 

--- a/examples/runbooks.tf
+++ b/examples/runbooks.tf
@@ -38,6 +38,26 @@ data "firehydrant_runbook_action" "email_notification" {
 resource "firehydrant_runbook" "default" {
   name = "Default Incident Process WOOHOO"
   type = "incident"
+  attachment_rule = jsonencode({
+    "logic" = {
+      "eq" = [
+        {
+          "var" = "incident_current_milestone",
+        },
+        {
+          "var" = "usr.1"
+        }
+      ]
+    },
+    "user_data" = {
+      "1" = {
+        "type"  = "Milestone",
+        "value" = "started",
+        "label" = "Started"
+      }
+    }
+    }
+  )
 
   steps {
     action_id = data.firehydrant_runbook_action.slack_channel.id

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -49,7 +49,7 @@ type APIClient struct {
 
 const (
 	// DefaultBaseURL is the URL that is used to make requests to the FireHydrant API
-	DefaultBaseURL = "https://api.local.firehydrant.io/v1/"
+	DefaultBaseURL = "https://api.firehydrant.io/v1/"
 )
 
 var _ Client = &APIClient{}

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -49,7 +49,7 @@ type APIClient struct {
 
 const (
 	// DefaultBaseURL is the URL that is used to make requests to the FireHydrant API
-	DefaultBaseURL = "https://api.firehydrant.io/v1/"
+	DefaultBaseURL = "https://api.local.firehydrant.io/v1/"
 )
 
 var _ Client = &APIClient{}

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -16,6 +16,8 @@ type CreateRunbookRequest struct {
 	Description string       `json:"description"`
 	Owner       *RunbookTeam `json:"owner,omitempty"`
 
+	AttachmentRule map[string]interface{} `json:"attachment_rule,omitempty"`
+
 	Severities []RunbookRelation `json:"severities"`
 
 	Steps []RunbookStep `json:"steps,omitempty"`
@@ -40,11 +42,12 @@ type RunbookStep struct {
 // UpdateRunbookRequest is the payload for updating a service
 // URL: PATCH https://api.firehydrant.io/v1/runbooks/{id}
 type UpdateRunbookRequest struct {
-	Name        string            `json:"name,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Owner       *RunbookTeam      `json:"owner,omitempty"`
-	Steps       []RunbookStep     `json:"steps,omitempty"`
-	Severities  []RunbookRelation `json:"severities"`
+	Name           string                 `json:"name,omitempty"`
+	Description    string                 `json:"description,omitempty"`
+	Owner          *RunbookTeam           `json:"owner,omitempty"`
+	Steps          []RunbookStep          `json:"steps,omitempty"`
+	Severities     []RunbookRelation      `json:"severities"`
+	AttachmentRule map[string]interface{} `json:"attachment_rule,omitempty"`
 }
 
 // RunbookResponse is the payload for retrieving a service
@@ -56,6 +59,8 @@ type RunbookResponse struct {
 	Description string        `json:"description"`
 	Owner       *RunbookTeam  `json:"owner"`
 	Steps       []RunbookStep `json:"steps"`
+
+	AttachmentRule map[string]interface{} `json:"attachment_rule"`
 
 	Severities []RunbookRelation `json:"severities"`
 

--- a/provider/runbook_data.go
+++ b/provider/runbook_data.go
@@ -25,6 +25,10 @@ func dataSourceRunbook() *schema.Resource {
 			},
 
 			// Computed
+			"attachment_rule": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -34,10 +38,6 @@ func dataSourceRunbook() *schema.Resource {
 				Computed: true,
 			},
 			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"attachment_rule": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/provider/runbook_data_test.go
+++ b/provider/runbook_data_test.go
@@ -43,6 +43,7 @@ func TestAccRunbookDataSource_allAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_runbook.test_runbook", "description", fmt.Sprintf("test-description-%s", rName)),
 					resource.TestCheckResourceAttrSet("data.firehydrant_runbook.test_runbook", "owner_id"),
+					resource.TestCheckResourceAttrSet("data.firehydrant_runbook.test_runbook", "attachment_rule"),
 				),
 			},
 		},
@@ -92,6 +93,26 @@ resource "firehydrant_runbook" "test_runbook" {
   type        = "incident"
   description = "test-description-%s"
   owner_id    = firehydrant_team.test_team1.id
+	attachment_rule = jsonencode({
+    "logic" = {
+      "eq" = [
+        {
+          "var" = "incident_current_milestone",
+        },
+        {
+          "var" = "usr.1"
+        }
+      ]
+    },
+    "user_data" = {
+      "1" = {
+        "type"  = "Milestone",
+        "value" = "started",
+        "label" = "Started"
+      }
+    }
+    }
+  )
 
   steps {
     name      = "Create Incident Channel"

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -88,14 +88,6 @@ func resourceRunbook() *schema.Resource {
 			},
 
 			// Optional
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"attachment_rule": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -104,6 +96,14 @@ func resourceRunbook() *schema.Resource {
 					normalizedJSON, _ := structure.NormalizeJsonString(value)
 					return normalizedJSON
 				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -97,6 +97,7 @@ func resourceRunbook() *schema.Resource {
 				Optional: true,
 			},
 			"attachment_rule": {
+				Default:          "null",
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsJSON),
@@ -137,9 +138,12 @@ func readResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceData,
 
 	// Gather values from API response
 	attributes := map[string]interface{}{
-		"name":            runbookResponse.Name,
-		"description":     runbookResponse.Description,
-		"attachment_rule": string(attachmentRule),
+		"name":        runbookResponse.Name,
+		"description": runbookResponse.Description,
+	}
+
+	if attachmentRule != nil {
+		attributes["attachment_rule"] = string(attachmentRule)
 	}
 
 	var ownerID string

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -317,7 +317,7 @@ func testAccCheckRunbookResourceExistsWithAttributes_update(resourceName string)
 		}
 
 		if runbookResponse.AttachmentRule == nil {
-			return fmt.Errorf("Unexpected attachment_rule. Expected attachment_rule to be set.)
+			return fmt.Errorf("Unexpected attachment_rule. Expected attachment_rule to be set.")
 		}
 		var attachmentRule []byte
 		if len(runbookResponse.AttachmentRule) > 0 {


### PR DESCRIPTION
## Description

r/runbook: Add support for runbook attachment_rule
In general, adding or changing an attribute involves:

Adding/changing it in the API client + tests in the /firehydrant directory
Adding/changing in the provider + tests in the /provider directory
Adding/changing it in the documentation in the /docs directory
Adding an entry to the changelog
It isn't perfect but the service resource is a good example to follow for the general format, naming conventions, and tests to use.

## Testing plan

1. Read through the docs and make sure things make sense, have not typos, etc.
1. Run the markdown through the [doc preview tool](https://registry.terraform.io/tools/doc-preview) and make sure things look good. 
1. Test the examples in the docs if you can.

Running the examples will require you to use a local build of the provider from this branch. You can do that by following these instructions:

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```

1. Create another new directory (all Terraform commands will be run in this directory)
2.  Save the following as `main.tf` in your new directory
   ```hcl
   terraform {
     required_providers {
       firehydrant = {
         source  = "firehydrant/firehydrant"
         version = "~> 0.2.1"
       }
     }
   }
   
   provider "firehydrant" {
     firehydrant_base_url = "https://api.firehydrant.io/v1/"
   }
   
  data "firehydrant_runbook_action" "notify-channel-action" {
    slug             = "notify_channel"
    integration_slug = "slack"
    type             = "incident"
  }

  resource "firehydrant_team" "example-owner-attachment-rule" {
    name        = "example-owner-team-attachment-rule"
    description = "This is an example team that owns a runbook"
  }


  resource "firehydrant_runbook" "example-runbook" {
    name        = "example-runbook-attachment_rule"
    description = "This is an example runbook"
    owner_id    = firehydrant_team.example-owner-attachment-rule.id
    attachment_rule = jsonencode({
      "logic" = {
        "eq" = [
          {
            "var" = "incident_current_milestone",
          },
          {
            "var" = "usr.1",
          }
        ]
      },
      "user_data" = {
        "1" = {
          "type"  = "Milestone",
          "value" = "started",
          "label" = "Started"
        }
      }
    })

    steps {
      name             = "Notify Channel"
      action_id        = data.firehydrant_runbook_action.notify-channel-action.id
      repeats          = true
      repeats_duration = "PT15M"

      config = jsonencode({
        channels = "#incidents"
      })
    }
  }

   ```
3. Run terraform init.
4. Now you can run various Terraform commands and test things out.
5. Verify in the UI that you see the correct conditional logic for the runbook.
6. Add in an invalid value for attachment rule and verify you get the correct error state
```
attachment_rule = "test"
```
<img width="958" alt="image" src="https://user-images.githubusercontent.com/10525357/180002932-d1b7813c-f2ae-4206-ad43-4dd1ec45c74f.png">


## Related links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developers.firehydrant.io/docs/api/6d750fbd2d88c-create-a-runbook)

## PR readiness 

- [X] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.