### PR TITLE
Refactor r/environment and d/environment and add logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ BREAKING CHANGES:
 
 BUG FIXES:
 
+* resource/environment: Fixed bug that prevented the `description` attribute from being unset ([#93](https://github.com/firehydrant/terraform-provider-firehydrant/pull/93))
 * resource/runbook: Fixed bug that prevented the `description` attribute from being unset ([#80](https://github.com/firehydrant/terraform-provider-firehydrant/pull/80))
 * resource/severity: Fixed bug that prevented the `description` attribute from being unset ([#88](https://github.com/firehydrant/terraform-provider-firehydrant/pull/88))
 * data_source/runbook_action: Fixed bug that prevented the Slack `add_bookmark_to_incident_channel` action from working by making `type` optional ([#92](https://github.com/firehydrant/terraform-provider-firehydrant/pull/92))
@@ -28,6 +29,7 @@ ENHANCEMENTS:
 
 * provider: Improved error messages by adding details from the API response ([#75](https://github.com/firehydrant/terraform-provider-firehydrant/pull/75))
 * provider: Improved documentation for configuring the provider ([#95](https://github.com/firehydrant/terraform-provider-firehydrant/pull/95))
+* resource/environment: Added logging ([#93](https://github.com/firehydrant/terraform-provider-firehydrant/pull/93))
 * resource/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * resource/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 * resource/runbook: Added the `repeats` and `repeat_duration` attribute to runbook step ([#78](https://github.com/firehydrant/terraform-provider-firehydrant/pull/78))
@@ -36,6 +38,7 @@ ENHANCEMENTS:
 * resource/runbook: Added the `rule` attribute to runbook steps ([#84](https://github.com/firehydrant/terraform-provider-firehydrant/pull/84))
 * resource/severity: Added logging to the resource and validation to the `slug` attribute ([#88](https://github.com/firehydrant/terraform-provider-firehydrant/pull/88))
 * resource/severity: Added support for the `type` attribute ([#88](https://github.com/firehydrant/terraform-provider-firehydrant/pull/88))
+* data_source/environment: Added logging ([#93](https://github.com/firehydrant/terraform-provider-firehydrant/pull/93))
 * data_source/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 * data_source/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -1,6 +1,5 @@
 ---
 page_title: "FireHydrant Data Source: firehydrant_environment"
-subcategory: "Beta"
 ---
 
 # firehydrant_environment Data Source

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -1,6 +1,5 @@
 ---
 page_title: "FireHydrant Resource: firehydrant_environment"
-subcategory: "Beta"
 ---
 
 # firehydrant_environment Resource

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -58,6 +58,7 @@ var _ Client = &APIClient{}
 type Client interface {
 	Ping(ctx context.Context) (*PingResponse, error)
 
+	Environments() EnvironmentsClient
 	IncidentRoles() IncidentRolesClient
 	Priorities() PrioritiesClient
 	Runbooks() RunbooksClient
@@ -66,12 +67,6 @@ type Client interface {
 	Services() ServicesClient
 	Severities() SeveritiesClient
 	TaskLists() TaskListsClient
-
-	// Environments
-	GetEnvironment(ctx context.Context, id string) (*EnvironmentResponse, error)
-	CreateEnvironment(ctx context.Context, req CreateEnvironmentRequest) (*EnvironmentResponse, error)
-	UpdateEnvironment(ctx context.Context, id string, req UpdateEnvironmentRequest) (*EnvironmentResponse, error)
-	DeleteEnvironment(ctx context.Context, id string) error
 
 	// Functionalities
 	GetFunctionality(ctx context.Context, id string) (*FunctionalityResponse, error)
@@ -143,6 +138,11 @@ func (c *APIClient) Ping(ctx context.Context) (*PingResponse, error) {
 	return pingResponse, nil
 }
 
+// Environments returns a EnvironmentsClient interface for interacting with environments in FireHydrant
+func (c *APIClient) Environments() EnvironmentsClient {
+	return &RESTEnvironmentsClient{client: c}
+}
+
 // IncidentRoles returns a IncidentRolesClient interface for interacting with incident roles in FireHydrant
 func (c *APIClient) IncidentRoles() IncidentRolesClient {
 	return &RESTIncidentRolesClient{client: c}
@@ -181,73 +181,6 @@ func (c *APIClient) Severities() SeveritiesClient {
 // TaskLists returns a TaskListsClient interface for interacting with task lists in FireHydrant
 func (c *APIClient) TaskLists() TaskListsClient {
 	return &RESTTaskListsClient{client: c}
-}
-
-// GetEnvironment retrieves an environment from FireHydrant
-func (c *APIClient) GetEnvironment(ctx context.Context, id string) (*EnvironmentResponse, error) {
-	envResponse := &EnvironmentResponse{}
-	apiError := &APIError{}
-	response, err := c.client().Get("environments/"+id).Receive(envResponse, apiError)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get environment")
-	}
-
-	err = checkResponseStatusCode(response, apiError)
-	if err != nil {
-		return nil, err
-	}
-
-	return envResponse, nil
-}
-
-// CreateEnvironment creates an environment in FireHydrant
-func (c *APIClient) CreateEnvironment(ctx context.Context, req CreateEnvironmentRequest) (*EnvironmentResponse, error) {
-	envResponse := &EnvironmentResponse{}
-	apiError := &APIError{}
-	response, err := c.client().Post("environments").BodyJSON(&req).Receive(envResponse, apiError)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create environment")
-	}
-
-	err = checkResponseStatusCode(response, apiError)
-	if err != nil {
-		return nil, err
-	}
-
-	return envResponse, nil
-}
-
-// UpdateEnvironment updates a environment in FireHydrant
-func (c *APIClient) UpdateEnvironment(ctx context.Context, id string, req UpdateEnvironmentRequest) (*EnvironmentResponse, error) {
-	envResponse := &EnvironmentResponse{}
-	apiError := &APIError{}
-	response, err := c.client().Patch("environments/"+id).BodyJSON(&req).Receive(envResponse, apiError)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not update environment")
-	}
-
-	err = checkResponseStatusCode(response, apiError)
-	if err != nil {
-		return nil, err
-	}
-
-	return envResponse, nil
-}
-
-// DeleteEnvironment deletes a environment from FireHydrant
-func (c *APIClient) DeleteEnvironment(ctx context.Context, id string) error {
-	apiError := &APIError{}
-	response, err := c.client().Delete("environments/"+id).Receive(nil, apiError)
-	if err != nil {
-		return errors.Wrap(err, "could not delete environment")
-	}
-
-	err = checkResponseStatusCode(response, apiError)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // GetFunctionality retrieves a functionality from FireHydrant

--- a/firehydrant/environments.go
+++ b/firehydrant/environments.go
@@ -1,0 +1,120 @@
+package firehydrant
+
+import (
+	"context"
+	"time"
+
+	"github.com/dghubble/sling"
+	"github.com/pkg/errors"
+)
+
+// EnvironmentsClient is an interface for interacting with environments on FireHydrant
+type EnvironmentsClient interface {
+	Get(ctx context.Context, id string) (*EnvironmentResponse, error)
+	Create(ctx context.Context, createReq CreateEnvironmentRequest) (*EnvironmentResponse, error)
+	Update(ctx context.Context, id string, updateReq UpdateEnvironmentRequest) (*EnvironmentResponse, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// RESTEnvironmentsClient implements the EnvironmentsClient interface
+type RESTEnvironmentsClient struct {
+	client *APIClient
+}
+
+var _ EnvironmentsClient = &RESTEnvironmentsClient{}
+
+func (c *RESTEnvironmentsClient) restClient() *sling.Sling {
+	return c.client.client()
+}
+
+// EnvironmentResponse is the payload for a single environment
+// URL: GET https://api.firehydrant.io/v1/environments/{id}
+type EnvironmentResponse struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Slug        string    `json:"slug"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Get retrieves an environment from FireHydrant
+func (c *RESTEnvironmentsClient) Get(ctx context.Context, id string) (*EnvironmentResponse, error) {
+	envResponse := &EnvironmentResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Get("environments/"+id).Receive(envResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get environment")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return envResponse, nil
+}
+
+// CreateEnvironmentRequest is the payload for creating a service
+// URL: POST https://api.firehydrant.io/v1/services
+type CreateEnvironmentRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// Create creates an environment in FireHydrant
+func (c *RESTEnvironmentsClient) Create(ctx context.Context, req CreateEnvironmentRequest) (*EnvironmentResponse, error) {
+	envResponse := &EnvironmentResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Post("environments").BodyJSON(&req).Receive(envResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create environment")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return envResponse, nil
+}
+
+// UpdateEnvironmentRequest is the payload for updating a environment
+// URL: PATCH https://api.firehydrant.io/v1/environments/{id}
+type UpdateEnvironmentRequest struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// Update updates a environment in FireHydrant
+func (c *RESTEnvironmentsClient) Update(ctx context.Context, id string, req UpdateEnvironmentRequest) (*EnvironmentResponse, error) {
+	envResponse := &EnvironmentResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Patch("environments/"+id).BodyJSON(&req).Receive(envResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not update environment")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return envResponse, nil
+}
+
+// Delete deletes a environment from FireHydrant
+func (c *RESTEnvironmentsClient) Delete(ctx context.Context, id string) error {
+	apiError := &APIError{}
+	response, err := c.restClient().Delete("environments/"+id).Receive(nil, apiError)
+	if err != nil {
+		return errors.Wrap(err, "could not delete environment")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/firehydrant/environments_test.go
+++ b/firehydrant/environments_test.go
@@ -37,7 +37,7 @@ func TestGetEnvironment(t *testing.T) {
 		return
 	}
 
-	res, err := c.GetEnvironment(context.TODO(), expectedEnvironment.ID)
+	res, err := c.Environments().Get(context.TODO(), expectedEnvironment.ID)
 	if err != nil {
 		t.Fatalf("Received error hitting environment get endpoint: %s", err.Error())
 	}
@@ -90,7 +90,7 @@ func TestCreateEnvironment(t *testing.T) {
 		return
 	}
 
-	res, err := c.CreateEnvironment(context.TODO(), req)
+	res, err := c.Environments().Create(context.TODO(), req)
 	if err != nil {
 		t.Fatalf("Received error hitting environment create endpoint: %s", err.Error())
 	}

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -136,31 +136,6 @@ type ServicesResponse struct {
 	Services []ServiceResponse `json:"data"`
 }
 
-// EnvironmentResponse is the payload for a single environment
-// URL: GET https://api.firehydrant.io/v1/environments/{id}
-type EnvironmentResponse struct {
-	ID          string    `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	Slug        string    `json:"slug"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
-}
-
-// CreateEnvironmentRequest is the payload for creating a service
-// URL: POST https://api.firehydrant.io/v1/services
-type CreateEnvironmentRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-// UpdateEnvironmentRequest is the payload for updating a environment
-// URL: PATCH https://api.firehydrant.io/v1/environments/{id}
-type UpdateEnvironmentRequest struct {
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-}
-
 // FunctionalityResponse is the payload for a single environment
 // URL: GET https://api.firehydrant.io/v1/functionalities/{id}
 type FunctionalityResponse struct {

--- a/provider/environment_data_test.go
+++ b/provider/environment_data_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEnvironmentDataSource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_environment.test_environment", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_environment.test_environment", "name", fmt.Sprintf("test-environment-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEnvironmentDataSource_allAttributes(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentDataSourceConfig_allAttributes(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_environment.test_environment", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_environment.test_environment", "name", fmt.Sprintf("test-environment-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_environment.test_environment", "description", fmt.Sprintf("test-description-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func testAccEnvironmentDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_environment" "test_environment" {
+  name    = "test-environment-%s"
+}
+
+data "firehydrant_environment" "test_environment" {
+  environment_id = firehydrant_environment.test_environment.id
+}`, rName)
+}
+
+func testAccEnvironmentDataSourceConfig_allAttributes(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_environment" "test_environment" {
+  name        = "test-environment-%s"
+  description = "test-description-%s"
+}
+
+data "firehydrant_environment" "test_environment" {
+  environment_id = firehydrant_environment.test_environment.id
+}`, rName, rName)
+}

--- a/provider/environment_resource_test.go
+++ b/provider/environment_resource_test.go
@@ -1,0 +1,223 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccEnvironmentResource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckEnvironmentResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnvironmentResourceExistsWithAttributes_basic("firehydrant_environment.test_environment"),
+					resource.TestCheckResourceAttrSet("firehydrant_environment.test_environment", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_environment.test_environment", "name", fmt.Sprintf("test-environment-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEnvironmentResource_update(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckEnvironmentResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnvironmentResourceExistsWithAttributes_basic("firehydrant_environment.test_environment"),
+					resource.TestCheckResourceAttrSet("firehydrant_environment.test_environment", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_environment.test_environment", "name", fmt.Sprintf("test-environment-%s", rName)),
+				),
+			},
+			{
+				Config: testAccEnvironmentResourceConfig_update(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnvironmentResourceExistsWithAttributes_update("firehydrant_environment.test_environment"),
+					resource.TestCheckResourceAttrSet("firehydrant_environment.test_environment", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_environment.test_environment", "name", fmt.Sprintf("test-environment-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_environment.test_environment", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
+				),
+			},
+			{
+				Config: testAccEnvironmentResourceConfig_basic(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnvironmentResourceExistsWithAttributes_basic("firehydrant_environment.test_environment"),
+					resource.TestCheckResourceAttrSet("firehydrant_environment.test_environment", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_environment.test_environment", "name", fmt.Sprintf("test-environment-%s", rNameUpdated)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEnvironmentResourceImport_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentResourceConfig_basic(rName),
+			},
+			{
+				ResourceName:      "firehydrant_environment.test_environment",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccEnvironmentResourceImport_allAttributes(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentResourceConfig_update(rName),
+			},
+			{
+				ResourceName:      "firehydrant_environment.test_environment",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEnvironmentResourceExistsWithAttributes_basic(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		environmentResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if environmentResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		environmentResponse, err := client.Environments().Get(context.TODO(), environmentResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := environmentResource.Primary.Attributes["name"], environmentResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		if environmentResponse.Description != "" {
+			return fmt.Errorf("Unexpected description. Expected no description, got: %s", environmentResponse.Description)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckEnvironmentResourceExistsWithAttributes_update(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		environmentResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if environmentResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		environmentResponse, err := client.Environments().Get(context.TODO(), environmentResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := environmentResource.Primary.Attributes["name"], environmentResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = environmentResource.Primary.Attributes["description"], environmentResponse.Description
+		if expected != got {
+			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckEnvironmentResourceDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		for _, stateResource := range s.RootModule().Resources {
+			if stateResource.Type != "firehydrant_environment" {
+				continue
+			}
+
+			if stateResource.Primary.ID == "" {
+				return fmt.Errorf("No instance ID is set")
+			}
+
+			_, err := client.Environments().Get(context.TODO(), stateResource.Primary.ID)
+			if err == nil {
+				return fmt.Errorf("Environment %s still exists", stateResource.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccEnvironmentResourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_environment" "test_environment" {
+  name    = "test-environment-%s"
+}`, rName)
+}
+
+func testAccEnvironmentResourceConfig_update(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_environment" "test_environment" {
+  name        = "test-environment-%s"
+  description = "test-description-%s"
+}`, rName, rName)
+}


### PR DESCRIPTION
## Description

This PR does the following:
1. Refactors the environment API client logic into its own file
1. Refactors the environment resource and data source for clarity and consistency
1. Adds logging and tests for environment
1. Fixes a bug that prevented description from being removed on update

fixes #41 
fixes #37 
fixes #35 

## Testing plan

Look at the new log output and see if it makes sense, has any typos, etc. [Documentation on managing log output and the various levels available are here](https://www.terraform.io/plugin/log/managing). TF_LOG_PROVIDER_FIREHYDRANT is not available at this time because we haven't implemented it but TF_LOG and TF_LOG_PROVIDER should work. Feel free to try different log levels if you'd like. 

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9213123/terraform-env-config.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create an environment. Then take the ID of your environment and replace the placeholder in the config with it. 

#### Provision resources and data sources:
1. Run `TF_LOG_PROVIDER=DEBUG terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `TF_LOG_PROVIDER=DEBUG terraform plan`. There should be no changes.

#### Make sure updating description works
1. Update your config by changing the description on your environment.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Update your config again by removing the description from your environment.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

  #### Make sure everything else works
1. Update your config again by changing the name of your environment.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/35f430a8cffa0-create-an-environment)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.