### PR TITLE
Add documentation on running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,48 @@ OS_ARCH=darwin_amd64
 
 default: install
 
-build:
+.PHONY: install
+install: fmtcheck
+	go install
+
+.PHONY: build
+build: fmtcheck
 	go build -o ${BINARY}
 
+# Formatting
+.PHONY: fmt
+fmt:
+	echo "==> Fixing code with gofmt..."
+	gofmt -l -w ./$(NAME)
+	gofmt -l -w ./provider
+
+.PHONY: fmtcheck
+fmtcheck:
+	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+
+# Tests
+.PHONY: test
+test: fmtcheck
+	go test -v $(TEST) || exit 1
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+
+.PHONY: testacc
+testacc: fmtcheck
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 15m
+
+# Local
+.PHONY: local
+local: build
+	mkdir -p ./local/bin
+	mv ${BINARY} ./local/bin
+
+.PHONY: install_as_terraform_plugin
+install_as_terraform_plugin: build
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+
+# Release
+.PHONY: release
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
@@ -24,18 +63,3 @@ release:
 	GOOS=solaris GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_solaris_amd64
 	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
 	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
-
-local: build
-	mkdir -p ./local/bin
-	mv ${BINARY} ./local/bin
-
-install: build
-	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
-	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
-
-test:
-	go test -i $(TEST) || exit 1
-	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
-
-testacc:
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,68 @@
+# Tests
+
+Running the tests for this provider requires access to FireHydrant. Some resources or data sources
+may require access to the Enterprise tier of FireHydrant to run successfully.
+
+## 1. Set up necessary environment variables
+
+1. `FIREHYDRANT_API_KEY` - (Required) A [bot token](https://support.firehydrant.com/hc/en-us/articles/360057722832-Creating-a-Bot-User)
+   to use for testing in FireHydrant.
+2. `FIREHYDRANT_BASE_URL` - (Optional) The FireHydrant API URL to connect to for testing. 
+   Defaults to `https://api.firehydrant.io/v1/`
+
+You can set your environment variables using whatever method you'd like. 
+The following are instructions for setting up environment variables using [envchain](https://github.com/sorah/envchain).
+
+1. Make sure you have envchain installed. 
+   [Instructions for this can be found in the envchain README](https://github.com/sorah/envchain#installation).
+2. Pick a namespace for storing your environment variables. I suggest `terraform-provider-firehydrant`.
+3. For each environment variable you need to set, run the following command:
+   ```sh
+   envchain --set YOUR_NAMESPACE_HERE ENVIRONMENT_VARIABLE_HERE
+   ```
+   **OR**
+
+   Set all of the environment variables at once with the following command:
+   ```sh
+   envchain --set YOUR_NAMESPACE_HERE FIREHYDRANT_BASE_URL FIREHYDRANT_API_KEY
+   ```
+
+## 2. Run the tests
+
+### Running all acceptance tests
+
+#### With envchain:
+```sh
+$ envchain YOUR_NAMESPACE_HERE make testacc
+```
+
+#### Without envchain:
+```sh
+$ make testacc
+```
+
+### Running specific acceptance tests
+
+The commands below use task lists as an example.
+
+#### With envchain:
+```sh
+$ TESTARGS="-run TestAccTaskList" envchain YOUR_NAMESPACE_HERE make testacc
+```
+
+#### Without envchain:
+```sh
+$ TESTARGS="-run TestAccTaskList" make testacc
+```
+
+### Running the all non-acceptance tests
+
+#### With envchain:
+```sh
+$ envchain YOUR_NAMESPACE_HERE make test
+```
+
+#### Without envchain:
+```sh
+$ make test
+```

--- a/examples/quick-redo.sh
+++ b/examples/quick-redo.sh
@@ -1,7 +1,0 @@
-set -ex
-
-pushd ../
-make install
-popd
-terraform init
-terraform plan

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/dghubble/sling"
 	"github.com/pkg/errors"
@@ -96,8 +97,13 @@ func WithUserAgentSuffix(suffix string) OptFunc {
 
 // NewRestClient initializes a new API client for FireHydrant
 func NewRestClient(token string, opts ...OptFunc) (*APIClient, error) {
+	firehydrantBaseURL := os.Getenv("FIREHYDRANT_BASE_URL")
+	if firehydrantBaseURL == "" {
+		firehydrantBaseURL = DefaultBaseURL
+	}
+
 	c := &APIClient{
-		baseURL: DefaultBaseURL,
+		baseURL: firehydrantBaseURL,
 		token:   token,
 	}
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -110,13 +110,3 @@ func convertStringMap(sm map[string]interface{}) map[string]string {
 
 	return m
 }
-
-func setAttributesFromMap(d *schema.ResourceData, sm map[string]interface{}) error {
-	for k, v := range sm {
-		if err := d.Set(k, v); err != nil {
-			return fmt.Errorf("could not set key %s: %w", k, err)
-		}
-	}
-
-	return nil
-}

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Check gofmt
+echo "==> Checking that code complies with gofmt requirements..."
+gofmt_files=$(find . -name '*.go' | grep -v vendor | xargs gofmt -l -s)
+if [[ -n ${gofmt_files} ]]; then
+    echo 'gofmt needs running on the following files:'
+    echo "${gofmt_files}"
+    echo "You can use the command: \`make fmt\` to reformat code."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Description

This PR adds documentation on how to run the tests in this repo. It also refactors the Makefile for clarity, [adds phony targets](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) to prevent file name conflicts, and adds a few new targets for formatting. It also removes a few unused files/functions.  

Fixes #44 

## Testing plan

1. Read through the docs, checking for typos or broken links. Let me know if anything doesn't make sense or if you can think of anything I forgot to add. 
1. Try following the steps for running the tests locally against your own org or a local build of FireHydrant. 

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.