### PR TITLE
Remove deprecated `services` attribute from r/functionality and add logging to d/functionality & r/functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BREAKING CHANGES:
 
+* resource/functionality: Removed deprecated `services` attribute, preferring `service_ids` instead ([#94](https://github.com/firehydrant/terraform-provider-firehydrant/pull/94))
 * resource/runbook: Changed the type of the `steps` `config` attribute to a JSON string ([#79](https://github.com/firehydrant/terraform-provider-firehydrant/pull/79))
 * resource/runbook: Removed deprecated `type` attribute ([#80](https://github.com/firehydrant/terraform-provider-firehydrant/pull/80))
 * resource/runbook: Removed deprecated `severities` attribute ([#80](https://github.com/firehydrant/terraform-provider-firehydrant/pull/80))
@@ -30,6 +31,7 @@ ENHANCEMENTS:
 * provider: Improved error messages by adding details from the API response ([#75](https://github.com/firehydrant/terraform-provider-firehydrant/pull/75))
 * provider: Improved documentation for configuring the provider ([#95](https://github.com/firehydrant/terraform-provider-firehydrant/pull/95))
 * resource/environment: Added logging ([#93](https://github.com/firehydrant/terraform-provider-firehydrant/pull/93))
+* resource/functionality: Added logging ([#94](https://github.com/firehydrant/terraform-provider-firehydrant/pull/94))
 * resource/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * resource/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 * resource/runbook: Added the `repeats` and `repeat_duration` attribute to runbook step ([#78](https://github.com/firehydrant/terraform-provider-firehydrant/pull/78))
@@ -39,6 +41,7 @@ ENHANCEMENTS:
 * resource/severity: Added logging to the resource and validation to the `slug` attribute ([#88](https://github.com/firehydrant/terraform-provider-firehydrant/pull/88))
 * resource/severity: Added support for the `type` attribute ([#88](https://github.com/firehydrant/terraform-provider-firehydrant/pull/88))
 * data_source/environment: Added logging ([#93](https://github.com/firehydrant/terraform-provider-firehydrant/pull/93))
+* data_source/functionality: Added logging ([#94](https://github.com/firehydrant/terraform-provider-firehydrant/pull/94))
 * data_source/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 * data_source/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))

--- a/docs/data-sources/functionality.md
+++ b/docs/data-sources/functionality.md
@@ -1,6 +1,5 @@
 ---
 page_title: "FireHydrant Data Source: firehydrant_functionality"
-subcategory: "Beta"
 ---
 
 # firehydrant_functionality Data Source

--- a/docs/resources/functionality.md
+++ b/docs/resources/functionality.md
@@ -1,6 +1,5 @@
 ---
 page_title: "FireHydrant Resource: firehydrant_functionality"
-subcategory: "Beta"
 ---
 
 # firehydrant_functionality Resource
@@ -39,9 +38,6 @@ The following arguments are supported:
 * `name` - (Required) The name of the functionality.
 * `description` - (Optional) A description of the functionality.
 * `service_ids` - (Optional) A set of IDs of the services this functionality is associated with.
-  This value _must not_ be provided if `services` is provided.
-* `services` - **Deprecated** Use `service_ids` instead. The services this functionality is associated with. 
-  This value _must not_ be provided if `service_ids` is provided.
 
 **Deprecated** The `services` block supports:
 
@@ -52,10 +48,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the functionality.
-
-**Deprecated** The `services` block contains:
-
-* `id` - The ID of the service.
 
 ## Import
 

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -59,6 +59,7 @@ type Client interface {
 	Ping(ctx context.Context) (*PingResponse, error)
 
 	Environments() EnvironmentsClient
+	Functionalities() FunctionalitiesClient
 	IncidentRoles() IncidentRolesClient
 	Priorities() PrioritiesClient
 	Runbooks() RunbooksClient
@@ -67,12 +68,6 @@ type Client interface {
 	Services() ServicesClient
 	Severities() SeveritiesClient
 	TaskLists() TaskListsClient
-
-	// Functionalities
-	GetFunctionality(ctx context.Context, id string) (*FunctionalityResponse, error)
-	CreateFunctionality(ctx context.Context, req CreateFunctionalityRequest) (*FunctionalityResponse, error)
-	UpdateFunctionality(ctx context.Context, id string, req UpdateFunctionalityRequest) (*FunctionalityResponse, error)
-	DeleteFunctionality(ctx context.Context, id string) error
 
 	// Teams
 	GetTeam(ctx context.Context, id string) (*TeamResponse, error)
@@ -143,6 +138,11 @@ func (c *APIClient) Environments() EnvironmentsClient {
 	return &RESTEnvironmentsClient{client: c}
 }
 
+// Functionalities returns a FunctionalitiesClient interface for interacting with functionalities in FireHydrant
+func (c *APIClient) Functionalities() FunctionalitiesClient {
+	return &RESTFunctionalitiesClient{client: c}
+}
+
 // IncidentRoles returns a IncidentRolesClient interface for interacting with incident roles in FireHydrant
 func (c *APIClient) IncidentRoles() IncidentRolesClient {
 	return &RESTIncidentRolesClient{client: c}
@@ -181,73 +181,6 @@ func (c *APIClient) Severities() SeveritiesClient {
 // TaskLists returns a TaskListsClient interface for interacting with task lists in FireHydrant
 func (c *APIClient) TaskLists() TaskListsClient {
 	return &RESTTaskListsClient{client: c}
-}
-
-// GetFunctionality retrieves a functionality from FireHydrant
-func (c *APIClient) GetFunctionality(ctx context.Context, id string) (*FunctionalityResponse, error) {
-	funcResponse := &FunctionalityResponse{}
-	apiError := &APIError{}
-	response, err := c.client().Get("functionalities/"+id).Receive(funcResponse, apiError)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get functionality")
-	}
-
-	err = checkResponseStatusCode(response, apiError)
-	if err != nil {
-		return nil, err
-	}
-
-	return funcResponse, nil
-}
-
-// CreateFunctionality creates a functionality in FireHydrant
-func (c *APIClient) CreateFunctionality(ctx context.Context, req CreateFunctionalityRequest) (*FunctionalityResponse, error) {
-	funcResponse := &FunctionalityResponse{}
-	apiError := &APIError{}
-	response, err := c.client().Post("functionalities").BodyJSON(&req).Receive(funcResponse, apiError)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create functionality")
-	}
-
-	err = checkResponseStatusCode(response, apiError)
-	if err != nil {
-		return nil, err
-	}
-
-	return funcResponse, nil
-}
-
-// UpdateFunctionality updates a functionality in FireHydrant
-func (c *APIClient) UpdateFunctionality(ctx context.Context, id string, req UpdateFunctionalityRequest) (*FunctionalityResponse, error) {
-	funcResponse := &FunctionalityResponse{}
-	apiError := &APIError{}
-	response, err := c.client().Patch("functionalities/"+id).BodyJSON(&req).Receive(funcResponse, apiError)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not update functionality")
-	}
-
-	err = checkResponseStatusCode(response, apiError)
-	if err != nil {
-		return nil, err
-	}
-
-	return funcResponse, nil
-}
-
-// DeleteFunctionality deletes a functionality from FireHydrant
-func (c *APIClient) DeleteFunctionality(ctx context.Context, id string) error {
-	apiError := &APIError{}
-	response, err := c.client().Delete("functionalities/"+id).Receive(nil, apiError)
-	if err != nil {
-		return errors.Wrap(err, "could not delete functionality")
-	}
-
-	err = checkResponseStatusCode(response, apiError)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // GetTeam retrieves a team from FireHydrant

--- a/firehydrant/functionalities.go
+++ b/firehydrant/functionalities.go
@@ -1,0 +1,129 @@
+package firehydrant
+
+import (
+	"context"
+	"time"
+
+	"github.com/dghubble/sling"
+	"github.com/pkg/errors"
+)
+
+// FunctionalitiesClient is an interface for interacting with task lists on FireHydrant
+type FunctionalitiesClient interface {
+	Get(ctx context.Context, id string) (*FunctionalityResponse, error)
+	Create(ctx context.Context, createReq CreateFunctionalityRequest) (*FunctionalityResponse, error)
+	Update(ctx context.Context, id string, updateReq UpdateFunctionalityRequest) (*FunctionalityResponse, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// RESTFunctionalitiesClient implements the FunctionalitiesClient interface
+type RESTFunctionalitiesClient struct {
+	client *APIClient
+}
+
+var _ FunctionalitiesClient = &RESTFunctionalitiesClient{}
+
+func (c *RESTFunctionalitiesClient) restClient() *sling.Sling {
+	return c.client.client()
+}
+
+// FunctionalityResponse is the payload for a single environment
+// URL: GET https://api.firehydrant.io/v1/functionalities/{id}
+type FunctionalityResponse struct {
+	ID          string                 `json:"id"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Slug        string                 `json:"slug"`
+	Services    []FunctionalityService `json:"services"`
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   time.Time              `json:"updated_at"`
+}
+
+// FunctionalityService represents a service when creating a functionality
+type FunctionalityService struct {
+	ID string `json:"id"`
+}
+
+// Get retrieves a functionality from FireHydrant
+func (c *RESTFunctionalitiesClient) Get(ctx context.Context, id string) (*FunctionalityResponse, error) {
+	funcResponse := &FunctionalityResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Get("functionalities/"+id).Receive(funcResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get functionality")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return funcResponse, nil
+}
+
+// CreateFunctionalityRequest is the payload for creating a service
+// URL: POST https://api.firehydrant.io/v1/services
+type CreateFunctionalityRequest struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Services    []FunctionalityService `json:"services,omitempty"`
+}
+
+// Create creates a functionality in FireHydrant
+func (c *RESTFunctionalitiesClient) Create(ctx context.Context, req CreateFunctionalityRequest) (*FunctionalityResponse, error) {
+	funcResponse := &FunctionalityResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Post("functionalities").BodyJSON(&req).Receive(funcResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create functionality")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return funcResponse, nil
+}
+
+// UpdateFunctionalityRequest is the payload for updating a environment
+// URL: PATCH https://api.firehydrant.io/v1/environments/{id}
+type UpdateFunctionalityRequest struct {
+	Name                    string                 `json:"name,omitempty"`
+	Description             string                 `json:"description"`
+	RemoveRemainingServices bool                   `json:"remove_remaining_services"`
+	Services                []FunctionalityService `json:"services"`
+}
+
+// Update updates a functionality in FireHydrant
+func (c *RESTFunctionalitiesClient) Update(ctx context.Context, id string, req UpdateFunctionalityRequest) (*FunctionalityResponse, error) {
+	funcResponse := &FunctionalityResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Patch("functionalities/"+id).BodyJSON(&req).Receive(funcResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not update functionality")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return funcResponse, nil
+}
+
+// Delete deletes a functionality from FireHydrant
+func (c *RESTFunctionalitiesClient) Delete(ctx context.Context, id string) error {
+	apiError := &APIError{}
+	response, err := c.restClient().Delete("functionalities/"+id).Receive(nil, apiError)
+	if err != nil {
+		return errors.Wrap(err, "could not delete functionality")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -136,40 +136,6 @@ type ServicesResponse struct {
 	Services []ServiceResponse `json:"data"`
 }
 
-// FunctionalityResponse is the payload for a single environment
-// URL: GET https://api.firehydrant.io/v1/functionalities/{id}
-type FunctionalityResponse struct {
-	ID          string            `json:"id"`
-	Name        string            `json:"name"`
-	Description string            `json:"description"`
-	Slug        string            `json:"slug"`
-	Services    []ServiceResponse `json:"services"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
-}
-
-// CreateFunctionalityRequest is the payload for creating a service
-// URL: POST https://api.firehydrant.io/v1/services
-type CreateFunctionalityRequest struct {
-	Name        string                 `json:"name"`
-	Description string                 `json:"description"`
-	Services    []FunctionalityService `json:"services,omitempty"`
-}
-
-// FunctionalityService represents a service when creating a functionality
-type FunctionalityService struct {
-	ID string `json:"id"`
-}
-
-// UpdateFunctionalityRequest is the payload for updating a environment
-// URL: PATCH https://api.firehydrant.io/v1/environments/{id}
-type UpdateFunctionalityRequest struct {
-	Name                    string                 `json:"name,omitempty"`
-	Description             string                 `json:"description"`
-	RemoveRemainingServices bool                   `json:"remove_remaining_services"`
-	Services                []FunctionalityService `json:"services"`
-}
-
 // TeamResponse is the payload for a single environment
 // URL: GET https://api.firehydrant.io/v1/teams/{id}
 type TeamResponse struct {

--- a/provider/functionality_resource.go
+++ b/provider/functionality_resource.go
@@ -34,29 +34,10 @@ func resourceFunctionality() *schema.Resource {
 				Optional: true,
 			},
 			"service_ids": {
-				Type:          schema.TypeSet,
-				ConflictsWith: []string{"services"},
-				Optional:      true,
+				Type:     schema.TypeSet,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
-				},
-			},
-			"services": {
-				Type:          schema.TypeList,
-				ConflictsWith: []string{"service_ids"},
-				Deprecated:    "Use service_ids instead. The services attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/firehydrant/terraform-provider-firehydrant/blob/v0.2.0/CHANGELOG.md",
-				Optional:      true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
 				},
 			},
 		},
@@ -90,38 +71,16 @@ func readResourceFireHydrantFunctionality(ctx context.Context, d *schema.Resourc
 		"description": functionalityResponse.Description,
 	}
 
+	serviceIDs := make([]string, 0)
+	for _, service := range functionalityResponse.Services {
+		serviceIDs = append(serviceIDs, service.ID)
+	}
+	attributes["service_ids"] = serviceIDs
+
 	// Set the resource attributes to the values we got from the API
 	for key, value := range attributes {
 		if err := d.Set(key, value); err != nil {
 			return diag.Errorf("Error setting %s for functionality %s: %v", key, functionalityID, err)
-		}
-	}
-
-	// TODO: refactor this once deprecated attribute is removed
-	// Update service IDs in state
-	_, servicesSet := d.GetOk("services")
-	if servicesSet {
-		// If the config is using the services attribute, update the services attribute
-		// in state with the information we got from the API
-		var services []interface{}
-		for _, service := range functionalityResponse.Services {
-			services = append(services, map[string]interface{}{
-				"id":   service.ID,
-				"name": service.Name,
-			})
-		}
-		if err := d.Set("services", services); err != nil {
-			return diag.FromErr(err)
-		}
-	} else {
-		// Otherwise, default to the preferred service_ids attribute and update the
-		// service_ids attribute in state with the information we got from the API
-		serviceIDs := make([]string, 0)
-		for _, service := range functionalityResponse.Services {
-			serviceIDs = append(serviceIDs, service.ID)
-		}
-		if err := d.Set("service_ids", serviceIDs); err != nil {
-			return diag.FromErr(err)
 		}
 	}
 
@@ -139,30 +98,12 @@ func createResourceFireHydrantFunctionality(ctx context.Context, d *schema.Resou
 	}
 
 	// Process any optional attributes and add to the create request if necessary
-	// TODO: refactor this once deprecated attribute is removed
-	// Add service IDs to the create request
-	services, servicesSet := d.GetOk("services")
-	serviceIDs, serviceIDsSet := d.GetOk("service_ids")
-	if servicesSet {
-		// If the services attribute is set, use the service IDs from that attribute
-		// to set the service IDs for the create functionality request
-		for _, service := range services.([]interface{}) {
-			serviceAttributes := service.(map[string]interface{})
-			createRequest.Services = append(createRequest.Services, firehydrant.FunctionalityService{
-				ID: serviceAttributes["id"].(string),
-			})
-		}
-	} else if serviceIDsSet {
-		// If the service_ids attribute is set, use the service IDs from that attribute
-		// to set the service IDs for the create functionality request
-		for _, serviceID := range serviceIDs.(*schema.Set).List() {
-			createRequest.Services = append(createRequest.Services, firehydrant.FunctionalityService{
-				ID: serviceID.(string),
-			})
-		}
+	serviceIDs := d.Get("service_ids")
+	for _, serviceID := range serviceIDs.(*schema.Set).List() {
+		createRequest.Services = append(createRequest.Services, firehydrant.FunctionalityService{
+			ID: serviceID.(string),
+		})
 	}
-	// Otherwise, don't send any service IDs in the create functionality request,
-	// which will create a functionality with no services
 
 	// Create the new functionality
 	tflog.Debug(ctx, fmt.Sprintf("Create functionality: %s", createRequest.Name), map[string]interface{}{
@@ -191,35 +132,16 @@ func updateResourceFireHydrantFunctionality(ctx context.Context, d *schema.Resou
 	}
 
 	// Process any optional attributes and add to the update request if necessary
-	// TODO: refactor this once deprecated attribute is removed
-	// Add service IDs to the update request
-	services, servicesSet := d.GetOk("services")
-	serviceIDs, serviceIDsSet := d.GetOk("service_ids")
-	updatedServices := make([]firehydrant.FunctionalityService, 0)
-	if servicesSet {
-		// If the services attribute is set, use the service IDs from that attribute
-		// to populate the list of service IDs for the update functionality request
-		for _, service := range services.([]interface{}) {
-			serviceAttributes := service.(map[string]interface{})
-			updatedServices = append(updatedServices, firehydrant.FunctionalityService{
-				ID: serviceAttributes["id"].(string),
-			})
-		}
-	} else if serviceIDsSet {
-		// If the service_ids attribute is set, use the service IDs from that attribute
-		// to populate the list of for service IDs for the update functionality request
-		for _, serviceID := range serviceIDs.(*schema.Set).List() {
-			updatedServices = append(updatedServices, firehydrant.FunctionalityService{
-				ID: serviceID.(string),
-			})
-		}
+	serviceIDs := d.Get("service_ids")
+	for _, serviceID := range serviceIDs.(*schema.Set).List() {
+		updateRequest.Services = append(updateRequest.Services, firehydrant.FunctionalityService{
+			ID: serviceID.(string),
+		})
 	}
 	// Otherwise, neither attribute is set, so updatedServiceIDs remains empty,
 	// which will allow us to remove services from a functionality if either attribute
 	// has been removed from the config
 
-	// Set the service IDs for the update functionality request
-	updateRequest.Services = updatedServices
 	// This will force the update request to replace the services with the ones we send
 	updateRequest.RemoveRemainingServices = true
 

--- a/provider/functionality_resource_test.go
+++ b/provider/functionality_resource_test.go
@@ -28,7 +28,7 @@ func TestAccFunctionalityResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "services.#", "0"),
+					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "service_ids.#", "0"),
 				),
 			},
 		},
@@ -51,7 +51,8 @@ func TestAccFunctionalityResource_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "services.#", "0"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_functionality.test_functionality", "service_ids.#", "0"),
 				),
 			},
 			{
@@ -63,10 +64,8 @@ func TestAccFunctionalityResource_update(t *testing.T) {
 						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_functionality.test_functionality", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "services.#", "1"),
-					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "services.0.id"),
 					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "services.0.name", fmt.Sprintf("test-service-%s", rNameUpdated)),
+						"firehydrant_functionality.test_functionality", "service_ids.#", "2"),
 				),
 			},
 			{
@@ -76,137 +75,8 @@ func TestAccFunctionalityResource_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "services.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFunctionalityResource_basicServiceIDs(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testFireHydrantIsSetup(t) },
-		ProviderFactories: defaultProviderFactories(),
-		CheckDestroy:      testAccCheckFunctionalityResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFunctionalityResourceConfig_basicServiceIDs(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckFunctionalityResourceExistsWithAttributes_basicServiceIDs("firehydrant_functionality.test_functionality"),
-					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
 					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "service_ids.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFunctionalityResource_updateServiceIDs(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testFireHydrantIsSetup(t) },
-		ProviderFactories: defaultProviderFactories(),
-		CheckDestroy:      testAccCheckFunctionalityResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFunctionalityResourceConfig_basicServiceIDs(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckFunctionalityResourceExistsWithAttributes_basicServiceIDs("firehydrant_functionality.test_functionality"),
-					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "service_ids.#", "1"),
-				),
-			},
-			{
-				Config: testAccFunctionalityResourceConfig_updateServiceIDs(rNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFunctionalityResourceExistsWithAttributes_updateServiceIDs("firehydrant_functionality.test_functionality"),
-					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "service_ids.#", "2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFunctionalityResource_updateServicesToServiceIDs(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testFireHydrantIsSetup(t) },
-		ProviderFactories: defaultProviderFactories(),
-		CheckDestroy:      testAccCheckFunctionalityResourceDestroy(),
-		Steps: []resource.TestStep{
-			// Start with a config that has services
-			{
-				Config: testAccFunctionalityResourceConfig_basicServices(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckFunctionalityResourceExistsWithAttributes_basicServices("firehydrant_functionality.test_functionality"),
-					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "services.#", "1"),
-				),
-			},
-			// Update the config by changing services to service_ids
-			{
-				Config: testAccFunctionalityResourceConfig_basicServiceIDs(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckFunctionalityResourceExistsWithAttributes_basicServiceIDs("firehydrant_functionality.test_functionality"),
-					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rName)),
-					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "service_ids.#", "1"),
-				),
-			},
-			// Update the config by adding a new service id to service_ids
-			{
-				Config: testAccFunctionalityResourceConfig_updateServiceIDs(rNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFunctionalityResourceExistsWithAttributes_updateServiceIDs("firehydrant_functionality.test_functionality"),
-					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "service_ids.#", "2"),
-				),
-			},
-			// Update the config by removing a service id from service_ids
-			{
-				Config: testAccFunctionalityResourceConfig_basicServiceIDs(rNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFunctionalityResourceExistsWithAttributes_basicServiceIDs("firehydrant_functionality.test_functionality"),
-					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "service_ids.#", "1"),
-				),
-			},
-			// Update the config by removing service_ids
-			{
-				Config: testAccFunctionalityResourceConfig_basic(rNameUpdated),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckFunctionalityResourceExistsWithAttributes_basic("firehydrant_functionality.test_functionality"),
-					resource.TestCheckResourceAttrSet("firehydrant_functionality.test_functionality", "id"),
-					resource.TestCheckResourceAttr(
-						"firehydrant_functionality.test_functionality", "name", fmt.Sprintf("test-functionality-%s", rNameUpdated)),
-					resource.TestCheckResourceAttr("firehydrant_functionality.test_functionality", "service_ids.#", "0"),
+						"firehydrant_functionality.test_functionality", "service_ids.#", "0"),
 				),
 			},
 		},
@@ -233,7 +103,7 @@ func TestAccFunctionalityResourceImport_basic(t *testing.T) {
 	})
 }
 
-func TestAccFunctionalityResourceImport_services(t *testing.T) {
+func TestAccFunctionalityResourceImport_allAttributes(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
@@ -241,28 +111,7 @@ func TestAccFunctionalityResourceImport_services(t *testing.T) {
 		ProviderFactories: defaultProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionalityResourceConfig_basicServices(rName),
-			},
-
-			{
-				ResourceName:            "firehydrant_functionality.test_functionality",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"services", "service_ids"},
-			},
-		},
-	})
-}
-
-func TestAccFunctionalityResourceImport_serviceIDs(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testFireHydrantIsSetup(t) },
-		ProviderFactories: defaultProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFunctionalityResourceConfig_basicServiceIDs(rName),
+				Config: testAccFunctionalityResourceConfig_update(rName),
 			},
 
 			{
@@ -304,7 +153,7 @@ func testAccCheckFunctionalityResourceExistsWithAttributes_basic(resourceName st
 		}
 
 		if len(functionalityResponse.Services) != 0 {
-			return fmt.Errorf("Unexpected number of services. Expected no services, got: %v", len(functionalityResponse.Services))
+			return fmt.Errorf("Unexpected number of service_ids. Expected no service_ids, got: %v", len(functionalityResponse.Services))
 		}
 
 		return nil
@@ -342,123 +191,8 @@ func testAccCheckFunctionalityResourceExistsWithAttributes_update(resourceName s
 		}
 
 		// TODO: Check the service ids
-		if len(functionalityResponse.Services) != 1 {
-			return fmt.Errorf("Unexpected number of services. Expected: 1, got: %v", len(functionalityResponse.Services))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckFunctionalityResourceExistsWithAttributes_basicServices(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		functionalityResource, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		if functionalityResource.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
-		if err != nil {
-			return err
-		}
-
-		functionalityResponse, err := client.Functionalities().Get(context.TODO(), functionalityResource.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		expected, got := functionalityResource.Primary.Attributes["name"], functionalityResponse.Name
-		if expected != got {
-			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
-		}
-
-		if functionalityResponse.Description != "" {
-			return fmt.Errorf("Unexpected description. Expected no description, got: %s", functionalityResponse.Description)
-		}
-
-		// TODO: Check the service ids
-		if len(functionalityResponse.Services) != 1 {
-			return fmt.Errorf("Unexpected number of services. Expected: 1, got: %v", len(functionalityResponse.Services))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckFunctionalityResourceExistsWithAttributes_basicServiceIDs(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		functionalityResource, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		if functionalityResource.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
-		if err != nil {
-			return err
-		}
-
-		functionalityResponse, err := client.Functionalities().Get(context.TODO(), functionalityResource.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		expected, got := functionalityResource.Primary.Attributes["name"], functionalityResponse.Name
-		if expected != got {
-			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
-		}
-
-		if functionalityResponse.Description != "" {
-			return fmt.Errorf("Unexpected description. Expected no description, got: %s", functionalityResponse.Description)
-		}
-
-		// TODO: Check the service ids
-		if len(functionalityResponse.Services) != 1 {
-			return fmt.Errorf("Unexpected number of services. Expected: 1, got: %v", len(functionalityResponse.Services))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckFunctionalityResourceExistsWithAttributes_updateServiceIDs(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		functionalityResource, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		if functionalityResource.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
-		if err != nil {
-			return err
-		}
-
-		functionalityResponse, err := client.Functionalities().Get(context.TODO(), functionalityResource.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		expected, got := functionalityResource.Primary.Attributes["name"], functionalityResponse.Name
-		if expected != got {
-			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
-		}
-
-		expected, got = functionalityResource.Primary.Attributes["description"], functionalityResponse.Description
-		if expected != got {
-			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
-		}
-
-		// TODO: Check the service ids
 		if len(functionalityResponse.Services) != 2 {
-			return fmt.Errorf("Unexpected number of services. Expected: 1, got: %v", len(functionalityResponse.Services))
+			return fmt.Errorf("Unexpected number of service_ids. Expected: 2, got: %v", len(functionalityResponse.Services))
 		}
 
 		return nil
@@ -500,35 +234,6 @@ resource "firehydrant_functionality" "test_functionality" {
 
 func testAccFunctionalityResourceConfig_update(rName string) string {
 	return fmt.Sprintf(`
-resource "firehydrant_service" "test_service" {
-  name = "test-service-%s"
-}
-
-resource "firehydrant_functionality" "test_functionality" {
-  name        = "test-functionality-%s"
-  description = "test-description-%s"
-
-  services {
-    id = firehydrant_service.test_service.id
-  }
-}`, rName, rName, rName)
-}
-
-func testAccFunctionalityResourceConfig_basicServiceIDs(rName string) string {
-	return fmt.Sprintf(`
-resource "firehydrant_service" "test_service1" {
-  name = "test-service1-%s"
-}
-
-resource "firehydrant_functionality" "test_functionality" {
-  name = "test-functionality-%s"
-
-  service_ids = [firehydrant_service.test_service1.id]
-}`, rName, rName)
-}
-
-func testAccFunctionalityResourceConfig_updateServiceIDs(rName string) string {
-	return fmt.Sprintf(`
 resource "firehydrant_service" "test_service1" {
   name = "test-service1-%s"
 }
@@ -546,19 +251,4 @@ resource "firehydrant_functionality" "test_functionality" {
     firehydrant_service.test_service2.id
   ]
 }`, rName, rName, rName, rName)
-}
-
-func testAccFunctionalityResourceConfig_basicServices(rName string) string {
-	return fmt.Sprintf(`
-resource "firehydrant_service" "test_service1" {
-  name = "test-service1-%s"
-}
-
-resource "firehydrant_functionality" "test_functionality" {
-  name = "test-functionality-%s"
-
-  services {
-    id = firehydrant_service.test_service1.id
-  }
-}`, rName, rName)
 }

--- a/provider/functionality_resource_test.go
+++ b/provider/functionality_resource_test.go
@@ -289,7 +289,7 @@ func testAccCheckFunctionalityResourceExistsWithAttributes_basic(resourceName st
 			return err
 		}
 
-		functionalityResponse, err := client.GetFunctionality(context.TODO(), functionalityResource.Primary.ID)
+		functionalityResponse, err := client.Functionalities().Get(context.TODO(), functionalityResource.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -326,7 +326,7 @@ func testAccCheckFunctionalityResourceExistsWithAttributes_update(resourceName s
 			return err
 		}
 
-		functionalityResponse, err := client.GetFunctionality(context.TODO(), functionalityResource.Primary.ID)
+		functionalityResponse, err := client.Functionalities().Get(context.TODO(), functionalityResource.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -365,7 +365,7 @@ func testAccCheckFunctionalityResourceExistsWithAttributes_basicServices(resourc
 			return err
 		}
 
-		functionalityResponse, err := client.GetFunctionality(context.TODO(), functionalityResource.Primary.ID)
+		functionalityResponse, err := client.Functionalities().Get(context.TODO(), functionalityResource.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -403,7 +403,7 @@ func testAccCheckFunctionalityResourceExistsWithAttributes_basicServiceIDs(resou
 			return err
 		}
 
-		functionalityResponse, err := client.GetFunctionality(context.TODO(), functionalityResource.Primary.ID)
+		functionalityResponse, err := client.Functionalities().Get(context.TODO(), functionalityResource.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -441,7 +441,7 @@ func testAccCheckFunctionalityResourceExistsWithAttributes_updateServiceIDs(reso
 			return err
 		}
 
-		functionalityResponse, err := client.GetFunctionality(context.TODO(), functionalityResource.Primary.ID)
+		functionalityResponse, err := client.Functionalities().Get(context.TODO(), functionalityResource.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -481,7 +481,7 @@ func testAccCheckFunctionalityResourceDestroy() resource.TestCheckFunc {
 				return fmt.Errorf("No instance ID is set")
 			}
 
-			_, err := client.GetFunctionality(context.TODO(), functionalityResource.Primary.ID)
+			_, err := client.Functionalities().Get(context.TODO(), functionalityResource.Primary.ID)
 			if err == nil {
 				return fmt.Errorf("Functionality %s still exists", functionalityResource.Primary.ID)
 			}


### PR DESCRIPTION
## Description

This PR does the following:
1. Refactors the functionality API client logic into its own file
1. Adds logging for functionalities
1. Removes the deprecated `services` attribute in favor of `service_ids`

## Testing plan

Look at the new log output and see if it makes sense, has any typos, etc. [Documentation on managing log output and the various levels available are here](https://www.terraform.io/plugin/log/managing). TF_LOG_PROVIDER_FIREHYDRANT is not available at this time because we haven't implemented it but TF_LOG and TF_LOG_PROVIDER should work. Feel free to try different log levels if you'd like. 

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9213250/terraform-func-config.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a functionality. Then take the ID of your functionality and replace the placeholder in the config with it. 

#### Provision resources and data sources:
1. Run `TF_LOG_PROVIDER=DEBUG terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `TF_LOG_PROVIDER=DEBUG terraform plan`. There should be no changes.

#### Make sure updating description works
1. Update your config by changing the description on your functionality.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Update your config again by removing the description from your functionality..
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure updating service_ids works
1. Update your config by adding a new service id to the list of service_ids on your functionality.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.
1. Update your config again by removing the service_ids from your functionality.
1. Run `terraform apply`. This should succeed and you should see your updates reflected in the UI and statefile.
1. Run `terraform plan`. You should see no changes.

#### Make sure destroy still works
1. Run `TF_LOG_PROVIDER=DEBUG terraform destroy`. This should succeed. 

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/22d58342a9149-create-a-functionality)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.