### PR TITLE
Fix broken links in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.3.1 (Unreleased)
 
+BUG FIXES:
+
+* documentation: Fixed broken links in runbook resource documentation ([#101](https://github.com/firehydrant/terraform-provider-firehydrant/pull/101))
+
 ## 0.3.0
 
 BREAKING CHANGES:

--- a/docs/guides/runbooks_steps.md
+++ b/docs/guides/runbooks_steps.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Step Configuration Overview"
+page_title: "Step Configuration"
 subcategory: "Runbooks"
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ terraform {
 
 # Configure the FireHydrant Provider
 provider "firehydrant" {
-  api_key              = var.firehydrant_api_key
+  api_key = var.firehydrant_api_key
 }
 
 # Configure a FireHydrant priority

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -93,7 +93,7 @@ The following arguments are supported:
   Use [Terraform's jsonencode](https://www.terraform.io/language/functions/jsonencode)
   function so that [Terraform can guarantee valid JSON syntax](https://www.terraform.io/language/expressions/strings#generating-json-or-yaml).
   For more information on the conditional logic used in `attachment_rule`, see the 
-  [Runbooks - Conditional Logic](./runbooks_conditional_logic.md) documentation.
+  [Runbooks - Conditional Logic](../guides/runbooks_conditional_logic.md) documentation.
   Defaults to attaching manually:
   ```hcl
   attachment_rule = jsonencode({
@@ -113,7 +113,7 @@ The following arguments are supported:
 The `steps` block supports:
 
 Available attributes and whether they are available and required varies depending on the specific runbook step in question.
-See [Runbook Steps Configuration documentation](../runbook_steps.md) for more detailed documentation on each step. 
+See [Runbook Steps Configuration documentation](../guides/runbook_steps.md) for more detailed documentation on each step. 
 
 * `action_id` - (Required) The ID of the runbook action for the step.
 * `name` - (Required) The name of the step.
@@ -129,7 +129,7 @@ See [Runbook Steps Configuration documentation](../runbook_steps.md) for more de
   This value _must_ be provided if `repeats` is `true`. This value _must not_ be provided if `repeats` is `false`.
 * `rule` - (Optional) JSON string representing the rule configuration for the runbook step.
   For more information on the conditional logic used in `rule`, see the
-  [Runbooks - Conditional Logic](./runbooks_conditional_logic.md) documentation.
+  [Runbooks - Conditional Logic](../guides/runbooks_conditional_logic.md)) documentation.
   The step will default to running manually if `rule` is not specified and `automatic` and `repeats` are both `false`.
 
 ## Attributes Reference

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -113,7 +113,7 @@ The following arguments are supported:
 The `steps` block supports:
 
 Available attributes and whether they are available and required varies depending on the specific runbook step in question.
-See [Runbook Steps Configuration documentation](../guides/runbook_steps.md) for more detailed documentation on each step. 
+See [Runbook Steps Configuration documentation](../guides/runbooks_steps.md) for more detailed documentation on each step. 
 
 * `action_id` - (Required) The ID of the runbook action for the step.
 * `name` - (Required) The name of the step.
@@ -129,7 +129,7 @@ See [Runbook Steps Configuration documentation](../guides/runbook_steps.md) for 
   This value _must_ be provided if `repeats` is `true`. This value _must not_ be provided if `repeats` is `false`.
 * `rule` - (Optional) JSON string representing the rule configuration for the runbook step.
   For more information on the conditional logic used in `rule`, see the
-  [Runbooks - Conditional Logic](../guides/runbooks_conditional_logic.md)) documentation.
+  [Runbooks - Conditional Logic](../guides/runbooks_conditional_logic.md) documentation.
   The step will default to running manually if `rule` is not specified and `automatic` and `repeats` are both `false`.
 
 ## Attributes Reference


### PR DESCRIPTION
## Description

This PR fixes a few broken links in the documentation

## Testing plan

1. Check that links work as expected 

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.