### PR TITLE
d/runbook_action: Make type attribute optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ BREAKING CHANGES:
 BUG FIXES:
 
 * resource/runbook: Fixed bug that prevented the `description` attribute from being unset ([#80](https://github.com/firehydrant/terraform-provider-firehydrant/pull/80))
+* data_source/runbook_action: Fixed bug that prevented the Slack `add_bookmark_to_incident_channel` action from working by making `type` optional ([#92](https://github.com/firehydrant/terraform-provider-firehydrant/pull/92))
 
 FEATURES:
 

--- a/docs/data-sources/runbook_action.md
+++ b/docs/data-sources/runbook_action.md
@@ -19,232 +19,201 @@ Basic usage:
 data "firehydrant_runbook_action" "confluence_cloud_export_retro" {
   integration_slug = "confluence_cloud"
   slug             = "export_retrospective"
-  type             = "incident"
 }
 
 # FireHydrant
 data "firehydrant_runbook_action" "firehydrant_add_task_list" {
   integration_slug = "patchy"
   slug             = "add_task_list"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_assign_a_role" {
   integration_slug = "patchy"
   slug             = "assign_a_role"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_assign_a_team" {
   integration_slug = "patchy"
   slug             = "assign_a_team"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_attach_a_runbook" {
   integration_slug = "patchy"
   slug             = "attach_a_runbook"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_add_services_related_to_functionality" {
   integration_slug = "patchy"
   slug             = "add_services_related_to_functionality"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_create_incident_ticket" {
   integration_slug = "patchy"
   slug             = "create_incident_ticket"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_email_notification" {
   integration_slug = "patchy"
   slug             = "email_notification"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_freeform_text" {
   integration_slug = "patchy"
   slug             = "freeform_text"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_incident_update" {
   integration_slug = "patchy"
   slug             = "incident_update"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_resolve_linked_alerts" {
   integration_slug = "patchy"
   slug             = "set_linked_alerts_status"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_script" {
   integration_slug = "patchy"
   slug             = "script"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_send_webhook" {
   integration_slug = "patchy"
   slug             = "send_webhook"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "firehydrant_publish_to_statuspage" {
   integration_slug = "nunc"
   slug             = "create_nunc"
-  type             = "incident"
 }
 
 # Giphy
 data "firehydrant_runbook_action" "giphy_incident_channel_gif" {
   integration_slug = "giphy"
   slug             = "incident_channel_gif"
-  type             = "incident"
 }
 
 # Google Docs
 data "firehydrant_runbook_action" "google_docs_export_retro" {
   integration_slug = "google_docs"
   slug             = "export_retrospective"
-  type             = "incident"
 }
 
 # Google Meet
 data "firehydrant_runbook_action" "google_meet_create_google_meet_link" {
   integration_slug = "google_meet"
   slug             = "create_google_meet_link"
-  type             = "incident"
 }
 
 # Jira Cloud
 data "firehydrant_runbook_action" "jira_cloud_create_incident_issue" {
   integration_slug = "jira_cloud"
   slug             = "create_incident_issue"
-  type             = "incident"
 }
 
 # Jira Server
 data "firehydrant_runbook_action" "jira_server_create_incident_issue" {
   integration_slug = "jira_onprem"
   slug             = "create_incident_issue"
-  type             = "incident"
 }
 
 # Microsoft Teams
 data "firehydrant_runbook_action" "microsoft_teams_create_incident_channel" {
   integration_slug = "microsoft_teams"
   slug             = "create_incident_channel"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "microsoft_teams_notify_channel" {
   integration_slug = "microsoft_teams"
   slug             = "notify_channel"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "microsoft_teams_notify_channel_custom" {
   integration_slug = "microsoft_teams"
   slug             = "notify_channel_custom_message"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "microsoft_teams_notify_incident_channel_custom" {
   integration_slug = "microsoft_teams"
   slug             = "notify_incident_channel_custom_message"
-  type             = "incident"
 }
 
 # OpsGenie
 data "firehydrant_runbook_action" "opsgenie_create_new_incident" {
   integration_slug = "opsgenie"
   slug             = "create_new_opsgenie_incident"
-  type             = "incident"
 }
 
 # PagerDuty
 data "firehydrant_runbook_action" "pagerduty_create_new_incident" {
   integration_slug = "pager_duty"
   slug             = "create_new_pager_duty_incident"
-  type             = "incident"
 }
 
 # Shortcut
 data "firehydrant_runbook_action" "shortcut_create_incident_issue" {
   integration_slug = "shortcut"
   slug             = "create_incident_issue"
-  type             = "incident"
 }
 
 # Slack
+data "firehydrant_runbook_action" "slack_add_bookmark_to_incident_channel" {
+  integration_slug = "slack"
+  slug             = "add_bookmark_to_incident_channel"
+}
+
 data "firehydrant_runbook_action" "slack_archive_channel" {
   integration_slug = "slack"
   slug             = "archive_incident_channel"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "slack_create_incident_channel" {
   integration_slug = "slack"
   slug             = "create_incident_channel"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "slack_notify_channel" {
   integration_slug = "slack"
   slug             = "notify_channel"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "slack_notify_channel_custom" {
   integration_slug = "slack"
   slug             = "notify_channel_custom_message"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "slack_notify_incident_channel_custom" {
   integration_slug = "slack"
   slug             = "notify_incident_channel_custom_message"
-  type             = "incident"
 }
 
 # Statuspage.io
 data "firehydrant_runbook_action" "statuspage_create_statuspage" {
   integration_slug = "statuspage"
   slug             = "create_statuspage"
-  type             = "incident"
 }
 
 data "firehydrant_runbook_action" "statuspage_update_statuspage" {
   integration_slug = "statuspage"
   slug             = "update_statuspage"
-  type             = "incident"
 }
 
 # VictorOps
 data "firehydrant_runbook_action" "victorops_create_new_incident" {
   integration_slug = "victorops"
   slug             = "create_new_victorops_incident"
-  type             = "incident"
 }
 
 # Webex
 data "firehydrant_runbook_action" "webex_create_meeting" {
   integration_slug = "webex"
   slug             = "create_meeting"
-  type             = "incident"
 }
 
 # Zoom 
 data "firehydrant_runbook_action" "zoom_create_meeting" {
   integration_slug = "zoom"
   slug             = "create_meeting"
-  type             = "incident"
 }
 ```
 
@@ -254,7 +223,7 @@ The following arguments are supported:
 
 * `integration_slug` - (Required) The slug of the integration associated with the runbook action.
 * `slug` - (Required) The slug of the runbook action.
-* `type` - (Required) The type of runbook supported for the runbook action. Valid values are `incident`, 
+* `type` - (Optional) The type of runbook supported for the runbook action. Valid values are `incident`, 
   `infrastructure`, and `incident_role`.
 
 ## Attributes Reference

--- a/firehydrant/runbook_actions.go
+++ b/firehydrant/runbook_actions.go
@@ -9,12 +9,28 @@ import (
 	"github.com/pkg/errors"
 )
 
+// RunbooksClient is an interface for interacting with runbooks on FireHydrant
+type RunbookActionsClient interface {
+	Get(ctx context.Context, runbookType string, integrationSlug string, actionSlug string) (*RunbookAction, error)
+}
+
+// RESTRunbooksClient implements the RunbooksClient interface
+type RESTRunbookActionsClient struct {
+	client *APIClient
+}
+
+var _ RunbookActionsClient = &RESTRunbookActionsClient{}
+
+func (c *RESTRunbookActionsClient) restClient() *sling.Sling {
+	return c.client.client()
+}
+
+// RunbookActionsResponse is the payload for retrieving runbook actions
+// URL: GET https://api.firehydrant.io/v1/runbooks/actions
 type RunbookActionsResponse struct {
 	Actions []RunbookAction `json:"data"`
 }
 
-// RunbookResponse is the payload for retrieving a service
-// URL: GET https://api.firehydrant.io/v1/runbooks/{id}
 type RunbookAction struct {
 	ID          string       `json:"id"`
 	Integration *Integration `json:"integration"`
@@ -32,22 +48,6 @@ type Integration struct {
 type RunbookActionsQuery struct {
 	Type  string `url:"type,omitempty"`
 	Items uint   `url:"per_page,omitempty"`
-}
-
-// RunbooksClient is an interface for interacting with runbooks on FireHydrant
-type RunbookActionsClient interface {
-	Get(ctx context.Context, runbookType string, integrationSlug string, actionSlug string) (*RunbookAction, error)
-}
-
-// RESTRunbooksClient implements the RunbooksClient interface
-type RESTRunbookActionsClient struct {
-	client *APIClient
-}
-
-var _ RunbookActionsClient = &RESTRunbookActionsClient{}
-
-func (c *RESTRunbookActionsClient) restClient() *sling.Sling {
-	return c.client.client()
 }
 
 // Get returns a runbook action from the FireHydrant API

--- a/provider/runbook_action_data.go
+++ b/provider/runbook_action_data.go
@@ -24,9 +24,11 @@ func dataSourceRunbookAction() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
+			// Optional
 			"type": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			// Computed

--- a/provider/runbook_action_data_test.go
+++ b/provider/runbook_action_data_test.go
@@ -18,9 +18,31 @@ func TestAccRunbookActionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.firehydrant_runbook_action.test_runbook_action", "id"),
 					resource.TestCheckResourceAttrSet("data.firehydrant_runbook_action.test_runbook_action", "name"),
 					resource.TestCheckResourceAttr(
+						"data.firehydrant_runbook_action.test_runbook_action", "slug", "add_bookmark_to_incident_channel"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_runbook_action.test_runbook_action", "integration_slug", "slack"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRunbookActionDataSource_allAttributes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRunbookActionDataSourceConfig_allAttributes(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_runbook_action.test_runbook_action", "id"),
+					resource.TestCheckResourceAttrSet("data.firehydrant_runbook_action.test_runbook_action", "name"),
+					resource.TestCheckResourceAttr(
 						"data.firehydrant_runbook_action.test_runbook_action", "slug", "create_incident_channel"),
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_runbook_action.test_runbook_action", "integration_slug", "slack"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_runbook_action.test_runbook_action", "type", "incident"),
 				),
 			},
 		},
@@ -51,6 +73,14 @@ func testAccRunbookActionDataSourceConfig_basic() string {
 	return fmt.Sprintf(`
 data "firehydrant_runbook_action" "test_runbook_action" {
   integration_slug = "slack"
+  slug             = "add_bookmark_to_incident_channel"
+}`)
+}
+
+func testAccRunbookActionDataSourceConfig_allAttributes() string {
+	return fmt.Sprintf(`
+data "firehydrant_runbook_action" "test_runbook_action" {
+  integration_slug = "slack"
   slug             = "create_incident_channel"
   type             = "incident"
 }`)
@@ -61,6 +91,5 @@ func testAccRunbookActionDataSourceConfig_multipleActionsForSlug() string {
 data "firehydrant_runbook_action" "test_runbook_action" {
   integration_slug = "shortcut"
   slug             = "create_incident_issue"
-  type             = "incident"
 }`)
 }


### PR DESCRIPTION
## Description

This PR makes the `type` attribute optional in the runbook action resource. It is just an attribute that filters out runbook actions when we query for them but it isn't required in our API. There is also at least one runbook action (Slack's add_bookmark_to_incident_channel) that doesn't have any type, which breaks when type is required. 

## Testing plan

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup:
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  Create a new file called `main.tf` in your new directory with the following format:
   ```
   terraform {
     required_providers {
       firehydrant = {
         source  = "firehydrant/firehydrant"
         version = "~> 0.2.1"
       }
     }
   }

   provider "firehydrant" {
     firehydrant_base_url = "https://api.firehydrant.io/v1/"
     # Note: this is not a secure way to handle credentials, this is just for ease of testing. 
     # Please destroy your bot token when you are done testing
     api_key              = "YOU_BOT_TOKEN_HERE"
   }
   ```
1. Copy the config from the runbook action data source docs and paste them at the end of your `main.tf` file
1. Run `terraform apply`. This should succeed.
1. Check through all the data sources in your terraform.tfstate file to make sure the slug, integration slug, and name all match to the correct integration and runbook action you'd expect. 

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/5c4c2f90c1b74-list-all-runbook-actions)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.