### PR TITLE
Add logging to the rest of the provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,14 +38,18 @@ ENHANCEMENTS:
 * resource/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))
 * resource/runbook: Added default value of `false` to the steps `automatic` attribute ([#83](https://github.com/firehydrant/terraform-provider-firehydrant/pull/83))
 * resource/runbook: Added the `rule` attribute to runbook steps ([#84](https://github.com/firehydrant/terraform-provider-firehydrant/pull/84))
+* resource/service: Added logging ([#96](https://github.com/firehydrant/terraform-provider-firehydrant/pull/96))
 * resource/severity: Added logging to the resource and validation to the `slug` attribute ([#88](https://github.com/firehydrant/terraform-provider-firehydrant/pull/88))
 * resource/severity: Added support for the `type` attribute ([#88](https://github.com/firehydrant/terraform-provider-firehydrant/pull/88))
+* resource/team: Added logging ([#96](https://github.com/firehydrant/terraform-provider-firehydrant/pull/96))
 * data_source/environment: Added logging ([#93](https://github.com/firehydrant/terraform-provider-firehydrant/pull/93))
 * data_source/functionality: Added logging ([#94](https://github.com/firehydrant/terraform-provider-firehydrant/pull/94))
 * data_source/runbook: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
 * data_source/runbook: Added the `owner_id` attribute to runbook ([#76](https://github.com/firehydrant/terraform-provider-firehydrant/pull/76))
 * data_source/runbook: Added the `attachment_rule` attribute to runbook ([#82](https://github.com/firehydrant/terraform-provider-firehydrant/pull/82))
 * data_source/runbook_action: Added logging ([#74](https://github.com/firehydrant/terraform-provider-firehydrant/pull/74))
+* data_source/service: Added logging ([#96](https://github.com/firehydrant/terraform-provider-firehydrant/pull/96))
+* data_source/services: Added logging ([#96](https://github.com/firehydrant/terraform-provider-firehydrant/pull/96))
 
 ## 0.2.1
 

--- a/provider/service_data.go
+++ b/provider/service_data.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -78,9 +80,12 @@ func dataFireHydrantService(ctx context.Context, d *schema.ResourceData, m inter
 
 	// Get the service
 	serviceID := d.Get("id").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Read service: %s", serviceID), map[string]interface{}{
+		"id": serviceID,
+	})
 	serviceResponse, err := firehydrantAPIClient.Services().Get(ctx, serviceID)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("Error reading service %s: %v", serviceID, err)
 	}
 
 	// Set values in state
@@ -115,7 +120,7 @@ func dataFireHydrantService(ctx context.Context, d *schema.ResourceData, m inter
 	// Set the data source attributes to the values we got from the API
 	for key, value := range attributes {
 		if err := d.Set(key, value); err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("Error setting %s for service %s: %v", key, serviceID, err)
 		}
 	}
 

--- a/provider/services_data.go
+++ b/provider/services_data.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -44,12 +46,16 @@ func dataFireHydrantServices(ctx context.Context, d *schema.ResourceData, m inte
 	for key, value := range labels {
 		labelsSelector[key] = value.(string)
 	}
+	tflog.Debug(ctx, fmt.Sprintf("Read services"), map[string]interface{}{
+		"query":  query,
+		"labels": labels,
+	})
 	servicesResponse, err := firehydrantAPIClient.Services().List(ctx, &firehydrant.ServiceQuery{
 		Query:          query,
 		LabelsSelector: labelsSelector,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("Error reading services: %v", err)
 	}
 
 	// Set the data source attributes to the values we got from the API
@@ -87,7 +93,7 @@ func dataFireHydrantServices(ctx context.Context, d *schema.ResourceData, m inte
 		services = append(services, attributes)
 	}
 	if err := d.Set("services", services); err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("Error setting services: %v", err)
 	}
 
 	d.SetId("does-not-matter")


### PR DESCRIPTION
## Description

This PR adds logging and more detailed error messages to the rest of the provider, specifically d/service, d/services, r/service and r/team. This follows the format [documented here](https://www.terraform.io/plugin/log/writing). This should not change the overall behavior of these resources and data sources.

fixes #53 

## Testing plan

Look at the new log output and see if it makes sense, has any typos, etc. [Documentation on managing log output and the various levels available are here](https://www.terraform.io/plugin/log/managing). TF_LOG_PROVIDER_FIREHYDRANT is not available at this time because we haven't implemented it but TF_LOG and TF_LOG_PROVIDER should work. Feel free to try different log levels if you'd like. 

Pre-requisites:
- You'll need Go 1.16 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Create another new directory (all Terraform commands will be run in this directory)
1.  [Download and save this file](https://github.com/firehydrant/terraform-provider-firehydrant/files/9213377/terraform-logging-config.txt) as `main.tf` in your new directory. You'll be modifying it in the steps below. 
1. In you FH org, create a service. Then take the id of your rservice and replace the placeholder in the config with it.

#### Make sure things still work and logs makes sense for the happy path:
1. Run `TF_LOG_PROVIDER=DEBUG terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `TF_LOG_PROVIDER=DEBUG terraform plan`. There should be no changes.
1. Run `TF_LOG_PROVIDER=DEBUG terraform destroy`. This should succeed. 

#### Try to create some errors to see if the logs make sense
1. Update your config to try and create an error. This could be something like providing an invalid attribute in your data sources and resources, creating things with the same name that should be unique, etc.
1. Run `TF_LOG_PROVIDER=DEBUG terraform apply` and check out the logs you get.
1. Repeat but with different invalid attributes. 

## Related links

- [Writing logs](https://www.terraform.io/plugin/log/writing)
- [Managing logs](https://www.terraform.io/plugin/log/managing)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.