### PR TITLE
Add support for incident roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ FEATURES:
 
 * **New Resource:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
 * **New Resource:** `firehydrant_task_list` ([#85](https://github.com/firehydrant/terraform-provider-firehydrant/pull/85))
+* **New Resource:** `firehydrant_incident_role` ([#87](https://github.com/firehydrant/terraform-provider-firehydrant/pull/87))
 * **New Data Source:** `firehydrant_priority` ([#65](https://github.com/firehydrant/terraform-provider-firehydrant/pull/65))
 * **New Data Source:** `firehydrant_task_list` ([#85](https://github.com/firehydrant/terraform-provider-firehydrant/pull/85))
+* **New Data Source:** `firehydrant_incident_role` ([#87](https://github.com/firehydrant/terraform-provider-firehydrant/pull/87))
 
 ENHANCEMENTS:
 

--- a/docs/data-sources/incident_role.md
+++ b/docs/data-sources/incident_role.md
@@ -1,0 +1,36 @@
+---
+page_title: "FireHydrant Data Source: firehydrant_incident_role"
+---
+
+# firehydrant_incident_role Data Source
+
+Use this data source to get information on incident roles.
+
+FireHydrant incident roles allow you to use predefined roles during your 
+incidents. These predefined roles help responders know exactly what their 
+responsibilities are as soon as they drop into an incident.
+
+
+## Example Usage
+
+Basic usage:
+```hcl
+data "firehydrant_incident_role" "example-incident-role" {
+  id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) The ID of the incident role.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the incident role.
+* `description` - A description of the incident role.
+* `name` - The name of the incident role.
+* `summary` - A summary of the incident role.

--- a/docs/resources/incident_role.md
+++ b/docs/resources/incident_role.md
@@ -1,0 +1,42 @@
+---
+page_title: "FireHydrant Resource: firehydrant_incident_role"
+---
+
+# firehydrant_incident_role Resource
+
+FireHydrant incident roles allow you to use predefined roles during your
+incidents. These predefined roles help responders know exactly what their
+responsibilities are as soon as they drop into an incident.
+
+## Example Usage
+
+Basic usage:
+```hcl
+resource "firehydrant_incident_role" "example-incident-role" {
+  name        = "Example Incident Role"
+  description = "This is an example incident role description"
+  summary     = "This is an example incident role summary"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the incident role.
+* `summary` - (Required) A summary of the incident role.
+* `description` - (Optional) A description of the incident role.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the incident role.
+
+## Import
+
+Incident roles can be imported; use `<INCIDENT ROLE ID>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_incident_role.test 3638b647-b99c-5051-b715-eda2c912c42e
+```

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -58,10 +58,11 @@ var _ Client = &APIClient{}
 type Client interface {
 	Ping(ctx context.Context) (*PingResponse, error)
 
-	Services() ServicesClient
-	TaskLists() TaskListsClient
+	IncidentRoles() IncidentRolesClient
 	Runbooks() RunbooksClient
 	RunbookActions() RunbookActionsClient
+	Services() ServicesClient
+	TaskLists() TaskListsClient
 
 	// Environments
 	GetEnvironment(ctx context.Context, id string) (*EnvironmentResponse, error)
@@ -151,14 +152,9 @@ func (c *APIClient) Ping(ctx context.Context) (*PingResponse, error) {
 	return pingResponse, nil
 }
 
-// Services returns a ServicesClient interface for interacting with services in FireHydrant
-func (c *APIClient) Services() ServicesClient {
-	return &RESTServicesClient{client: c}
-}
-
-// TaskLists returns a TaskListsClient interface for interacting with task lists in FireHydrant
-func (c *APIClient) TaskLists() TaskListsClient {
-	return &RESTTaskListsClient{client: c}
+// IncidentRoles returns a IncidentRolesClient interface for interacting with incident roles in FireHydrant
+func (c *APIClient) IncidentRoles() IncidentRolesClient {
+	return &RESTIncidentRolesClient{client: c}
 }
 
 // Runbooks returns a RunbooksClient interface for interacting with runbooks in FireHydrant
@@ -169,6 +165,16 @@ func (c *APIClient) Runbooks() RunbooksClient {
 // RunbookActions returns a RunbookActionsClient interface for interacting with runbook actions in FireHydrant
 func (c *APIClient) RunbookActions() RunbookActionsClient {
 	return &RESTRunbookActionsClient{client: c}
+}
+
+// Services returns a ServicesClient interface for interacting with services in FireHydrant
+func (c *APIClient) Services() ServicesClient {
+	return &RESTServicesClient{client: c}
+}
+
+// TaskLists returns a TaskListsClient interface for interacting with task lists in FireHydrant
+func (c *APIClient) TaskLists() TaskListsClient {
+	return &RESTTaskListsClient{client: c}
 }
 
 // GetEnvironment retrieves an environment from FireHydrant

--- a/firehydrant/incident_roles.go
+++ b/firehydrant/incident_roles.go
@@ -1,0 +1,123 @@
+package firehydrant
+
+import (
+	"context"
+	"time"
+
+	"github.com/dghubble/sling"
+	"github.com/pkg/errors"
+)
+
+// IncidentRolesClient is an interface for interacting with incident roles on FireHydrant
+type IncidentRolesClient interface {
+	Get(ctx context.Context, id string) (*IncidentRoleResponse, error)
+	Create(ctx context.Context, createReq CreateIncidentRoleRequest) (*IncidentRoleResponse, error)
+	Update(ctx context.Context, id string, updateReq UpdateIncidentRoleRequest) (*IncidentRoleResponse, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// RESTIncidentRolesClient implements the IncidentRolesClient interface
+type RESTIncidentRolesClient struct {
+	client *APIClient
+}
+
+func (c *RESTIncidentRolesClient) restClient() *sling.Sling {
+	return c.client.client()
+}
+
+var _ IncidentRolesClient = &RESTIncidentRolesClient{}
+
+// IncidentRoleResponse is the payload for retrieving an incident role
+// URL: GET https://api.firehydrant.io/v1/incident_roles/{id}
+type IncidentRoleResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Summary     string `json:"summary"`
+
+	CreatedAt   time.Time `json:"created_at"`
+	DiscardedAt time.Time `json:"discarded_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Get returns an incident role from the FireHydrant API
+func (c *RESTIncidentRolesClient) Get(ctx context.Context, id string) (*IncidentRoleResponse, error) {
+	incidentRoleResponse := &IncidentRoleResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Get("incident_roles/"+id).Receive(incidentRoleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get incident role")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return incidentRoleResponse, nil
+}
+
+// CreateIncidentRoleRequest is the payload for creating an incident role
+// URL: POST https://api.firehydrant.io/v1/incident_roles
+type CreateIncidentRoleRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Summary     string `json:"summary"`
+}
+
+// Create creates a brand spankin new incident role in FireHydrant
+func (c *RESTIncidentRolesClient) Create(ctx context.Context, createReq CreateIncidentRoleRequest) (*IncidentRoleResponse, error) {
+	incidentRoleResponse := &IncidentRoleResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Post("incident_roles").BodyJSON(&createReq).Receive(incidentRoleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create incident role")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return incidentRoleResponse, nil
+}
+
+// UpdateIncidentRoleRequest is the payload for updating an incident role
+// URL: PATCH https://api.firehydrant.io/v1/incident_roles/{id}
+type UpdateIncidentRoleRequest struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description"`
+	Summary     string `json:"summary"`
+}
+
+// Update updates an incident role in FireHydrant
+func (c *RESTIncidentRolesClient) Update(ctx context.Context, id string, updateReq UpdateIncidentRoleRequest) (*IncidentRoleResponse, error) {
+	incidentRoleResponse := &IncidentRoleResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Patch("incident_roles/"+id).BodyJSON(updateReq).Receive(incidentRoleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not update incident role")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return incidentRoleResponse, nil
+}
+
+func (c *RESTIncidentRolesClient) Delete(ctx context.Context, id string) error {
+	apiError := &APIError{}
+	response, err := c.restClient().Delete("incident_roles/"+id).Receive(nil, apiError)
+	if err != nil {
+		return errors.Wrap(err, "could not delete incident role")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/firehydrant/task_lists.go
+++ b/firehydrant/task_lists.go
@@ -27,7 +27,7 @@ func (c *RESTTaskListsClient) restClient() *sling.Sling {
 	return c.client.client()
 }
 
-// TaskListResponse is the payload for retrieving a service
+// TaskListResponse is the payload for retrieving a task list
 // URL: GET https://api.firehydrant.io/v1/task_lists/{id}
 type TaskListResponse struct {
 	ID          string `json:"id"`
@@ -64,7 +64,7 @@ func (c *RESTTaskListsClient) Get(ctx context.Context, id string) (*TaskListResp
 }
 
 // CreateTaskListRequest is the payload for creating a task list
-// URL: POST https://api.firehydrant.io/v1/task_list
+// URL: POST https://api.firehydrant.io/v1/task_lists
 type CreateTaskListRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`

--- a/provider/incident_role_data.go
+++ b/provider/incident_role_data.go
@@ -1,0 +1,80 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Singular services data source
+func dataSourceIncidentRole() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataFireHydrantIncidentRole,
+		Schema: map[string]*schema.Schema{
+			// Required
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Computed
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"summary": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataFireHydrantIncidentRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get the incident role
+	incidentRoleID := d.Get("id").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Read incident role: %s", incidentRoleID), map[string]interface{}{
+		"id": incidentRoleID,
+	})
+	incidentRoleResponse, err := firehydrantAPIClient.IncidentRoles().Get(ctx, incidentRoleID)
+	if err != nil {
+		return diag.Errorf("Error reading incident role %s: %v", incidentRoleID, err)
+	}
+	// Currently, the incident role API will still return deleted/archived incident roles instead of returning
+	// 404. So, to check for incident roles that are deleted, we have to check for incident roles that have
+	// a DiscardedAt timestamp
+	if !incidentRoleResponse.DiscardedAt.IsZero() {
+		return diag.Errorf("Error reading incident role %s: Incident role has been archived", incidentRoleID)
+	}
+
+	// Gather values from API response
+	attributes := map[string]interface{}{
+		"description": incidentRoleResponse.Description,
+		"name":        incidentRoleResponse.Name,
+		"summary":     incidentRoleResponse.Summary,
+	}
+
+	// Set the resource attributes to the values we got from the API
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
+			return diag.Errorf("Error setting %s for incident role %s: %v", key, incidentRoleID, err)
+		}
+	}
+
+	// Set the incident role's ID in state
+	d.SetId(incidentRoleResponse.ID)
+
+	return diag.Diagnostics{}
+}

--- a/provider/incident_role_data_test.go
+++ b/provider/incident_role_data_test.go
@@ -1,0 +1,78 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIncidentRoleDataSource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentRoleDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_incident_role.test_incident_role", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_incident_role.test_incident_role", "name", fmt.Sprintf("test-incident-role-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_incident_role.test_incident_role", "summary", fmt.Sprintf("test-summary-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIncidentRoleDataSource_allAttributes(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentRoleDataSourceConfig_allAttributes(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_incident_role.test_incident_role", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_incident_role.test_incident_role", "name", fmt.Sprintf("test-incident-role-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_incident_role.test_incident_role", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_incident_role.test_incident_role", "summary", fmt.Sprintf("test-summary-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func testAccIncidentRoleDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_incident_role" "test_incident_role" {
+  name    = "test-incident-role-%s"
+  summary = "test-summary-%s"
+}
+
+data "firehydrant_incident_role" "test_incident_role" {
+  id = firehydrant_incident_role.test_incident_role.id
+}`, rName, rName)
+}
+
+func testAccIncidentRoleDataSourceConfig_allAttributes(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_incident_role" "test_incident_role" {
+  name        = "test-incident-role-%s"
+  description = "test-description-%s"
+  summary     = "test-summary-%s"
+}
+
+data "firehydrant_incident_role" "test_incident_role" {
+  id = firehydrant_incident_role.test_incident_role.id
+}`, rName, rName, rName)
+}

--- a/provider/incident_role_resource.go
+++ b/provider/incident_role_resource.go
@@ -1,0 +1,161 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceIncidentRole() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createResourceFireHydrantIncidentRole,
+		UpdateContext: updateResourceFireHydrantIncidentRole,
+		ReadContext:   readResourceFireHydrantIncidentRole,
+		DeleteContext: deleteResourceFireHydrantIncidentRole,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			// Required
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"summary": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Optional
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func readResourceFireHydrantIncidentRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get the incident role
+	incidentRoleID := d.Id()
+	tflog.Debug(ctx, fmt.Sprintf("Read incident role: %s", incidentRoleID), map[string]interface{}{
+		"id": incidentRoleID,
+	})
+	incidentRoleResponse, err := firehydrantAPIClient.IncidentRoles().Get(ctx, incidentRoleID)
+	if err != nil {
+		if errors.Is(err, firehydrant.ErrorNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("Incident role %s no longer exists", incidentRoleID), map[string]interface{}{
+				"id": incidentRoleID,
+			})
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error reading incident role %s: %v", incidentRoleID, err)
+	}
+	// Currently, the incident role API will still return deleted/archived incident roles instead of returning
+	// 404. So, to check for incident roles that are deleted, we have to check for incident roles that have
+	// a DiscardedAt timestamp
+	if !incidentRoleResponse.DiscardedAt.IsZero() {
+		tflog.Debug(ctx, fmt.Sprintf("Incident role %s has been archived", incidentRoleID), map[string]interface{}{
+			"id": incidentRoleID,
+		})
+		d.SetId("")
+		return nil
+	}
+
+	// Gather values from API response
+	attributes := map[string]interface{}{
+		"description": incidentRoleResponse.Description,
+		"name":        incidentRoleResponse.Name,
+		"summary":     incidentRoleResponse.Summary,
+	}
+
+	// Set the resource attributes to the values we got from the API
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
+			return diag.Errorf("Error setting %s for incident role %s: %v", key, incidentRoleID, err)
+		}
+	}
+
+	return diag.Diagnostics{}
+}
+
+func createResourceFireHydrantIncidentRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get attributes from config and construct the create request
+	createRequest := firehydrant.CreateIncidentRoleRequest{
+		Name:        d.Get("name").(string),
+		Summary:     d.Get("summary").(string),
+		Description: d.Get("description").(string),
+	}
+
+	// Create the new incident role
+	tflog.Debug(ctx, fmt.Sprintf("Create incident role: %s", createRequest.Name), map[string]interface{}{
+		"name": createRequest.Name,
+	})
+	incidentRoleResponse, err := firehydrantAPIClient.IncidentRoles().Create(ctx, createRequest)
+	if err != nil {
+		return diag.Errorf("Error creating incident role %s: %v", createRequest.Name, err)
+	}
+
+	// Set the new incident role's ID in state
+	d.SetId(incidentRoleResponse.ID)
+
+	// Update state with the latest information from the API
+	return readResourceFireHydrantIncidentRole(ctx, d, m)
+}
+
+func updateResourceFireHydrantIncidentRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Construct the update request
+	updateRequest := firehydrant.UpdateIncidentRoleRequest{
+		Name:        d.Get("name").(string),
+		Summary:     d.Get("summary").(string),
+		Description: d.Get("description").(string),
+	}
+
+	// Update the incident role
+	tflog.Debug(ctx, fmt.Sprintf("Update incident role: %s", d.Id()), map[string]interface{}{
+		"id": d.Id(),
+	})
+	_, err := firehydrantAPIClient.IncidentRoles().Update(ctx, d.Id(), updateRequest)
+	if err != nil {
+		return diag.Errorf("Error updating incident role %s: %v", d.Id(), err)
+	}
+
+	// Update state with the latest information from the API
+	return readResourceFireHydrantIncidentRole(ctx, d, m)
+}
+
+func deleteResourceFireHydrantIncidentRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Delete the incident role
+	incidentRoleID := d.Id()
+	tflog.Debug(ctx, fmt.Sprintf("Delete incident role: %s", incidentRoleID), map[string]interface{}{
+		"id": incidentRoleID,
+	})
+	err := firehydrantAPIClient.IncidentRoles().Delete(ctx, incidentRoleID)
+	if err != nil {
+		if errors.Is(err, firehydrant.ErrorNotFound) {
+			return nil
+		}
+		return diag.Errorf("Error deleting incident role %s: %v", incidentRoleID, err)
+	}
+
+	return diag.Diagnostics{}
+}

--- a/provider/incident_role_resource_test.go
+++ b/provider/incident_role_resource_test.go
@@ -1,0 +1,246 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccIncidentRoleResource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckIncidentRoleResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentRoleResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIncidentRoleResourceExistsWithAttributes_basic("firehydrant_incident_role.test_incident_role"),
+					resource.TestCheckResourceAttrSet("firehydrant_incident_role.test_incident_role", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "name", fmt.Sprintf("test-incident-role-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "summary", fmt.Sprintf("test-summary-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIncidentRoleResource_update(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckIncidentRoleResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentRoleResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIncidentRoleResourceExistsWithAttributes_basic("firehydrant_incident_role.test_incident_role"),
+					resource.TestCheckResourceAttrSet("firehydrant_incident_role.test_incident_role", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "name", fmt.Sprintf("test-incident-role-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "summary", fmt.Sprintf("test-summary-%s", rName)),
+				),
+			},
+			{
+				Config: testAccIncidentRoleResourceConfig_update(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIncidentRoleResourceExistsWithAttributes_update("firehydrant_incident_role.test_incident_role"),
+					resource.TestCheckResourceAttrSet("firehydrant_incident_role.test_incident_role", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "name", fmt.Sprintf("test-incident-role-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "summary", fmt.Sprintf("test-summary-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
+				),
+			},
+			{
+				Config: testAccIncidentRoleResourceConfig_basic(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIncidentRoleResourceExistsWithAttributes_basic("firehydrant_incident_role.test_incident_role"),
+					resource.TestCheckResourceAttrSet("firehydrant_incident_role.test_incident_role", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "name", fmt.Sprintf("test-incident-role-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "summary", fmt.Sprintf("test-summary-%s", rNameUpdated)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIncidentRoleResourceImport_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentRoleResourceConfig_basic(rName),
+			},
+			{
+				ResourceName:      "firehydrant_incident_role.test_incident_role",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIncidentRoleResourceImport_allAttributes(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentRoleResourceConfig_update(rName),
+			},
+			{
+				ResourceName:      "firehydrant_incident_role.test_incident_role",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIncidentRoleResourceExistsWithAttributes_basic(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		incidentRoleResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if incidentRoleResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		incidentRoleResponse, err := client.IncidentRoles().Get(context.TODO(), incidentRoleResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := incidentRoleResource.Primary.Attributes["name"], incidentRoleResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = incidentRoleResource.Primary.Attributes["summary"], incidentRoleResponse.Summary
+		if expected != got {
+			return fmt.Errorf("Unexpected summary. Expected: %s, got: %s", expected, got)
+		}
+
+		if incidentRoleResponse.Description != "" {
+			return fmt.Errorf("Unexpected description. Expected no description, got: %s", incidentRoleResponse.Description)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIncidentRoleResourceExistsWithAttributes_update(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		incidentRoleResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if incidentRoleResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		incidentRoleResponse, err := client.IncidentRoles().Get(context.TODO(), incidentRoleResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := incidentRoleResource.Primary.Attributes["name"], incidentRoleResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = incidentRoleResource.Primary.Attributes["summary"], incidentRoleResponse.Summary
+		if expected != got {
+			return fmt.Errorf("Unexpected summary. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = incidentRoleResource.Primary.Attributes["description"], incidentRoleResponse.Description
+		if expected != got {
+			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIncidentRoleResourceDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		for _, stateResource := range s.RootModule().Resources {
+			if stateResource.Type != "firehydrant_incident_role" {
+				continue
+			}
+
+			if stateResource.Primary.ID == "" {
+				return fmt.Errorf("No instance ID is set")
+			}
+
+			// Normally we'd check if err == nil here, because we'd expect a 404 if we try to get a resource
+			// that has been deleted. However, the incident role API will still return deleted/archived incident
+			// roles instead of returning 404. So, to check for incident roles that are deleted, we have to check
+			// for incident roles that have a DiscardedAt timestamp
+			incidentRoleResponse, _ := client.IncidentRoles().Get(context.TODO(), stateResource.Primary.ID)
+			if incidentRoleResponse.DiscardedAt.IsZero() {
+				return fmt.Errorf("Incident role %s still exists", stateResource.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccIncidentRoleResourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_incident_role" "test_incident_role" {
+  name    = "test-incident-role-%s"
+  summary = "test-summary-%s"
+}`, rName, rName)
+}
+
+func testAccIncidentRoleResourceConfig_update(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_incident_role" "test_incident_role" {
+  name        = "test-incident-role-%s"
+  summary     = "test-summary-%s"
+  description = "test-description-%s"
+}`, rName, rName, rName)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -59,6 +59,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"firehydrant_environment":    dataSourceEnvironment(),
 			"firehydrant_functionality":  dataSourceFunctionality(),
+			"firehydrant_incident_role":  dataSourceIncidentRole(),
 			"firehydrant_priority":       dataSourcePriority(),
 			"firehydrant_runbook":        dataSourceRunbook(),
 			"firehydrant_runbook_action": dataSourceRunbookAction(),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -49,6 +49,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"firehydrant_environment":   resourceEnvironment(),
 			"firehydrant_functionality": resourceFunctionality(),
+			"firehydrant_incident_role": resourceIncidentRole(),
 			"firehydrant_priority":      resourcePriority(),
 			"firehydrant_runbook":       resourceRunbook(),
 			"firehydrant_service":       resourceService(),


### PR DESCRIPTION
## Description

This PR adds a resource and data source for incident roles. 

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9182299/terraform-incident-role-config.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In your FH org, create an incident role. Then take the id of your role and replace the placeholder in the config with it. 

#### Provision resources and data sources:
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.

#### Make sure updating role description works
1. Update your config by changing the description on your role.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Update your config again by removing the description from your role.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure updating everything else works
1. Update your config by changing the name and summary.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Try adding another role with the same name as your existing role. This should fail.

#### Make sure recreating when deleted outside of Terraform works
1. Delete you example incident role in the UI
1. Run `terraform apply`. This should show that your example incident role will be recreated. If you type yes, this should succeed and you should see your changes reflected in the UI.
1. Run `terraform plan`. You should see no changes.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/4a138ef3689e8-create-an-incident-role)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.