### PR TITLE
Add issue templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,74 @@
+---
+name: Bug report
+about: Let us know about an unexpected error, a crash, or an incorrect behavior.
+labels: bug, new
+
+---
+
+<!--
+Thank you for opening an issue! Please note that we try to keep this issue tracker reserved for bug reports 
+and feature requests for the FireHydrant provider. For issues related to the FireHydrant platform, please 
+visit [FireHydrant Support](https://support.firehydrant.com/hc/en-us).
+-->
+
+### Terraform Version
+<!---
+Run `terraform version` to show the version, and paste the result between the ``` marks below.
+If you are not running the latest version of Terraform, please try upgrading because your 
+issue may have already been fixed.
+-->
+
+```
+...
+```
+
+### Terraform Configuration Files
+<!--
+Paste the relevant parts of your Terraform configuration between the ``` marks below.
+-->
+
+```terraform
+...
+```
+
+### Debug Output
+<!--
+Full debug output can be obtained by running Terraform with the environment variable `TF_LOG=trace`. 
+Please create a GitHub Gist containing the debug output. Please do _not_ paste the debug output in 
+the issue, since debug output is long.
+
+Debug output may contain sensitive information. Please review it before posting publicly.
+-->
+
+### Expected Behavior
+<!--
+What should have happened?
+-->
+
+### Actual Behavior
+<!--
+What actually happened?
+-->
+
+### Steps to Reproduce
+<!--
+Please list the full steps required to reproduce the issue.
+-->
+
+1. _Describe how to replicate the conditions_
+1. _under which you experienced your issue_
+1. _including example Terraform configs where necessary._
+
+### Additional Context
+<!--
+Is there anything atypical about your situation that we should know? For example: 
+is Terraform running in a wrapper script or in a CI system? Are you passing any 
+unusual command line options or environment variables to opt-in to non-default behavior?
+-->
+
+### References
+<!--
+Are there any other GitHub issues (open or closed) or pull requests that should be linked here?
+For example:
+- #6017
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: FireHydrant Support
+    url: https://support.firehydrant.com/hc/en-us
+    about: For issues and feature requests related to the FireHydrant platform, please visit FireHydrant Support.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,43 @@
+---
+name: Feature request
+about: Suggest a new feature or other enhancement.
+labels: enhancement, new
+
+---
+
+<!--
+Thank you for opening an issue! Please note that we try to keep this issue tracker reserved for bug reports 
+and feature requests for the FireHydrant provider. For issues related to the FireHydrant platform, please 
+visit [FireHydrant Support](https://support.firehydrant.com/hc/en-us).
+-->
+
+### Use-cases
+<!---
+In order to properly evaluate a feature request, it is necessary to understand the use-cases for it.
+Please describe below the _end goal_ you are trying to achieve that has led you to request this feature.
+Please keep this section focused on the problem and not on the suggested solution. We'll get to that in a moment, below!
+-->
+
+### Attempted Solutions
+<!---
+If you've already tried to solve the problem with existing features and found a limitation that prevented you from succeeding, 
+please describe it below in as much detail as possible.
+Ideally, this would include real configuration snippets that you tried, real Terraform command lines you ran, and what 
+results you got in each case.
+Please remove any sensitive information such as passwords before sharing configuration snippets and command lines.
+--->
+
+### Proposal
+<!---
+If you have an idea for a way to address the problem via a change to this provider, please describe it below.
+In this section, it's helpful to include specific examples of how what you are suggesting might look in configuration files, 
+or on the command line, since that allows us to understand the full picture of what you are proposing.
+If you're not sure of some details, don't worry! When we evaluate the feature request, we'll be able to help.
+-->
+
+### References
+<!--
+Are there any other GitHub issues (open or closed) or pull requests that should be linked here?
+For example:
+- #6017
+-->


### PR DESCRIPTION
## Description

This PR adds issue templates for bugs and feature requests, modeled after [the issue templates in the Terraform core repo](https://github.com/hashicorp/terraform/tree/main/.github/ISSUE_TEMPLATE). 

Fixes #43 

## Testing plan

Check the template for any typos or things that don't make sense.

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.