### PR TITLE
Configure goreleaser to skip invalid windows/arm64 combo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
## Description

This PR configures goreleaser to skip the invalid windows/arm64 GOOS/GOARCH pair. These are supposed to be skipped by goreleaser automatically but the windows/arm64 skipping was recently removed https://goreleaser.com/deprecations/#builds-for-windowsarm64

## Related links

- [Related PR](https://github.com/firehydrant/firehydrant/pull/99)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.