### PR TITLE
r/runbook: Set steps automatic attribute to have a default of false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ ENHANCEMENTS:
 * resource/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 * resource/runbook: Added the `repeats` and `repeat_duration` attribute to runbook step ([#78](https://github.com/firehydrant/terraform-provider-firehydrant/pull/78))
 * resource/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))
+* resource/runbook: Added default value of `false` to the steps `automatic` attribute ([#83](https://github.com/firehydrant/terraform-provider-firehydrant/pull/83))
 * data_source/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 * data_source/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -32,35 +32,36 @@ resource "firehydrant_runbook" "example-runbook" {
   description = "This is an example runbook"
   owner_id    = firehydrant_team.example-owner-team.id
   attachment_rule = jsonencode({
-    "logic" = {
-      "eq" = [
+    logic = {
+      eq = [
         {
-          "var" = "incident_current_milestone",
+          var = "incident_current_milestone"
         },
         {
-          "var" = "usr.1"
+          var = "usr.1"
         }
       ]
-    },
-    "user_data" = {
+    }
+    user_data = {
       "1" = {
-        "type"  = "Milestone",
-        "value" = "started",
-        "label" = "Started"
+        type  = "Milestone",
+        value = "started",
+        label = "Started"
       }
     }
-    }
-  )
+  })
 
   steps {
-    name             = "Notify Channel"
-    action_id        = data.firehydrant_runbook_action.notify-channel-action.id
-    repeats          = true
-    repeats_duration = "PT15M"
+    name      = "Notify Channel"
+    action_id = data.firehydrant_runbook_action.notify-channel-action.id
 
     config = jsonencode({
       channels = "#incidents"
     })
+
+    automatic        = false
+    repeats          = true
+    repeats_duration = "PT15M"
   }
 }
 ```
@@ -80,6 +81,7 @@ The `steps` block supports:
 * `action_id` - (Required) The ID of the runbook action for the step.
 * `name` - (Required) The name of the step.
 * `automatic` - (Optional) Whether this step should be automatically execute.
+  Defaults to `false`.
 * `config` - (Optional) JSON string representing the configuration settings for the step. 
   Use [Terraform's jsonencode](https://www.terraform.io/language/functions/jsonencode) 
   function so that [Terraform can guarantee valid JSON syntax](https://www.terraform.io/language/expressions/strings#generating-json-or-yaml).

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -50,6 +50,7 @@ func resourceRunbook() *schema.Resource {
 						"automatic": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"config": {
 							Type:             schema.TypeString,

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -36,6 +36,8 @@ func TestAccRunbookResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"firehydrant_runbook.test_runbook", "steps.0.action_id"),
 					resource.TestCheckResourceAttr(
+						"firehydrant_runbook.test_runbook", "steps.0.automatic", "false"),
+					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.0.repeats", "false"),
 				),
 			},
@@ -66,6 +68,8 @@ func TestAccRunbookResource_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"firehydrant_runbook.test_runbook", "steps.0.action_id"),
 					resource.TestCheckResourceAttr(
+						"firehydrant_runbook.test_runbook", "steps.0.automatic", "false"),
+					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.0.repeats", "false"),
 				),
 			},
@@ -84,6 +88,8 @@ func TestAccRunbookResource_update(t *testing.T) {
 						"firehydrant_runbook.test_runbook", "steps.#", "2"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.0.name", "Notify Channel"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_runbook.test_runbook", "steps.0.automatic", "true"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.0.repeats", "true"),
 					resource.TestCheckResourceAttr(
@@ -105,6 +111,8 @@ func TestAccRunbookResource_update(t *testing.T) {
 						"firehydrant_runbook.test_runbook", "steps.0.name", "Create Incident Channel"),
 					resource.TestCheckResourceAttrSet(
 						"firehydrant_runbook.test_runbook", "steps.0.action_id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_runbook.test_runbook", "steps.0.automatic", "false"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_runbook.test_runbook", "steps.0.repeats", "false"),
 				),
@@ -273,6 +281,10 @@ func testAccCheckRunbookResourceExistsWithAttributes_basic(resourceName string) 
 				return fmt.Errorf("Unexpected runbook step config. Expected %s, got: %s", step.Config, runbookResource.Primary.Attributes[key+".config"])
 			}
 
+			if runbookResource.Primary.Attributes[key+".automatic"] != fmt.Sprintf("%t", step.Automatic) {
+				return fmt.Errorf("Unexpected runbook step automatic. Expected %t, got: %s", step.Automatic, runbookResource.Primary.Attributes[key+".automatic"])
+			}
+
 			if runbookResource.Primary.Attributes[key+".repeats"] != fmt.Sprintf("%t", step.Repeats) {
 				return fmt.Errorf("Unexpected runbook step repeats. Expected %t, got: %s", step.Repeats, runbookResource.Primary.Attributes[key+".repeats"])
 			}
@@ -363,6 +375,10 @@ func testAccCheckRunbookResourceExistsWithAttributes_update(resourceName string)
 				return fmt.Errorf("Unexpected runbook step config. Expected %s, got: %s", step.Config, runbookResource.Primary.Attributes[key+".config"])
 			}
 
+			if runbookResource.Primary.Attributes[key+".automatic"] != fmt.Sprintf("%t", step.Automatic) {
+				return fmt.Errorf("Unexpected runbook step automatic. Expected %t, got: %s", step.Automatic, runbookResource.Primary.Attributes[key+".automatic"])
+			}
+
 			if runbookResource.Primary.Attributes[key+".repeats"] != fmt.Sprintf("%t", step.Repeats) {
 				return fmt.Errorf("Unexpected runbook step repeats. Expected %t, got: %s", step.Repeats, runbookResource.Primary.Attributes[key+".repeats"])
 			}
@@ -446,30 +462,30 @@ resource "firehydrant_runbook" "test_runbook" {
   name        = "test-runbook-%s"
   description = "test-description-%s"
   owner_id    = firehydrant_team.test_team1.id
-	attachment_rule = jsonencode({
-		"logic" = {
-			"eq" = [
-				{
-					"var" = "incident_current_milestone",
-				},
-				{
-					"var" = "usr.1"
-				}
-			]
-		},
-		"user_data" = {
-			"1" = {
-				"type"  = "Milestone",
-				"value" = "started",
-				"label" = "Started"
-			}
-		}
-		}
-	)
+  attachment_rule = jsonencode({
+    logic = {
+      eq = [
+        {
+          var = "incident_current_milestone"
+        },
+        {
+          var = "usr.1"
+        }
+      ]
+    }
+    user_data = {
+      "1" = {
+        type  = "Milestone"
+        value = "started"
+        label = "Started"
+      }
+    }
+  })
 
   steps {
     name             = "Notify Channel"
     action_id        = data.firehydrant_runbook_action.notify_channel.id
+    automatic        = true
     repeats          = true
     repeats_duration = "PT15M"
 
@@ -482,7 +498,8 @@ resource "firehydrant_runbook" "test_runbook" {
     name      = "Archive Channel"
     action_id = data.firehydrant_runbook_action.archive_channel.id
   }
-}`, rName, rName, rName)
+}
+`, rName, rName, rName)
 }
 
 func testAccRunbookResourceConfig_stepsRequiredRepeatsDurationNotSet(rName string) string {
@@ -495,26 +512,25 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 
 resource "firehydrant_runbook" "test_runbook" {
   name = "test-runbook-%s"
-	attachment_rule = jsonencode({
-		"logic" = {
-			"eq" = [
-				{
-					"var" = "incident_current_milestone",
-				},
-				{
-					"var" = "usr.1"
-				}
-			]
-		},
-		"user_data" = {
-			"1" = {
-				"type"  = "Milestone",
-				"value" = "started",
-				"label" = "Started"
-			}
-		}
-		}
-	)
+  attachment_rule = jsonencode({
+    logic = {
+      eq = [
+        {
+          var = "incident_current_milestone"
+        },
+        {
+          var = "usr.1"
+        }
+      ]
+    }
+    user_data = {
+      "1" = {
+        type  = "Milestone"
+        value = "started"
+        label = "Started"
+      }
+    }
+  })
 
   steps {
     name      = "Create Incident Channel"
@@ -538,26 +554,25 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 
 resource "firehydrant_runbook" "test_runbook" {
   name = "test-runbook-%s"
-	attachment_rule = jsonencode({
-		"logic" = {
-			"eq" = [
-				{
-					"var" = "incident_current_milestone",
-				},
-				{
-					"var" = "usr.1"
-				}
-			]
-		},
-		"user_data" = {
-			"1" = {
-				"type"  = "Milestone",
-				"value" = "started",
-				"label" = "Started"
-			}
-		}
-		}
-	)
+  attachment_rule = jsonencode({
+    logic = {
+      eq = [
+        {
+          var = "incident_current_milestone"
+        },
+        {
+          var = "usr.1"
+        }
+      ]
+    }
+    user_data = {
+      "1" = {
+        type  = "Milestone"
+        value = "started"
+        label = "Started"
+      }
+    }
+  })
 
   steps {
     name             = "Create Incident Channel"
@@ -600,8 +615,8 @@ data "firehydrant_runbook_action" "create_incident_channel" {
 }
 
 resource "firehydrant_runbook" "test_runbook" {
-  name = "test-runbook-%s"
-	attachment_rule = "{invalid_json = {{}}"
+  name            = "test-runbook-%s"
+  attachment_rule = "{invalid_json = {{}}"
 
   steps {
     name      = "Create Incident Channel"


### PR DESCRIPTION
## Description

This PR adds a default value of false for the steps automatic attribute in the runbook resource. This matches the default in the API. 

## Testing plan

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9142902/terraform-runbook-steps-config.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a runbook. Then take the id of your runbook and replace the placeholder in the config with it. 

#### Provision resources and data sources:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.
1. Check that automatic is set to false in your statefile.

#### Make sure updating automatic works
1. Update your config by adding automatic = false to your step.
1. Run `terraform apply`. You should see no changes.
1. Update your config again by setting automatic to true.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Update your config again by removing automatic from your step.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile. Automatic should be false in your statefile again.
1. Run `terraform plan`. You should see no changes.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/6d750fbd2d88c-create-a-runbook)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.