### PR TITLE
Add the ability to attach memberships to teams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
         env:
           TF_ACC: 'true'
           FIREHYDRANT_API_KEY: ${{ secrets.FIREHYDRANT_API_KEY }}
+          EXISTING_USER_EMAIL: 'ops+terraform-ci@firehydrant.io'

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -26,7 +26,7 @@ resource "firehydrant_team" "example-team" {
 
   memberships {
     user_id          = data.firehydrant_user.my-user.id
-    incident_role_id = data.firehydrant_incident_role.ops-lead.id
+    default_incident_role_id = data.firehydrant_incident_role.ops-lead.id
   }
 }
 ```

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -12,9 +12,22 @@ and configured as owners of various resources, like services and runbooks.
 
 Basic usage:
 ```hcl
+data "firehydrant_user" "my-user" {
+  email = "example@firehydrant.io"
+}
+
+data "firehydrant_incident_role" "ops-lead" {
+  id = "1c679abe-3060-47d4-ab5e-e1ecbd5ce55f"
+}
+
 resource "firehydrant_team" "example-team" {
   name        = "example-team"
   description = "This is an example team"
+
+  memberships {
+    user_id          = data.firehydrant_user.my-user.id
+    incident_role_id = data.firehydrant_incident_role.ops-lead.id
+  }
 }
 ```
 
@@ -24,6 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the team.
 * `description` - (Optional) A description for the team.
+* `memberships` - (Optional) A resource to tie a schedule or user to a team via a incident role.
 
 ## Attributes Reference
 

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -39,6 +39,14 @@ The following arguments are supported:
 * `description` - (Optional) A description for the team.
 * `memberships` - (Optional) A resource to tie a schedule or user to a team via a incident role.
 
+The `memberships` block supports:
+
+Either the user_id or schedule_id is required for this block.
+
+* `user_id` - (Required) Id of the user.
+* `schedule_id` - (Required) Id of the schedule.
+* `default_incident_role_id` - (Optional) Incident role to assign the user or schedule.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -176,21 +176,39 @@ type ScheduleResponse struct {
 // TeamResponse is the payload for a single environment
 // URL: GET https://api.firehydrant.io/v1/teams/{id}
 type TeamResponse struct {
-	ID            string            `json:"id"`
-	Name          string            `json:"name"`
-	Description   string            `json:"description"`
-	Slug          string            `json:"slug"`
-	OwnedServices []ServiceResponse `json:"owned_services"`
-	Services      []ServiceResponse `json:"services"`
-	CreatedAt     time.Time         `json:"created_at"`
-	UpdatedAt     time.Time         `json:"updated_at"`
+	ID            string               `json:"id"`
+	Name          string               `json:"name"`
+	Description   string               `json:"description"`
+	Slug          string               `json:"slug"`
+	OwnedServices []ServiceResponse    `json:"owned_services"`
+	Services      []ServiceResponse    `json:"services"`
+	Memberships   []MembershipResponse `json:"memberships"`
+	CreatedAt     time.Time            `json:"created_at"`
+	UpdatedAt     time.Time            `json:"updated_at"`
+}
+
+// MembershipResponse represents the response coming back from teams
+// for membership
+type MembershipResponse struct {
+	DefaultIncidentRole IncidentRoleResponse `json:"default_incident_role,omitempty"`
+	Schedule            Schedule             `json:"schedule,omitempty"`
+	User                User                 `json:"user,omitempty"`
+}
+
+// Membership represents a user_id or schedule_id along with a
+// incident_role_id for a team membership resource
+type Membership struct {
+	IncidentRoleId string `json:"incident_role_id,omitempty"`
+	ScheduleId     string `json:"schedule_id,omitempty"`
+	UserId         string `json:"user_id,omitempty"`
 }
 
 // CreateTeamRequest is the payload for creating a service
 // URL: POST https://api.firehydrant.io/v1/services
 type CreateTeamRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Memberships []Membership `json:"memberships,omitempty"`
 }
 
 // TeamService represents a service when creating a functionality
@@ -201,6 +219,7 @@ type TeamService struct {
 // UpdateTeamRequest is the payload for updating a environment
 // URL: PATCH https://api.firehydrant.io/v1/environments/{id}
 type UpdateTeamRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Memberships []Membership `json:"memberships,omitempty"`
 }

--- a/provider/team_resource.go
+++ b/provider/team_resource.go
@@ -151,7 +151,7 @@ func updateResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 		Description: d.Get("description").(string),
 	}
 
-	// Process any optional attributes and add to the create request if necessary
+	// Process any optional attributes and add to the update request if necessary
 	memberships := d.Get("memberships")
 	for _, currentMembership := range memberships.(*schema.Set).List() {
 		membership := currentMembership.(map[string]interface{})

--- a/provider/team_resource.go
+++ b/provider/team_resource.go
@@ -33,6 +33,26 @@ func resourceTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"memberships": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"incident_role_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"user_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"schedule_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -64,6 +84,17 @@ func readResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, m 
 		"description": teamResponse.Description,
 	}
 
+	// Process any attributes that could be nil
+	memberships := make([]map[string]interface{}, len(teamResponse.Memberships))
+	for index, currentMembership := range teamResponse.Memberships {
+		memberships[index] = map[string]interface{}{
+			"incident_role_id": currentMembership.DefaultIncidentRole.ID,
+			"schedule_id":      currentMembership.Schedule.ID,
+			"user_id":          currentMembership.User.ID,
+		}
+	}
+	attributes["memberships"] = memberships
+
 	for key, value := range attributes {
 		if err := d.Set(key, value); err != nil {
 			return diag.Errorf("Error setting %s for team %s: %v", key, teamID, err)
@@ -81,6 +112,17 @@ func createResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 	createRequest := firehydrant.CreateTeamRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
+	}
+
+	// Process any optional attributes and add to the create request if necessary
+	memberships := d.Get("memberships")
+	for _, currentMembership := range memberships.(*schema.Set).List() {
+		membership := currentMembership.(map[string]interface{})
+		createRequest.Memberships = append(createRequest.Memberships, firehydrant.Membership{
+			IncidentRoleId: membership["incident_role_id"].(string),
+			ScheduleId:     membership["schedule_id"].(string),
+			UserId:         membership["user_id"].(string),
+		})
 	}
 
 	// Create the new team
@@ -107,6 +149,17 @@ func updateResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 	updateRequest := firehydrant.UpdateTeamRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
+	}
+
+	// Process any optional attributes and add to the create request if necessary
+	memberships := d.Get("memberships")
+	for _, currentMembership := range memberships.(*schema.Set).List() {
+		membership := currentMembership.(map[string]interface{})
+		updateRequest.Memberships = append(updateRequest.Memberships, firehydrant.Membership{
+			IncidentRoleId: membership["incident_role_id"].(string),
+			ScheduleId:     membership["schedule_id"].(string),
+			UserId:         membership["user_id"].(string),
+		})
 	}
 
 	// Update the team

--- a/provider/team_resource.go
+++ b/provider/team_resource.go
@@ -38,7 +38,7 @@ func resourceTeam() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"incident_role_id": {
+						"default_incident_role_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -88,9 +88,9 @@ func readResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, m 
 	memberships := make([]map[string]interface{}, len(teamResponse.Memberships))
 	for index, currentMembership := range teamResponse.Memberships {
 		memberships[index] = map[string]interface{}{
-			"incident_role_id": currentMembership.DefaultIncidentRole.ID,
-			"schedule_id":      currentMembership.Schedule.ID,
-			"user_id":          currentMembership.User.ID,
+			"default_incident_role_id": currentMembership.DefaultIncidentRole.ID,
+			"schedule_id":              currentMembership.Schedule.ID,
+			"user_id":                  currentMembership.User.ID,
 		}
 	}
 	attributes["memberships"] = memberships
@@ -119,7 +119,7 @@ func createResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 	for _, currentMembership := range memberships.(*schema.Set).List() {
 		membership := currentMembership.(map[string]interface{})
 		createRequest.Memberships = append(createRequest.Memberships, firehydrant.Membership{
-			IncidentRoleId: membership["incident_role_id"].(string),
+			IncidentRoleId: membership["default_incident_role_id"].(string),
 			ScheduleId:     membership["schedule_id"].(string),
 			UserId:         membership["user_id"].(string),
 		})
@@ -156,7 +156,7 @@ func updateResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 	for _, currentMembership := range memberships.(*schema.Set).List() {
 		membership := currentMembership.(map[string]interface{})
 		updateRequest.Memberships = append(updateRequest.Memberships, firehydrant.Membership{
-			IncidentRoleId: membership["incident_role_id"].(string),
+			IncidentRoleId: membership["default_incident_role_id"].(string),
 			ScheduleId:     membership["schedule_id"].(string),
 			UserId:         membership["user_id"].(string),
 		})


### PR DESCRIPTION
## Description

We previously added support to get user and schedule information as a data resource. That was in order to provide support for memberships on the teams resource. This PR adds that ability to attach memberships to a teams resource.

This is going to be hard to test in our test suite because the data resources for user and schedules can only be mocked since we don't have a resource way of creating them. Yet the incident_role and teams can just go through the normal end to end flow. Would love to possibly get some eyes on this from Platform @bmorton possibly to see thoughts around testing this.

```terraform
data "firehydrant_user" "my-user" {
  email = "local@firehydrant.io"
}

data "firehydrant_schedule" "my-schedule" {
  name = "Customer Success_schedule"
}

data "firehydrant_incident_role" "commander" {
  id = "f61a06d2-f7a0-44cf-a944-c8af457060e6"
}

data "firehydrant_incident_role" "ops-lead" {
  id = "1c679abe-3060-47d4-ab5e-e1ecbd5ce55f"
}


resource "firehydrant_team" "example-team" {
  name        = "example-team-23"
  description = "This is an example team"
  memberships {
    user_id          = data.firehydrant_user.my-user.id
    default_incident_role_id = data.firehydrant_incident_role.ops-lead.id
  }

  memberships {
    schedule_id      = data.firehydrant_schedule.my-schedule.id
    default_incident_role_id = data.firehydrant_incident_role.commander.id
  }
}
```

## Testing plan

Pre-requisites:
- You'll need Go 1.18.2 and the latest Terraform installed.
- You'll need an instance of FireHydrant running locally or an organization in production to test against.
- You'll need a bot token for the organization you plan to test against.

#### Setup
1. Create a new directory called `providers` somewhere you can easily access (but not inside the same folder as your Terraform config).
1. Build the provider by checking out this branch and running `make build`
1. Move the executable created to the `providers` directory you created earlier.
   ```
   mv terraform-provider-firehydrant /PATH/TO/YOUR/DIRECTORY/providers
   ```
1. Add the following to your ~/.terraformrc file:
   ```
   provider_installation {

     # Use /PATH/TO/YOUR/DIRECTORY/providers/terraform-provider-firehydrant
     # as an overridden package directory for the firehydrant/firehydrant provider. 
     # This disables the version and checksum verifications for this provider and 
     # forces Terraform to look for the null provider plugin in the given directory.
     dev_overrides {
       "firehydrant/firehydrant" = "/PATH/TO/YOUR/DIRECTORY/providers"
     }

     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
1. Ensure that you have a schedule available within your dataset to pull from as well as the user you would like to pull from and update the below setup with the name and email

```terraform
data "firehydrant_user" "my-user" {
  email = "EMAIL"
}

data "firehydrant_schedule" "my-schedule" {
  name = "NAME"
}

data "firehydrant_incident_role" "commander" {
  id = "ROLE_ID"
}

data "firehydrant_incident_role" "ops-lead" {
  id = "ROLE_ID"
}


resource "firehydrant_team" "example-team" {
  name        = "example-team-23"
  description = "This is an example team"
  memberships {
    user_id          = data.firehydrant_user.my-user.id
    default_incident_role_id = data.firehydrant_incident_role.ops-lead.id
  }

  memberships {
    schedule_id      = data.firehydrant_schedule.my-schedule.id
    default_incident_role_id = data.firehydrant_incident_role.commander.id
  }
}
```

#### Provision data sources:
1. Make sure to setup the correct email and name for the user and schedule. As well replace the commander and ops-lead roles above with roles you have and update the id's.
1. Run `terraform apply`. When prompted for an API key, provide your bot token. This should succeed and if you check in the UI, you should see the various resources you just created. 
1. Run `terraform plan`. There should be no changes.
1. verify that the terraform.tfstate has the correct information for the schedule and user.

## Related links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developers.firehydrant.io/docs/api/xxxx)
- [Related PR](https://github.com/firehydrant/firehydrant/pull/xxxx)

## PR readiness 

- [X] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [ ] An entry has been added to the changelog, if necessary.