### PR TITLE
Add support for task lists 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ BUG FIXES:
 FEATURES:
 
 * **New Resource:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
+* **New Resource:** `firehydrant_task_list` ([#85](https://github.com/firehydrant/terraform-provider-firehydrant/pull/85))
 * **New Data Source:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
+* **New Data Source:** `firehydrant_task_list` ([#85](https://github.com/firehydrant/terraform-provider-firehydrant/pull/85))
 
 ENHANCEMENTS:
 

--- a/docs/data-sources/task_list.md
+++ b/docs/data-sources/task_list.md
@@ -1,0 +1,42 @@
+---
+page_title: "FireHydrant Data Source: firehydrant_task_list"
+---
+
+# firehydrant_task_list Data Source
+
+Use this data source to get information on task lists.
+
+FireHydrant task lists help ensure integrity in your incident response.
+With tasks lists, you can create predefined tasks for your responders to
+reduce cognitive load during an incident. When used during an incident,
+each task list item will be assigned as a separate task.
+
+
+## Example Usage
+
+Basic usage:
+```hcl
+data "firehydrant_task_list" "example-task-list" {
+  id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) The ID of the task list.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the task list.
+* `description` - A description of the task list.
+* `name` - The name of the task list.
+* `task_list_items` - A list of tasks in the task list.
+
+The `task_list_items` block contains:
+
+* `summary` - (Required) A summary of the task.
+* `description` - (Optional) A description of the task list.

--- a/docs/resources/task_list.md
+++ b/docs/resources/task_list.md
@@ -1,0 +1,56 @@
+---
+page_title: "FireHydrant Resource: firehydrant_task_list"
+---
+
+# firehydrant_task_list Resource
+
+FireHydrant task lists help ensure integrity in your incident response. 
+With tasks lists, you can create predefined tasks for your responders to 
+reduce cognitive load during an incident. When used during an incident, 
+each task list item will be assigned as a separate task.
+
+## Example Usage
+
+Basic usage:
+```hcl
+resource "firehydrant_task_list" "example-task-list" {
+  name        = "example-task-list"
+  description = "This is an example task list"
+
+  task_list_items {
+    summary = "Example task #1"
+  }
+
+  task_list_items {
+    summary     = "Example task #2"
+    description = "This task is very important."
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the task list.
+* `task_list_items` - (Required) A list of tasks to include in the task list.
+* `description` - (Optional) A description of the task list.
+
+The `task_list_items` block supports:
+
+* `summary` - (Required) A summary of the task.
+* `description` - (Optional) A description of the task list.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the task list.
+
+## Import
+
+Task Lists can be imported; use `<TASK LIST ID>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_task_list.test 3638b647-b99c-5051-b715-eda2c912c42e
+```

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -59,6 +59,7 @@ type Client interface {
 	Ping(ctx context.Context) (*PingResponse, error)
 
 	Services() ServicesClient
+	TaskLists() TaskListsClient
 	Runbooks() RunbooksClient
 	RunbookActions() RunbookActionsClient
 
@@ -153,6 +154,11 @@ func (c *APIClient) Ping(ctx context.Context) (*PingResponse, error) {
 // Services returns a ServicesClient interface for interacting with services in FireHydrant
 func (c *APIClient) Services() ServicesClient {
 	return &RESTServicesClient{client: c}
+}
+
+// TaskLists returns a TaskListsClient interface for interacting with task lists in FireHydrant
+func (c *APIClient) TaskLists() TaskListsClient {
+	return &RESTTaskListsClient{client: c}
 }
 
 // Runbooks returns a RunbooksClient interface for interacting with runbooks in FireHydrant

--- a/firehydrant/task_lists.go
+++ b/firehydrant/task_lists.go
@@ -1,0 +1,131 @@
+package firehydrant
+
+import (
+	"context"
+	"time"
+
+	"github.com/dghubble/sling"
+	"github.com/pkg/errors"
+)
+
+// TaskListsClient is an interface for interacting with task lists on FireHydrant
+type TaskListsClient interface {
+	Get(ctx context.Context, id string) (*TaskListResponse, error)
+	Create(ctx context.Context, createReq CreateTaskListRequest) (*TaskListResponse, error)
+	Update(ctx context.Context, id string, updateReq UpdateTaskListRequest) (*TaskListResponse, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// RESTTaskListsClient implements the TaskListsClient interface
+type RESTTaskListsClient struct {
+	client *APIClient
+}
+
+var _ TaskListsClient = &RESTTaskListsClient{}
+
+func (c *RESTTaskListsClient) restClient() *sling.Sling {
+	return c.client.client()
+}
+
+// TaskListResponse is the payload for retrieving a service
+// URL: GET https://api.firehydrant.io/v1/task_lists/{id}
+type TaskListResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+
+	TaskListItems []TaskListItem `json:"task_list_items"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// TaskListItem is an item in a task list
+type TaskListItem struct {
+	Description string `json:"description"`
+	Summary     string `json:"summary"`
+}
+
+// Get returns a task list from the FireHydrant API
+func (c *RESTTaskListsClient) Get(ctx context.Context, id string) (*TaskListResponse, error) {
+	taskListResponse := &TaskListResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Get("task_lists/"+id).Receive(taskListResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get task list")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return taskListResponse, nil
+}
+
+// CreateTaskListRequest is the payload for creating a task list
+// URL: POST https://api.firehydrant.io/v1/task_list
+type CreateTaskListRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+
+	TaskListItems []TaskListItem `json:"task_list_items"`
+}
+
+// Create creates a brand spankin new task list in FireHydrant
+func (c *RESTTaskListsClient) Create(ctx context.Context, createReq CreateTaskListRequest) (*TaskListResponse, error) {
+	taskListResponse := &TaskListResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Post("task_lists").BodyJSON(&createReq).Receive(taskListResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create task list")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return taskListResponse, nil
+}
+
+// UpdateTaskListRequest is the payload for updating a task list
+// URL: PATCH https://api.firehydrant.io/v1/task_lists/{id}
+type UpdateTaskListRequest struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description"`
+
+	TaskListItems []TaskListItem `json:"task_list_items"`
+}
+
+// Update updates a task list in FireHydrant
+func (c *RESTTaskListsClient) Update(ctx context.Context, id string, updateReq UpdateTaskListRequest) (*TaskListResponse, error) {
+	taskListResponse := &TaskListResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Patch("task_lists/"+id).BodyJSON(updateReq).Receive(taskListResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not update task list")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return taskListResponse, nil
+}
+
+func (c *RESTTaskListsClient) Delete(ctx context.Context, id string) error {
+	apiError := &APIError{}
+	response, err := c.restClient().Delete("task_lists/"+id).Receive(nil, apiError)
+	if err != nil {
+		return errors.Wrap(err, "could not delete task list")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -56,13 +56,14 @@ func Provider() *schema.Provider {
 			"firehydrant_runbook":       resourceRunbook(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"firehydrant_service":        dataSourceService(),
-			"firehydrant_services":       dataSourceServices(),
 			"firehydrant_environment":    dataSourceEnvironment(),
 			"firehydrant_functionality":  dataSourceFunctionality(),
 			"firehydrant_priority":       dataSourcePriority(),
 			"firehydrant_runbook":        dataSourceRunbook(),
 			"firehydrant_runbook_action": dataSourceRunbookAction(),
+			"firehydrant_service":        dataSourceService(),
+			"firehydrant_services":       dataSourceServices(),
+			"firehydrant_task_list":      dataSourceTaskList(),
 		},
 	}
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -47,13 +47,14 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"firehydrant_service":       resourceService(),
 			"firehydrant_environment":   resourceEnvironment(),
 			"firehydrant_functionality": resourceFunctionality(),
-			"firehydrant_team":          resourceTeam(),
 			"firehydrant_priority":      resourcePriority(),
-			"firehydrant_severity":      resourceSeverity(),
 			"firehydrant_runbook":       resourceRunbook(),
+			"firehydrant_service":       resourceService(),
+			"firehydrant_severity":      resourceSeverity(),
+			"firehydrant_task_list":     resourceTaskList(),
+			"firehydrant_team":          resourceTeam(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"firehydrant_environment":    dataSourceEnvironment(),

--- a/provider/task_list_data.go
+++ b/provider/task_list_data.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Singular services data source
+func dataSourceTaskList() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataFireHydrantTaskList,
+		Schema: map[string]*schema.Schema{
+			// Required
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Computed
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"task_list_items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Computed
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"summary": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataFireHydrantTaskList(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get the task list
+	taskListID := d.Get("id").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Read task list: %s", taskListID), map[string]interface{}{
+		"id": taskListID,
+	})
+	taskListResponse, err := firehydrantAPIClient.TaskLists().Get(ctx, taskListID)
+	if err != nil {
+		return diag.Errorf("Error reading task list %s: %v", taskListID, err)
+	}
+
+	// Gather values from API response
+	attributes := map[string]interface{}{
+		"name":        taskListResponse.Name,
+		"description": taskListResponse.Description,
+	}
+
+	taskListItems := make([]interface{}, len(taskListResponse.TaskListItems))
+	for index, currentTaskListItem := range taskListResponse.TaskListItems {
+		taskListItems[index] = map[string]interface{}{
+			"description": currentTaskListItem.Description,
+			"summary":     currentTaskListItem.Summary,
+		}
+	}
+	attributes["task_list_items"] = taskListItems
+
+	// Set the resource attributes to the values we got from the API
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
+			return diag.Errorf("Error setting %s for task list %s: %v", key, taskListID, err)
+		}
+	}
+
+	// Set the task list's ID in state
+	d.SetId(taskListResponse.ID)
+
+	return diag.Diagnostics{}
+}

--- a/provider/task_list_data_test.go
+++ b/provider/task_list_data_test.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTaskListDataSource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskListDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_task_list.test_task_list", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "name", fmt.Sprintf("test-task-list-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "task_list_items.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "task_list_items.0.summary", fmt.Sprintf("test-summary1-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTaskListDataSource_allAttributes(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskListDataSourceConfig_allAttributes(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_task_list.test_task_list", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "name", fmt.Sprintf("test-task-list-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "task_list_items.#", "2"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "task_list_items.0.summary", fmt.Sprintf("test-summary1-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "task_list_items.0.description", fmt.Sprintf("test-description1-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "task_list_items.1.summary", fmt.Sprintf("test-summary2-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_task_list.test_task_list", "task_list_items.1.description", fmt.Sprintf("test-description2-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func testAccTaskListDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_task_list" "test_task_list" {
+  name = "test-task-list-%s"
+
+  task_list_items {
+    summary = "test-summary1-%s"
+  }
+}
+
+data "firehydrant_task_list" "test_task_list" {
+  id = firehydrant_task_list.test_task_list.id
+}`, rName, rName)
+}
+
+func testAccTaskListDataSourceConfig_allAttributes(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_task_list" "test_task_list" {
+  name        = "test-task-list-%s"
+  description = "test-description-%s"
+
+  task_list_items {
+    summary     = "test-summary1-%s"
+    description = "test-description1-%s"
+  }
+
+  task_list_items {
+    summary     = "test-summary2-%s"
+    description = "test-description2-%s"
+  }
+}
+
+data "firehydrant_task_list" "test_task_list" {
+  id = firehydrant_task_list.test_task_list.id
+}`, rName, rName, rName, rName, rName, rName)
+}

--- a/provider/task_list_resource.go
+++ b/provider/task_list_resource.go
@@ -1,0 +1,194 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceTaskList() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createResourceFireHydrantTaskList,
+		UpdateContext: updateResourceFireHydrantTaskList,
+		ReadContext:   readResourceFireHydrantTaskList,
+		DeleteContext: deleteResourceFireHydrantTaskList,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			// Required
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"task_list_items": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Required
+						"summary": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						// Optional
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			// Optional
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func readResourceFireHydrantTaskList(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get the task list
+	taskListID := d.Id()
+	tflog.Debug(ctx, fmt.Sprintf("Read task list: %s", taskListID), map[string]interface{}{
+		"id": taskListID,
+	})
+	taskListResponse, err := firehydrantAPIClient.TaskLists().Get(ctx, taskListID)
+	if err != nil {
+		if errors.Is(err, firehydrant.ErrorNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("Task list %s no longer exists", taskListID), map[string]interface{}{
+				"id": taskListID,
+			})
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error reading task list %s: %v", taskListID, err)
+	}
+
+	// Gather values from API response
+	attributes := map[string]interface{}{
+		"name":        taskListResponse.Name,
+		"description": taskListResponse.Description,
+	}
+
+	taskListItems := make([]interface{}, len(taskListResponse.TaskListItems))
+	for index, currentTaskListItem := range taskListResponse.TaskListItems {
+		taskListItems[index] = map[string]interface{}{
+			"description": currentTaskListItem.Description,
+			"summary":     currentTaskListItem.Summary,
+		}
+	}
+	attributes["task_list_items"] = taskListItems
+
+	// Set the resource attributes to the values we got from the API
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
+			return diag.Errorf("Error setting %s for task list %s: %v", key, taskListID, err)
+		}
+	}
+
+	return diag.Diagnostics{}
+}
+
+func createResourceFireHydrantTaskList(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get attributes from config and construct the create request
+	createRequest := firehydrant.CreateTaskListRequest{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+
+	// Process any optional attributes and add to the create request if necessary
+	taskListItems := d.Get("task_list_items").([]interface{})
+	for _, currentTaskListItem := range taskListItems {
+		taskListItem := currentTaskListItem.(map[string]interface{})
+
+		createRequest.TaskListItems = append(createRequest.TaskListItems, firehydrant.TaskListItem{
+			Description: taskListItem["description"].(string),
+			Summary:     taskListItem["summary"].(string),
+		})
+	}
+
+	// Create the new task list
+	tflog.Debug(ctx, fmt.Sprintf("Create task list: %s", createRequest.Name), map[string]interface{}{
+		"name": createRequest.Name,
+	})
+	taskListResponse, err := firehydrantAPIClient.TaskLists().Create(ctx, createRequest)
+	if err != nil {
+		return diag.Errorf("Error creating task list %s: %v", createRequest.Name, err)
+	}
+
+	// Set the new task list's ID in state
+	d.SetId(taskListResponse.ID)
+
+	// Update state with the latest information from the API
+	return readResourceFireHydrantTaskList(ctx, d, m)
+}
+
+func updateResourceFireHydrantTaskList(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Construct the update request
+	updateRequest := firehydrant.UpdateTaskListRequest{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+
+	// Process any optional attributes and add to the update request if necessary
+	taskListItems := d.Get("task_list_items").([]interface{})
+	for _, currentTaskListItem := range taskListItems {
+		taskListItem := currentTaskListItem.(map[string]interface{})
+
+		updateRequest.TaskListItems = append(updateRequest.TaskListItems, firehydrant.TaskListItem{
+			Description: taskListItem["description"].(string),
+			Summary:     taskListItem["summary"].(string),
+		})
+	}
+
+	// Update the task list
+	tflog.Debug(ctx, fmt.Sprintf("Update task list: %s", d.Id()), map[string]interface{}{
+		"id": d.Id(),
+	})
+	_, err := firehydrantAPIClient.TaskLists().Update(ctx, d.Id(), updateRequest)
+	if err != nil {
+		return diag.Errorf("Error updating task list %s: %v", d.Id(), err)
+	}
+
+	// Update state with the latest information from the API
+	return readResourceFireHydrantTaskList(ctx, d, m)
+}
+
+func deleteResourceFireHydrantTaskList(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Delete the task list
+	taskListID := d.Id()
+	tflog.Debug(ctx, fmt.Sprintf("Delete task list: %s", taskListID), map[string]interface{}{
+		"id": taskListID,
+	})
+	err := firehydrantAPIClient.TaskLists().Delete(ctx, taskListID)
+	if err != nil {
+		if errors.Is(err, firehydrant.ErrorNotFound) {
+			return nil
+		}
+		return diag.Errorf("Error deleting task list %s: %v", taskListID, err)
+	}
+
+	return diag.Diagnostics{}
+}

--- a/provider/task_list_resource_test.go
+++ b/provider/task_list_resource_test.go
@@ -1,0 +1,288 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccTaskListResource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckTaskListResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskListResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTaskListResourceExistsWithAttributes_basic("firehydrant_task_list.test_task_list"),
+					resource.TestCheckResourceAttrSet("firehydrant_task_list.test_task_list", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "name", fmt.Sprintf("test-task-list-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.#", "1"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.0.summary", fmt.Sprintf("test-summary1-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTaskListResource_update(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckTaskListResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskListResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTaskListResourceExistsWithAttributes_basic("firehydrant_task_list.test_task_list"),
+					resource.TestCheckResourceAttrSet("firehydrant_task_list.test_task_list", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "name", fmt.Sprintf("test-task-list-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.#", "1"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.0.summary", fmt.Sprintf("test-summary1-%s", rName)),
+				),
+			},
+			{
+				Config: testAccTaskListResourceConfig_update(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTaskListResourceExistsWithAttributes_update("firehydrant_task_list.test_task_list"),
+					resource.TestCheckResourceAttrSet("firehydrant_task_list.test_task_list", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "name", fmt.Sprintf("test-task-list-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.#", "2"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.0.summary", fmt.Sprintf("test-summary1-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.0.description", fmt.Sprintf("test-description1-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.1.summary", fmt.Sprintf("test-summary2-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.1.description", fmt.Sprintf("test-description2-%s", rNameUpdated)),
+				),
+			},
+			{
+				Config: testAccTaskListResourceConfig_basic(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTaskListResourceExistsWithAttributes_basic("firehydrant_task_list.test_task_list"),
+					resource.TestCheckResourceAttrSet("firehydrant_task_list.test_task_list", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "name", fmt.Sprintf("test-task-list-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.#", "1"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_task_list.test_task_list", "task_list_items.0.summary", fmt.Sprintf("test-summary1-%s", rNameUpdated)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTaskListResourceImport_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskListResourceConfig_basic(rName),
+			},
+			{
+				ResourceName:      "firehydrant_task_list.test_task_list",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTaskListResourceImport_allAttributes(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskListResourceConfig_update(rName),
+			},
+			{
+				ResourceName:      "firehydrant_task_list.test_task_list",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTaskListResourceExistsWithAttributes_basic(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		taskListResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if taskListResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		taskListResponse, err := client.TaskLists().Get(context.TODO(), taskListResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := taskListResource.Primary.Attributes["name"], taskListResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		if taskListResponse.Description != "" {
+			return fmt.Errorf("Unexpected description. Expected no description, got: %s", taskListResponse.Description)
+		}
+
+		if len(taskListResponse.TaskListItems) != 1 {
+			return fmt.Errorf("Unexpected number of task list items. Expected 1 item, got: %v", len(taskListResponse.TaskListItems))
+		}
+
+		for index, taskListItem := range taskListResponse.TaskListItems {
+			key := fmt.Sprintf("task_list_items.%d", index)
+			if taskListResource.Primary.Attributes[key+".summary"] != taskListItem.Summary {
+				return fmt.Errorf("Unexpected task list item summary. Expected %s, got: %s", taskListItem.Summary, taskListResource.Primary.Attributes[key+".summary"])
+			}
+
+			if taskListResource.Primary.Attributes[key+".description"] != taskListItem.Description {
+				return fmt.Errorf("Unexpected task list item description. Expected %s, got: %s", taskListItem.Description, taskListResource.Primary.Attributes[key+".description"])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTaskListResourceExistsWithAttributes_update(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		taskListResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if taskListResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		taskListResponse, err := client.TaskLists().Get(context.TODO(), taskListResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := taskListResource.Primary.Attributes["name"], taskListResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = taskListResource.Primary.Attributes["description"], taskListResponse.Description
+		if expected != got {
+			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
+		}
+
+		if len(taskListResponse.TaskListItems) != 2 {
+			return fmt.Errorf("Unexpected number of task list items. Expected 2 items, got: %v", len(taskListResponse.TaskListItems))
+		}
+
+		for index, taskListItem := range taskListResponse.TaskListItems {
+			key := fmt.Sprintf("task_list_items.%d", index)
+			if taskListResource.Primary.Attributes[key+".summary"] != taskListItem.Summary {
+				return fmt.Errorf("Unexpected task list item summary. Expected %s, got: %s", taskListItem.Summary, taskListResource.Primary.Attributes[key+".summary"])
+			}
+
+			if taskListResource.Primary.Attributes[key+".description"] != taskListItem.Description {
+				return fmt.Errorf("Unexpected task list item description. Expected %s, got: %s", taskListItem.Description, taskListResource.Primary.Attributes[key+".description"])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTaskListResourceDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		for _, stateResource := range s.RootModule().Resources {
+			if stateResource.Type != "firehydrant_task_list" {
+				continue
+			}
+
+			if stateResource.Primary.ID == "" {
+				return fmt.Errorf("No instance ID is set")
+			}
+
+			_, err := client.TaskLists().Get(context.TODO(), stateResource.Primary.ID)
+			if err == nil {
+				return fmt.Errorf("Task list %s still exists", stateResource.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccTaskListResourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_task_list" "test_task_list" {
+  name = "test-task-list-%s"
+
+  task_list_items {
+    summary = "test-summary1-%s"
+  }
+}`, rName, rName)
+}
+
+func testAccTaskListResourceConfig_update(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_task_list" "test_task_list" {
+  name        = "test-task-list-%s"
+  description = "test-description-%s"
+
+  task_list_items {
+    summary     = "test-summary1-%s"
+    description = "test-description1-%s"
+  }
+
+  task_list_items {
+    summary     = "test-summary2-%s"
+    description = "test-description2-%s"
+  }
+}`, rName, rName, rName, rName, rName, rName)
+}


### PR DESCRIPTION
## Description

This PR adds a resource and data source for task lists. 

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9170064/terraform-task-list-config.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a task list. Then take the id of your task list and replace the placeholder in the config with it. 

#### Provision resources and data sources:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.

#### Make sure updating task list description works
1. Update your config by changing the description on your task list.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Update your config again by removing the description from your task list.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure updating item description works
1. Update your config by adding a description to your first task list item.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Update your config again by removing the description from your fire task list item.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure updating everything else works
1. Update your config by changing various things. Try removing/adding items, reordering your items, updating attributes, adding attributes, etc.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Try adding another task list with the same name as your existing task list. This should fail.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/da872059d2d12-create-a-task-list)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.