### PR TITLE
Prepare CHANGELOG.md for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.1 (Unreleased)
+
 ## 0.3.0
 
 BREAKING CHANGES:


### PR DESCRIPTION
## Description

This PR prepares the changelog for the next release. Now that 0.3.0 has been released, we need to prepare for the next release by adding a new "Unreleased" section to the changelog. The version used doesn't really matter as it can always be changed before the next release is actually done. 

## PR readiness 

- [ ] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [ ] An entry has been added to the changelog, if necessary.