### PR TITLE
chore: removed unused constant

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -22,9 +22,6 @@ const (
 	MinorVersion = 1
 	// PatchVersion is the patch version
 	PatchVersion = 0
-
-	// UserAgentPrefix is the prefix of the User-Agent header that all terraform REST calls perform
-	UserAgentPrefix = "firehydrant-terraform-provider"
 )
 
 // Version is the semver of this provider


### PR DESCRIPTION
## Description

Constant is not used in the given go module.

This is one is the one being used:

https://github.com/firehydrant/terraform-provider-firehydrant/blob/main/firehydrant/client.go#L22

## Testing plan

build worked.

## Related links

N/A.

## PR readiness

N/A.
