### PR TITLE
r/runbook: Add default value for runbook attachment_rule

### DIFF
--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -91,7 +91,20 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the runbook.
 * `steps` - (Required) Steps to add to the runbook.
-* `attachment_rule` - (Optional) JSON string representing the attachment rule configuration for the runbook. This will default to attaching automatically if attachment rule is not specified.
+* `attachment_rule` - (Optional) JSON string representing the attachment rule configuration for the runbook. 
+  Defaults to attaching manually:
+  ```hcl
+  attachment_rule = jsonencode({
+    logic = {
+      manually = [
+        {
+          var = "when_invoked"
+        }
+      ]
+    }
+    user_data = {}
+  })
+  ```
 * `description` - (Optional) A description of the runbook.
 * `owner_id` - (Optional) The ID of the team that owns this runbook.
 

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -16,6 +16,18 @@ const (
 	RunbookTypeDefault RunbookType = "incident"
 )
 
+const RunbookAttachmentRuleDefaultJSON = `
+{
+  "logic": {
+    "manually": [
+      {
+        "var": "when_invoked"
+      }
+    ]
+  },
+  "user_data": {}
+}`
+
 // CreateRunbookRequest is the payload for creating a service
 // URL: POST https://api.firehydrant.io/v1/runbooks
 type CreateRunbookRequest struct {

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -101,6 +100,7 @@ func resourceRunbook() *schema.Resource {
 			"attachment_rule": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Default:          firehydrant.RunbookAttachmentRuleDefaultJSON,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsJSON),
 				StateFunc: func(value interface{}) string {
 					normalizedJSON, _ := structure.NormalizeJsonString(value)


### PR DESCRIPTION
## Description

This PR adds a default value to the runbook resource's `attachment_rule` attribute so that it sets the runbook to manually attach if no `attachment_rule` is specified. This matches FireHydrant's UI and prevents new runbooks from automatically attaching to incidents as soon as they are created unless a user specifies that explicitly. 

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9172167/terraform-runbook-steps-config.3.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a runbook. Then take the id of your runbook and replace the placeholder in the config with it. 

#### Provision resources and data sources:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.

#### Make sure updating attachment_rule works
1. Update your config by adding a an attachment_rule of that manually attaches:
   ```hcl
    attachment_rule = jsonencode({
      logic = {
        manually = [
          {
            var = "when_invoked"
          }
        ]
      }
      user_data = {}
    })
   ```
1. Run `terraform plan`. You should see no changes.
1. Update your config again by changing the attachment rule to the example from the docs:
   ```hcl
   attachment_rule = jsonencode({
     logic = {
       eq = [
         {
           var = "incident_current_milestone"
         },
         {
           var = "usr.1"
         }
       ]
     }
     user_data = {
       "1" = {
         type  = "Milestone",
         value = "started",
         label = "Started"
       }
     }
   })
   ```
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Update your config again by removing the attachment rule from your runbook.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/6d750fbd2d88c-create-a-runbook)
- [Related PR](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [ ] An entry has been added to the changelog, if necessary.
   - I'm not adding a changelog entry for this as the attachment_rule is new and unreleased. The addition of the attachment rule is already captured in the entry that says "resource/runbook: Added the `attachment_rule` attribute to runbook"