### PR TITLE
Runbook add support for steps rule attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ ENHANCEMENTS:
 * resource/runbook: Added the `repeats` and `repeat_duration` attribute to runbook step ([#78](https://github.com/firehydrant/terraform-provider-firehydrant/pull/78))
 * resource/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))
 * resource/runbook: Added default value of `false` to the steps `automatic` attribute ([#83](https://github.com/firehydrant/terraform-provider-firehydrant/pull/83))
+* resource/runbook: Added the `rule` attribute to runbook steps ([#84](https://github.com/firehydrant/terraform-provider-firehydrant/pull/84))
 * data_source/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 * data_source/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -62,6 +62,25 @@ resource "firehydrant_runbook" "example-runbook" {
     automatic        = false
     repeats          = true
     repeats_duration = "PT15M"
+    rule = jsonencode({
+      logic = {
+        eq = [
+          {
+            var = "incident_current_milestone",
+          },
+          {
+            var = "usr.1"
+          }
+        ]
+      },
+      user_data = {
+        1 = {
+          type  = "Milestone",
+          value = "resolved",
+          label = "Resolved"
+        }
+      }
+    })
   }
 }
 ```
@@ -88,6 +107,7 @@ The `steps` block supports:
 * `repeats` - (Optional) Whether this step should repeat.
 * `repeats_duration` - (Optional) How often this step should repeat in ISO8601. 
   Example: PT10M [Format Spec](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)
+* `rule` - (Optional) JSON string representing the rule configuration for the runbook step.
 
 ## Attributes Reference
 

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -74,7 +74,7 @@ resource "firehydrant_runbook" "example-runbook" {
         ]
       },
       user_data = {
-        1 = {
+        "1" = {
           type  = "Milestone",
           value = "resolved",
           label = "Resolved"

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -66,17 +66,17 @@ resource "firehydrant_runbook" "example-runbook" {
       logic = {
         eq = [
           {
-            var = "incident_current_milestone",
+            var = "incident_current_milestone"
           },
           {
             var = "usr.1"
           }
         ]
-      },
+      }
       user_data = {
         "1" = {
-          type  = "Milestone",
-          value = "resolved",
+          type  = "Milestone"
+          value = "resolved"
           label = "Resolved"
         }
       }

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -108,6 +108,7 @@ The `steps` block supports:
 * `repeats_duration` - (Optional) How often this step should repeat in ISO8601. 
   Example: PT10M [Format Spec](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)
 * `rule` - (Optional) JSON string representing the rule configuration for the runbook step.
+  The step will default to running manually if `rule` is not specified and `automatic` and `repeats` are both `false`.
 
 ## Attributes Reference
 

--- a/examples/runbooks.tf
+++ b/examples/runbooks.tf
@@ -140,7 +140,27 @@ resource "firehydrant_runbook" "default" {
   steps {
     action_id = data.firehydrant_runbook_action.archive_channel.id
     name      = "Archive incident channel after retrospective completion"
-    automatic = true
+    automatic = false
     repeats   = false
+    rule = jsonencode({
+      "logic" = {
+        "eq" = [
+          {
+            "var" = "incident_current_milestone",
+          },
+          {
+            "var" = "usr.1"
+          }
+        ]
+      },
+      "user_data" = {
+        "1" = {
+          "type"  = "Milestone",
+          "value" = "resolved",
+          "label" = "Resolved"
+        }
+      }
+      }
+    )
   }
 }

--- a/examples/runbooks.tf
+++ b/examples/runbooks.tf
@@ -154,7 +154,7 @@ resource "firehydrant_runbook" "default" {
         ]
       },
       user_data = {
-        1 = {
+        "1" = {
           type  = "Milestone",
           value = "resolved",
           label = "Resolved"

--- a/examples/runbooks.tf
+++ b/examples/runbooks.tf
@@ -143,24 +143,23 @@ resource "firehydrant_runbook" "default" {
     automatic = false
     repeats   = false
     rule = jsonencode({
-      "logic" = {
-        "eq" = [
+      logic = {
+        eq = [
           {
-            "var" = "incident_current_milestone",
+            var = "incident_current_milestone",
           },
           {
-            "var" = "usr.1"
+            var = "usr.1"
           }
         ]
       },
-      "user_data" = {
-        "1" = {
-          "type"  = "Milestone",
-          "value" = "resolved",
-          "label" = "Resolved"
+      user_data = {
+        1 = {
+          type  = "Milestone",
+          value = "resolved",
+          label = "Resolved"
         }
       }
-      }
-    )
+    })
   }
 }

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -50,6 +50,7 @@ type RunbookStep struct {
 	Automatic       bool                   `json:"automatic,omitempty"`
 	Repeats         bool                   `json:"repeats,omitempty"`
 	RepeatsDuration string                 `json:"repeats_duration,omitempty"`
+	Rule            map[string]interface{} `json:"rule,omitempty"`
 }
 
 // UpdateRunbookRequest is the payload for updating a service

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -96,6 +96,7 @@ func TestAccRunbookResource_update(t *testing.T) {
 						"firehydrant_runbook.test_runbook", "steps.0.repeats_duration", "PT15M"),
 					resource.TestCheckResourceAttrSet(
 						"firehydrant_runbook.test_runbook", "steps.0.action_id"),
+					resource.TestCheckResourceAttrSet("firehydrant_runbook.test_runbook", "steps.0.rule"),
 				),
 			},
 			{
@@ -136,7 +137,7 @@ func TestAccRunbookResource_validateSchemaAttributesStepsConfig(t *testing.T) {
 	})
 }
 
-func TestAccRunbookResource_validateSchemaAttributesStepsAttachmentRule(t *testing.T) {
+func TestAccRunbookResource_validateSchemaAttributesAttachmentRule(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
@@ -146,6 +147,21 @@ func TestAccRunbookResource_validateSchemaAttributesStepsAttachmentRule(t *testi
 			{
 				Config:      testAccRunbookResourceConfig_attachmentRuleInvalidJSON(rName),
 				ExpectError: regexp.MustCompile(`"attachment_rule" contains an invalid JSON`),
+			},
+		},
+	})
+}
+
+func TestAccRunbookResource_validateSchemaAttributesStepsRule(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRunbookResourceConfig_stepsRuleInvalidJSON(rName),
+				ExpectError: regexp.MustCompile(`"rule" contains an invalid JSON`),
 			},
 		},
 	})
@@ -292,6 +308,17 @@ func testAccCheckRunbookResourceExistsWithAttributes_basic(resourceName string) 
 			if runbookResource.Primary.Attributes[key+".repeats_duration"] != step.RepeatsDuration {
 				return fmt.Errorf("Unexpected runbook step repeats_duration. Expected %s, got: %s", step.RepeatsDuration, runbookResource.Primary.Attributes[key+".repeats_duration"])
 			}
+
+			var rule []byte
+			if len(step.Rule) > 0 {
+				rule, err = json.Marshal(step.Rule)
+				if err != nil {
+					return fmt.Errorf("Unexpected error converting runbook step rule to JSON: %v", err)
+				}
+			}
+			if runbookResource.Primary.Attributes[key+".rule"] != string(rule) {
+				return fmt.Errorf("Unexpected runbook step rule. Expected %s, got: %s", step.Rule, runbookResource.Primary.Attributes[key+".rule"])
+			}
 		}
 
 		return nil
@@ -385,6 +412,17 @@ func testAccCheckRunbookResourceExistsWithAttributes_update(resourceName string)
 
 			if runbookResource.Primary.Attributes[key+".repeats_duration"] != step.RepeatsDuration {
 				return fmt.Errorf("Unexpected runbook step repeats_duration. Expected %s, got: %s", step.RepeatsDuration, runbookResource.Primary.Attributes[key+".repeats_duration"])
+			}
+
+			var rule []byte
+			if len(step.Rule) > 0 {
+				rule, err = json.Marshal(step.Rule)
+				if err != nil {
+					return fmt.Errorf("Unexpected error converting runbook step rule to JSON: %v", err)
+				}
+			}
+			if runbookResource.Primary.Attributes[key+".rule"] != string(rule) {
+				return fmt.Errorf("Unexpected runbook step rule. Expected %s, got: %s", step.Rule, runbookResource.Primary.Attributes[key+".rule"])
 			}
 		}
 
@@ -492,6 +530,26 @@ resource "firehydrant_runbook" "test_runbook" {
     config = jsonencode({
       channels = "#incidents"
     })
+		rule = jsonencode({
+			"logic" = {
+				"eq" = [
+					{
+						"var" = "incident_current_milestone",
+					},
+					{
+						"var" = "usr.1"
+					}
+				]
+			},
+			"user_data" = {
+				"1" = {
+					"type"  = "Milestone",
+					"value" = "started",
+					"label" = "Started"
+				}
+			}
+			}
+		)
   }
 
   steps {
@@ -540,6 +598,26 @@ resource "firehydrant_runbook" "test_runbook" {
     config = jsonencode({
       channel_name_format = "-inc-{{ number }}"
     })
+		rule = jsonencode({
+			"logic" = {
+				"eq" = [
+					{
+						"var" = "incident_current_milestone",
+					},
+					{
+						"var" = "usr.1"
+					}
+				]
+			},
+			"user_data" = {
+				"1" = {
+					"type"  = "Milestone",
+					"value" = "started",
+					"label" = "Started"
+				}
+			}
+			}
+		)
   }
 }`, rName)
 }
@@ -582,6 +660,26 @@ resource "firehydrant_runbook" "test_runbook" {
     config = jsonencode({
       channel_name_format = "-inc-{{ number }}"
     })
+		rule = jsonencode({
+			"logic" = {
+				"eq" = [
+					{
+						"var" = "incident_current_milestone",
+					},
+					{
+						"var" = "usr.1"
+					}
+				]
+			},
+			"user_data" = {
+				"1" = {
+					"type"  = "Milestone",
+					"value" = "started",
+					"label" = "Started"
+				}
+			}
+			}
+		)
   }
 }`, rName)
 }
@@ -621,6 +719,25 @@ resource "firehydrant_runbook" "test_runbook" {
   steps {
     name      = "Create Incident Channel"
     action_id = data.firehydrant_runbook_action.create_incident_channel.id
+  }
+}`, rName)
+}
+
+func testAccRunbookResourceConfig_stepsRuleInvalidJSON(rName string) string {
+	return fmt.Sprintf(`
+data "firehydrant_runbook_action" "create_incident_channel" {
+  slug             = "create_incident_channel"
+  integration_slug = "slack"
+  type             = "incident"
+}
+
+resource "firehydrant_runbook" "test_runbook" {
+  name = "test-runbook-%s"
+
+  steps {
+    name      = "Create Incident Channel"
+    action_id = data.firehydrant_runbook_action.create_incident_channel.id
+		rule = "{invalid_json = {{}}"
   }
 }`, rName)
 }

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -542,7 +542,7 @@ resource "firehydrant_runbook" "test_runbook" {
         ]
       },
       user_data = {
-        1 = {
+        "1" = {
           type  = "Milestone",
           value = "resolved",
           label = "Resolved"
@@ -609,7 +609,7 @@ resource "firehydrant_runbook" "test_runbook" {
         ]
       },
       user_data = {
-        1 = {
+        "1" = {
           type  = "Milestone",
           value = "resolved",
           label = "Resolved"
@@ -670,7 +670,7 @@ resource "firehydrant_runbook" "test_runbook" {
         ]
       },
       user_data = {
-        1 = {
+        "1" = {
           type  = "Milestone",
           value = "resolved",
           label = "Resolved"

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -530,7 +530,7 @@ resource "firehydrant_runbook" "test_runbook" {
     config = jsonencode({
       channels = "#incidents"
     })
-		rule = jsonencode({
+    rule = jsonencode({
       logic = {
         eq = [
           {
@@ -548,8 +548,7 @@ resource "firehydrant_runbook" "test_runbook" {
           label = "Resolved"
         }
       }
-      }
-    )
+    })
   }
 
   steps {
@@ -598,7 +597,7 @@ resource "firehydrant_runbook" "test_runbook" {
     config = jsonencode({
       channel_name_format = "-inc-{{ number }}"
     })
-		rule = jsonencode({
+    rule = jsonencode({
       logic = {
         eq = [
           {
@@ -616,8 +615,7 @@ resource "firehydrant_runbook" "test_runbook" {
           label = "Resolved"
         }
       }
-      }
-    )
+    })
   }
 }`, rName)
 }
@@ -660,7 +658,7 @@ resource "firehydrant_runbook" "test_runbook" {
     config = jsonencode({
       channel_name_format = "-inc-{{ number }}"
     })
-		rule = jsonencode({
+    rule = jsonencode({
       logic = {
         eq = [
           {
@@ -678,8 +676,7 @@ resource "firehydrant_runbook" "test_runbook" {
           label = "Resolved"
         }
       }
-      }
-    )
+    })
   }
 }`, rName)
 }

--- a/provider/runbook_resource_test.go
+++ b/provider/runbook_resource_test.go
@@ -531,25 +531,25 @@ resource "firehydrant_runbook" "test_runbook" {
       channels = "#incidents"
     })
 		rule = jsonencode({
-			"logic" = {
-				"eq" = [
-					{
-						"var" = "incident_current_milestone",
-					},
-					{
-						"var" = "usr.1"
-					}
-				]
-			},
-			"user_data" = {
-				"1" = {
-					"type"  = "Milestone",
-					"value" = "started",
-					"label" = "Started"
-				}
-			}
-			}
-		)
+      logic = {
+        eq = [
+          {
+            var = "incident_current_milestone",
+          },
+          {
+            var = "usr.1"
+          }
+        ]
+      },
+      user_data = {
+        1 = {
+          type  = "Milestone",
+          value = "resolved",
+          label = "Resolved"
+        }
+      }
+      }
+    )
   }
 
   steps {
@@ -599,25 +599,25 @@ resource "firehydrant_runbook" "test_runbook" {
       channel_name_format = "-inc-{{ number }}"
     })
 		rule = jsonencode({
-			"logic" = {
-				"eq" = [
-					{
-						"var" = "incident_current_milestone",
-					},
-					{
-						"var" = "usr.1"
-					}
-				]
-			},
-			"user_data" = {
-				"1" = {
-					"type"  = "Milestone",
-					"value" = "started",
-					"label" = "Started"
-				}
-			}
-			}
-		)
+      logic = {
+        eq = [
+          {
+            var = "incident_current_milestone",
+          },
+          {
+            var = "usr.1"
+          }
+        ]
+      },
+      user_data = {
+        1 = {
+          type  = "Milestone",
+          value = "resolved",
+          label = "Resolved"
+        }
+      }
+      }
+    )
   }
 }`, rName)
 }
@@ -661,25 +661,25 @@ resource "firehydrant_runbook" "test_runbook" {
       channel_name_format = "-inc-{{ number }}"
     })
 		rule = jsonencode({
-			"logic" = {
-				"eq" = [
-					{
-						"var" = "incident_current_milestone",
-					},
-					{
-						"var" = "usr.1"
-					}
-				]
-			},
-			"user_data" = {
-				"1" = {
-					"type"  = "Milestone",
-					"value" = "started",
-					"label" = "Started"
-				}
-			}
-			}
-		)
+      logic = {
+        eq = [
+          {
+            var = "incident_current_milestone",
+          },
+          {
+            var = "usr.1"
+          }
+        ]
+      },
+      user_data = {
+        1 = {
+          type  = "Milestone",
+          value = "resolved",
+          label = "Resolved"
+        }
+      }
+      }
+    )
   }
 }`, rName)
 }


### PR DESCRIPTION
## Description

r/runbook: Add support for runbook steps rule
In general, adding or changing an attribute involves:

Adding/changing it in the API client + tests in the /firehydrant directory
Adding/changing in the provider + tests in the /provider directory
Adding/changing it in the documentation in the /docs directory
Adding an entry to the changelog
It isn't perfect but the service resource is a good example to follow for the general format, naming conventions, and tests to use.

## Testing plan

1. Read through the docs and make sure things make sense, have not typos, etc.
1. Run the markdown through the [doc preview tool](https://registry.terraform.io/tools/doc-preview) and make sure things look good. 
1. Test the examples in the docs if you can.

Running the examples will require you to use a local build of the provider from this branch. You can do that by following these instructions:

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```

1. Create another new directory (all Terraform commands will be run in this directory)
2.  Save the following as `main.tf` in your new directory
   ```hcl
   terraform {
     required_providers {
       firehydrant = {
         source  = "firehydrant/firehydrant"
         version = "~> 0.2.1"
       }
     }
   }
   
   provider "firehydrant" {
     firehydrant_base_url = "https://api.firehydrant.io/v1/"
   }
   
  data "firehydrant_runbook_action" "notify-channel-action" {
    slug             = "notify_channel"
    integration_slug = "slack"
    type             = "incident"
  }

  resource "firehydrant_runbook" "example-runbook" {
    name        = "example-runbook-step-rule"

    steps {
      name             = "Notify Channel"
      action_id        = data.firehydrant_runbook_action.notify-channel-action.id
      repeats          = true
      repeats_duration = "PT15M"

      config = jsonencode({
        channels = "#incidents"
      })
      rule = jsonencode({
        "logic" = {
          "eq" = [
            {
              "var" = "incident_current_milestone",
            },
            {
              "var" = "usr.1",
            }
          ]
        },
        "user_data" = {
          "1" = {
            "type"  = "Milestone",
            "value" = "resolved",
            "label" = "Resolved"
          }
        }
      })
    }
  }

   ```
3. Run terraform init.
4. Now you can run various Terraform commands and test things out.
5. Verify in the UI that you see the correct conditional logic for the runbook step.
6. Add in an invalid value for step rule and verify you get the correct error state
```
rule = "test"
```
<img width="868" alt="image" src="https://user-images.githubusercontent.com/10525357/180314227-9587dc7b-52a5-4abf-b563-8ffd7b7b5ec9.png">


## Related links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developers.firehydrant.io/docs/api/6d750fbd2d88c-create-a-runbook)

## PR readiness 

- [X] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.