### PR TITLE
feat: add users and schedule data

### DIFF
--- a/docs/data-sources/schedule.md
+++ b/docs/data-sources/schedule.md
@@ -1,0 +1,28 @@
+---
+page_title: "FireHydrant Data Source: firehydrant_schedule"
+---
+
+# firehydrant_schedule Data Source
+
+Use this data source to get information on schedules.
+
+## Example Usage
+
+Basic usage:
+```hcl
+data "firehydrant_schedule" "my-oncall-schedule" {
+  email = "Main Oncall Schedule"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the oncall schedule.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the schedule. 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -1,0 +1,28 @@
+---
+page_title: "FireHydrant Data Source: firehydrant_user"
+---
+
+# firehydrant_user Data Source
+
+Use this data source to get information on users.
+
+## Example Usage
+
+Basic usage:
+```hcl
+data "firehydrant_user" "my-user" {
+  email = "my-user@firehydrant.io"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `email` - (Required) The user's email address.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the user. 

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -75,6 +75,12 @@ type Client interface {
 	CreateTeam(ctx context.Context, req CreateTeamRequest) (*TeamResponse, error)
 	UpdateTeam(ctx context.Context, id string, req UpdateTeamRequest) (*TeamResponse, error)
 	DeleteTeam(ctx context.Context, id string) error
+
+	// Users
+	GetUsers(ctx context.Context, params GetUserParams) (*UserResponse, error)
+
+	// Schedules
+	GetSchedules(ctx context.Context, params GetScheduleParams) (*ScheduleResponse, error)
 }
 
 // OptFunc is a function that sets a setting on a client
@@ -204,6 +210,40 @@ func (c *APIClient) GetTeam(ctx context.Context, id string) (*TeamResponse, erro
 	}
 
 	return teamResponse, nil
+}
+
+// GetUsers gets matching users in FireHydrant
+func (c *APIClient) GetUsers(ctx context.Context, params GetUserParams) (*UserResponse, error) {
+	userResponse := &UserResponse{}
+	apiError := &APIError{}
+	response, err := c.client().Get("users").QueryStruct(params).Receive(userResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get users")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return userResponse, nil
+}
+
+// GetSchedules gets matching schedules in FireHydrant
+func (c *APIClient) GetSchedules(ctx context.Context, params GetScheduleParams) (*ScheduleResponse, error) {
+	scheduleResponse := &ScheduleResponse{}
+	apiError := &APIError{}
+	response, err := c.client().Get("schedules").QueryStruct(params).Receive(scheduleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get schedules")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return scheduleResponse, nil
 }
 
 // CreateTeam creates a team in FireHydrant

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -146,7 +146,7 @@ type User struct {
 	ID          string    `json:"id"`
 	Name        string    `json:"name"`
 	Email       string    `json:"email"`
-	SlackLinked string    `json:"slack_linked?"`
+	SlackLinked bool      `json:"slack_linked?"`
 	SlackUserId string    `json:"slack_user_id"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
@@ -166,7 +166,7 @@ type Schedule struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Integration string `json:"integration"`
-	Discarded   string `json:"discarded"`
+	Discarded   bool   `json:"discarded"`
 }
 
 type ScheduleResponse struct {

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -136,6 +136,43 @@ type ServicesResponse struct {
 	Services []ServiceResponse `json:"data"`
 }
 
+// UserResponse is the payload for a user
+// URL: GET https://api.firehydrant.io/v1/users
+type GetUserParams struct {
+	Query string `url:"query,omitempty"`
+}
+
+type User struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Email       string    `json:"email"`
+	SlackLinked string    `json:"slack_linked?"`
+	SlackUserId string    `json:"slack_user_id"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type UserResponse struct {
+	Users []User `json:"data"`
+}
+
+// ScheduleResponse is the payload for a schedule
+// URL: GET https://api.firehydrant.io/v1/schedules
+type GetScheduleParams struct {
+	Query string `url:"query,omitempty"`
+}
+
+type Schedule struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Integration string `json:"integration"`
+	Discarded   string `json:"discarded"`
+}
+
+type ScheduleResponse struct {
+	Schedules []Schedule `json:"data"`
+}
+
 // TeamResponse is the payload for a single environment
 // URL: GET https://api.firehydrant.io/v1/teams/{id}
 type TeamResponse struct {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -69,6 +69,8 @@ func Provider() *schema.Provider {
 			"firehydrant_services":       dataSourceServices(),
 			"firehydrant_severity":       dataSourceSeverity(),
 			"firehydrant_task_list":      dataSourceTaskList(),
+			"firehydrant_schedule":       dataSourceSchedule(),
+			"firehydrant_user":           dataSourceUser(),
 		},
 	}
 

--- a/provider/schedule_data.go
+++ b/provider/schedule_data.go
@@ -43,14 +43,14 @@ func dataFireHydrantSchedule(ctx context.Context, d *schema.ResourceData, m inte
 	params := firehydrant.GetScheduleParams{Query: name}
 	scheduleResponse, err := firehydrantAPIClient.GetSchedules(ctx, params)
 	if err != nil {
-		return diag.Errorf("Error fetching schedule %s: %v", name, err)
+		return diag.Errorf("Error fetching schedule '%s': %v", name, err)
 	}
 
 	if len(scheduleResponse.Schedules) == 0 {
-		return diag.Errorf("Did not find schedule matching %s: %v", name, err)
+		return diag.Errorf("Did not find schedule matching '%s'", name)
 	}
 	if len(scheduleResponse.Schedules) > 1 {
-		return diag.Errorf("Found multiple matching schedules for %s: %v", name, err)
+		return diag.Errorf("Found multiple matching schedules for '%s'", name)
 	}
 
 	// Gather values from API response

--- a/provider/schedule_data.go
+++ b/provider/schedule_data.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSchedule() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataFireHydrantSchedule,
+		Schema: map[string]*schema.Schema{
+			// Required
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Computed
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataFireHydrantSchedule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get the user
+	name := d.Get("name").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Fetch schedule: %s", name), map[string]interface{}{
+		"id": name,
+	})
+
+	params := firehydrant.GetScheduleParams{Query: name}
+	scheduleResponse, err := firehydrantAPIClient.GetSchedules(ctx, params)
+	if err != nil {
+		return diag.Errorf("Error fetching schedule %s: %v", name, err)
+	}
+
+	if len(scheduleResponse.Schedules) == 0 {
+		return diag.Errorf("Did not find schedule matching %s: %v", name, err)
+	}
+	if len(scheduleResponse.Schedules) > 1 {
+		return diag.Errorf("Found multiple matching schedules for %s: %v", name, err)
+	}
+
+	// Gather values from API response
+	attributes := map[string]interface{}{
+		"id": scheduleResponse.Schedules[0].ID,
+	}
+
+	// Set the data source attributes to the values we got from the API
+	for key, val := range attributes {
+		if err := d.Set(key, val); err != nil {
+			return diag.Errorf("Error setting %s for user %s: %v", key, name, err)
+		}
+	}
+
+	// Set the priority's ID in state
+	d.SetId(scheduleResponse.Schedules[0].ID)
+
+	return diag.Diagnostics{}
+}

--- a/provider/schedule_data_test.go
+++ b/provider/schedule_data_test.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestScheduleDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testScheduleDataSourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_schedule.test_schedule", "name", "My Rotation"),
+				),
+			},
+		},
+	})
+}
+
+func testScheduleDataSourceConfig_basic() string {
+	return fmt.Sprintln(`
+data "firehydrant_schedule" "test_schedule" {
+  name = "My Rotation"
+}`)
+}

--- a/provider/schedule_data_test.go
+++ b/provider/schedule_data_test.go
@@ -2,12 +2,42 @@ package provider
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestScheduleDataSource_basic(t *testing.T) {
+func testScheduleDataSourceConfig_basic() string {
+	return fmt.Sprintln(`
+data "firehydrant_schedule" "test_schedule" {
+  name = "My Rotation"
+}`)
+}
+
+func TestScheduleDataSource_OneMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Path != "/ping" && r.URL.Path != "/schedules" {
+			t.Errorf("Expected to request '/ping' or '/schedules', got: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "My Rotation" {
+			t.Errorf("Expected query param 'query' to be 'My Rotation', got: %s", r.URL.Query().Get("query"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"id": "123", "name":"My Rotation", "integration" : "", "discarded" : false }]}`))
+	}))
+
+	defer server.Close()
+
+	orig := os.Getenv("FIREHYDRANT_BASE_URL")
+	os.Setenv("FIREHYDRANT_BASE_URL", server.URL)
+	t.Cleanup(func() { os.Setenv("FIREHYDRANT_BASE_URL", orig) })
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testFireHydrantIsSetup(t) },
 		ProviderFactories: defaultProviderFactories(),
@@ -18,15 +48,74 @@ func TestScheduleDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.firehydrant_schedule.test_schedule", "id"),
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_schedule.test_schedule", "name", "My Rotation"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_schedule.test_schedule", "id", "123"),
 				),
 			},
 		},
 	})
 }
 
-func testScheduleDataSourceConfig_basic() string {
-	return fmt.Sprintln(`
-data "firehydrant_schedule" "test_schedule" {
-  name = "My Rotation"
-}`)
+func TestScheduleDataSource_MultipleMatches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Path != "/ping" && r.URL.Path != "/schedules" {
+			t.Errorf("Expected to request '/ping' or '/schedules', got: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "My Rotation" {
+			t.Errorf("Expected query param 'query' to be 'My Rotation', got: %s", r.URL.Query().Get("query"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"id": "123", "name":"My Rotation", "integration" : "", "discarded" : false }, {"id": "123", "name":"My Rotation", "integration" : "", "discarded" : false }]}`))
+	}))
+
+	defer server.Close()
+
+	orig := os.Getenv("FIREHYDRANT_BASE_URL")
+	os.Setenv("FIREHYDRANT_BASE_URL", server.URL)
+	t.Cleanup(func() { os.Setenv("FIREHYDRANT_BASE_URL", orig) })
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testUserDataSourceConfig_basic(),
+				ExpectError: regexp.MustCompile(`Found multiple matching schedules for 'My Rotation'`),
+			},
+		},
+	})
+}
+
+func TestScheduleDataSource_NoMatches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Path != "/ping" && r.URL.Path != "/schedules" {
+			t.Errorf("Expected to request '/ping' or '/schedules', got: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "My Rotation" {
+			t.Errorf("Expected query param 'query' to be 'My Rotation', got: %s", r.URL.Query().Get("query"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+
+	defer server.Close()
+
+	orig := os.Getenv("FIREHYDRANT_BASE_URL")
+	os.Setenv("FIREHYDRANT_BASE_URL", server.URL)
+	t.Cleanup(func() { os.Setenv("FIREHYDRANT_BASE_URL", orig) })
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testUserDataSourceConfig_basic(),
+				ExpectError: regexp.MustCompile(`Did not find schedule matching 'My Rotation'`),
+			},
+		},
+	})
 }

--- a/provider/user_data.go
+++ b/provider/user_data.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataFireHydrantPriority,
+		Schema: map[string]*schema.Schema{
+			// Required
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Computed
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataFireHydrantUser(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get the user
+	email := d.Get("email").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Fetch user: %s", email), map[string]interface{}{
+		"id": email,
+	})
+
+	params := firehydrant.GetUserParams{Query: email}
+	userResponse, err := firehydrantAPIClient.GetUsers(ctx, params)
+	if err != nil {
+		return diag.Errorf("Error fetching user %s: %v", email, err)
+	}
+
+	if len(userResponse.Users) == 0 {
+		return diag.Errorf("Did not find user matching %s: %v", email, err)
+	}
+	if len(userResponse.Users) > 1 {
+		return diag.Errorf("Found multiple matching users for %s: %v", email, err)
+	}
+
+	// Gather values from API response
+	attributes := map[string]interface{}{
+		"id": userResponse.Users[0].ID,
+	}
+
+	// Set the data source attributes to the values we got from the API
+	for key, val := range attributes {
+		if err := d.Set(key, val); err != nil {
+			return diag.Errorf("Error setting %s for user %s: %v", key, email, err)
+		}
+	}
+
+	// Set the priority's ID in state
+	d.SetId(userResponse.Users[0].ID)
+
+	return diag.Diagnostics{}
+}

--- a/provider/user_data.go
+++ b/provider/user_data.go
@@ -43,14 +43,14 @@ func dataFireHydrantUser(ctx context.Context, d *schema.ResourceData, m interfac
 	params := firehydrant.GetUserParams{Query: email}
 	userResponse, err := firehydrantAPIClient.GetUsers(ctx, params)
 	if err != nil {
-		return diag.Errorf("Error fetching user %s: %v", email, err)
+		return diag.Errorf("Error fetching user '%s': %v", email, err)
 	}
 
 	if len(userResponse.Users) == 0 {
-		return diag.Errorf("Did not find user matching %s: %v", email, err)
+		return diag.Errorf("Did not find user matching '%s'", email)
 	}
 	if len(userResponse.Users) > 1 {
-		return diag.Errorf("Found multiple matching users for %s: %v", email, err)
+		return diag.Errorf("Found multiple matching users for '%s'", email)
 	}
 
 	// Gather values from API response

--- a/provider/user_data.go
+++ b/provider/user_data.go
@@ -13,7 +13,7 @@ import (
 
 func dataSourceUser() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataFireHydrantPriority,
+		ReadContext: dataFireHydrantUser,
 		Schema: map[string]*schema.Schema{
 			// Required
 			"email": {
@@ -37,7 +37,7 @@ func dataFireHydrantUser(ctx context.Context, d *schema.ResourceData, m interfac
 	// Get the user
 	email := d.Get("email").(string)
 	tflog.Debug(ctx, fmt.Sprintf("Fetch user: %s", email), map[string]interface{}{
-		"id": email,
+		"email": email,
 	})
 
 	params := firehydrant.GetUserParams{Query: email}

--- a/provider/user_data_test.go
+++ b/provider/user_data_test.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestUserDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testUserDataSourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.firehydrant_user.test_user", "id"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_user.test_user", "email", "test-user@firehydrant.io"),
+				),
+			},
+		},
+	})
+}
+
+func testUserDataSourceConfig_basic() string {
+	return fmt.Sprintln(`
+data "firehydrant_user" "test_user" {
+  email = "test-user@firehydrant.io"
+}`)
+}

--- a/provider/user_data_test.go
+++ b/provider/user_data_test.go
@@ -2,12 +2,42 @@ package provider
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestUserDataSource_basic(t *testing.T) {
+func testUserDataSourceConfig_basic() string {
+	return fmt.Sprintln(`
+data "firehydrant_user" "test_user" {
+  email = "test-user@firehydrant.io"
+}`)
+}
+
+func TestUserDataSource_OneMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Path != "/ping" && r.URL.Path != "/users" {
+			t.Errorf("Expected to request '/ping' or '/users', got: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "test-user@firehydrant.io" {
+			t.Errorf("Expected query param 'query' to be 'test-user@firehydrant.io', got: %s", r.URL.Query().Get("query"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"id": "123", "email":"test-user@firehydrant.io"}]}`))
+	}))
+
+	defer server.Close()
+
+	orig := os.Getenv("FIREHYDRANT_BASE_URL")
+	os.Setenv("FIREHYDRANT_BASE_URL", server.URL)
+	t.Cleanup(func() { os.Setenv("FIREHYDRANT_BASE_URL", orig) })
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testFireHydrantIsSetup(t) },
 		ProviderFactories: defaultProviderFactories(),
@@ -18,15 +48,74 @@ func TestUserDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.firehydrant_user.test_user", "id"),
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_user.test_user", "email", "test-user@firehydrant.io"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_user.test_user", "id", "123"),
 				),
 			},
 		},
 	})
 }
 
-func testUserDataSourceConfig_basic() string {
-	return fmt.Sprintln(`
-data "firehydrant_user" "test_user" {
-  email = "test-user@firehydrant.io"
-}`)
+func TestUserDataSource_MultipleMatches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Path != "/ping" && r.URL.Path != "/users" {
+			t.Errorf("Expected to request '/ping' or '/users', got: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "test-user@firehydrant.io" {
+			t.Errorf("Expected query param 'query' to be 'test-user@firehydrant.io', got: %s", r.URL.Query().Get("query"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"id": "123", "email":"test-user@firehydrant.io"}, {"data":[{"id": "123", "email":"test-user@example.io"}]}`))
+	}))
+
+	defer server.Close()
+
+	orig := os.Getenv("FIREHYDRANT_BASE_URL")
+	os.Setenv("FIREHYDRANT_BASE_URL", server.URL)
+	t.Cleanup(func() { os.Setenv("FIREHYDRANT_BASE_URL", orig) })
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testUserDataSourceConfig_basic(),
+				ExpectError: regexp.MustCompile(`Found multiple matching users for 'test-user@firehydrant.io'`),
+			},
+		},
+	})
+}
+
+func TestUserDataSource_NoMatches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Path != "/ping" && r.URL.Path != "/users" {
+			t.Errorf("Expected to request '/ping' or '/users', got: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "test-user@firehydrant.io" {
+			t.Errorf("Expected query param 'query' to be 'test-user@firehydrant.io', got: %s", r.URL.Query().Get("query"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+
+	defer server.Close()
+
+	orig := os.Getenv("FIREHYDRANT_BASE_URL")
+	os.Setenv("FIREHYDRANT_BASE_URL", server.URL)
+	t.Cleanup(func() { os.Setenv("FIREHYDRANT_BASE_URL", orig) })
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testUserDataSourceConfig_basic(),
+				ExpectError: regexp.MustCompile(`Did not find user matching 'test-user@firehydrant.io'`),
+			},
+		},
+	})
 }


### PR DESCRIPTION
This PR adds two new data providers; `user` and `schedule`.  These are a pre-requisite to be able to implement #17.

