### PR TITLE
chore: ignore bin/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 dist/
 local/bin/terraform-provider-firehydrant
 local/examples/**/*


### PR DESCRIPTION
## Description

When doing a `make release`, `git status` starts reporting `bin/` is not being tracked.

This PR makes `git` ignore the `bin/` directory.

## Testing plan

N/A.

## Related links

N/A.

## PR readiness 

N/A.
