### PR TITLE
Add auto_add_responding_team to r/service and d/service(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ENHANCEMENTS: 
 
-* resource/service: Added `auto_add_responding_team` attribute to service
-* data_source/service: Added `auto_add_responding_team` attribute to service
-* data_source/services: Added `auto_add_responding_team` attribute to service
+* resource/service: Added `auto_add_responding_team` attribute to service ([#117](https://github.com/firehydrant/terraform-provider-firehydrant/pull/117))
+* data_source/service: Added `auto_add_responding_team` attribute to service ([#117](https://github.com/firehydrant/terraform-provider-firehydrant/pull/117))
+* data_source/services: Added `auto_add_responding_team` attribute to service ([#117](https://github.com/firehydrant/terraform-provider-firehydrant/pull/117))
 
 ## 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.3.2 (Unreleased)
 
+ENHANCEMENTS: 
+
+* resource/service: Added `auto_add_responding_team` attribute to service
+* data_source/service: Added `auto_add_responding_team` attribute to service
+* data_source/services: Added `auto_add_responding_team` attribute to service
+
 ## 0.3.1
 
 BUG FIXES:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,7 +19,7 @@ on registry.terraform.io.
    ```
    Make sure any major customer-facing changes have an entry in the changelog.
 2. Review the changelog to check for the following:
-   - The changelog follows [the changelog format](./README.md#updating-the-changelog)
+   - The changelog follows [the changelog format](./CONTRIBUTING.md#updating-the-changelog)
    - Information is accurate and free of typos 
    - All links work 
    - If there are any breaking changes, a "Notes" section has been added with 

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -33,6 +33,8 @@ In addition to all arguments above, the following attributes are exported:
 * `alert_on_add` - Indicates if FireHydrant should automatically create an alert 
   based on the integrations set up for this service, if this service is added to 
   an active incident.
+* `auto_add_responding_team` - Indicates if FireHydrant should automatically add
+  the responding team if this service is added to an active incident.
 * `description` - A description of the service.
 * `labels` - Key-value pairs associated with the service. Useful for supporting 
   searching and filtering of the service catalog.

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -53,6 +53,8 @@ The `services` block contains:
 * `alert_on_add` - Indicates if FireHydrant should automatically create an alert
   based on the integrations set up for this service, if this service is added to
   an active incident.
+* `auto_add_responding_team` - Indicates if FireHydrant should automatically add
+  the responding team if this service is added to an active incident.
 * `description` - A description of the service.
 * `labels` - Key-value pairs associated with the service. Useful for supporting
   searching and filtering of the service catalog.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -60,6 +60,8 @@ The following arguments are supported:
 * `alert_on_add` - (Optional) Indicates if FireHydrant should automatically create
   an alert based on the integrations set up for this service, if this service is added to an
   active incident. Defaults to `false`.
+* `auto_add_responding_team` - (Optional) Indicates if FireHydrant should automatically add
+  the responding team if this service is added to an active incident. Defaults to `false`.
 * `description` - (Optional) A description for the service.
 * `labels` - (Optional) Key-value pairs associated with the service. Useful for
   supporting searching and filtering of the service catalog.

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -27,14 +27,15 @@ type PingResponse struct {
 // CreateServiceRequest is the payload for creating a service
 // URL: POST https://api.firehydrant.io/v1/services
 type CreateServiceRequest struct {
-	AlertOnAdd  bool              `json:"alert_on_add,omitempty"`
-	Description string            `json:"description"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Links       []ServiceLink     `json:"links,omitempty"`
-	Name        string            `json:"name"`
-	Owner       *ServiceTeam      `json:"owner,omitempty"`
-	ServiceTier int               `json:"service_tier,int,omitempty"`
-	Teams       []ServiceTeam     `json:"teams,omitempty"`
+	AlertOnAdd            bool              `json:"alert_on_add,omitempty"`
+	AutoAddRespondingTeam bool              `json:"auto_add_responding_team,omitempty"`
+	Description           string            `json:"description"`
+	Labels                map[string]string `json:"labels,omitempty"`
+	Links                 []ServiceLink     `json:"links,omitempty"`
+	Name                  string            `json:"name"`
+	Owner                 *ServiceTeam      `json:"owner,omitempty"`
+	ServiceTier           int               `json:"service_tier,int,omitempty"`
+	Teams                 []ServiceTeam     `json:"teams,omitempty"`
 }
 
 // RunbookTeam represents a team when creating a runbook
@@ -69,31 +70,33 @@ type ServiceLink struct {
 // UpdateServiceRequest is the payload for updating a service
 // URL: PATCH https://api.firehydrant.io/v1/services/{id}
 type UpdateServiceRequest struct {
-	AlertOnAdd           bool              `json:"alert_on_add"`
-	Description          string            `json:"description"`
-	Labels               map[string]string `json:"labels"`
-	Links                []ServiceLink     `json:"links"`
-	Name                 string            `json:"name,omitempty"`
-	Owner                *ServiceTeam      `json:"owner"`
-	RemoveOwner          bool              `json:"remove_owner,omitempty"`
-	RemoveRemainingTeams bool              `json:"remove_remaining_teams,omitempty"`
-	ServiceTier          int               `json:"service_tier,int"`
-	Teams                []ServiceTeam     `json:"teams"`
+	AlertOnAdd            bool              `json:"alert_on_add"`
+	AutoAddRespondingTeam bool              `json:"auto_add_responding_team"`
+	Description           string            `json:"description"`
+	Labels                map[string]string `json:"labels"`
+	Links                 []ServiceLink     `json:"links"`
+	Name                  string            `json:"name,omitempty"`
+	Owner                 *ServiceTeam      `json:"owner"`
+	RemoveOwner           bool              `json:"remove_owner,omitempty"`
+	RemoveRemainingTeams  bool              `json:"remove_remaining_teams,omitempty"`
+	ServiceTier           int               `json:"service_tier,int"`
+	Teams                 []ServiceTeam     `json:"teams"`
 }
 
 // ServiceResponse is the payload for retrieving a service
 // URL: GET https://api.firehydrant.io/v1/services/{id}
 type ServiceResponse struct {
-	ID          string            `json:"id"`
-	AlertOnAdd  bool              `json:"alert_on_add"`
-	Description string            `json:"description"`
-	Labels      map[string]string `json:"labels"`
-	Links       []ServiceLink     `json:"links"`
-	Name        string            `json:"name"`
-	Owner       *ServiceTeam      `json:"owner"`
-	ServiceTier int               `json:"service_tier"`
-	Slug        string            `json:"slug"`
-	Teams       []ServiceTeam     `json:"teams"`
+	ID                    string            `json:"id"`
+	AlertOnAdd            bool              `json:"alert_on_add"`
+	AutoAddRespondingTeam bool              `json:"auto_add_responding_team"`
+	Description           string            `json:"description"`
+	Labels                map[string]string `json:"labels"`
+	Links                 []ServiceLink     `json:"links"`
+	Name                  string            `json:"name"`
+	Owner                 *ServiceTeam      `json:"owner"`
+	ServiceTier           int               `json:"service_tier"`
+	Slug                  string            `json:"slug"`
+	Teams                 []ServiceTeam     `json:"teams"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/provider/service_data.go
+++ b/provider/service_data.go
@@ -26,6 +26,10 @@ func dataSourceService() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"auto_add_responding_team": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -90,11 +94,12 @@ func dataFireHydrantService(ctx context.Context, d *schema.ResourceData, m inter
 
 	// Set values in state
 	attributes := map[string]interface{}{
-		"alert_on_add": serviceResponse.AlertOnAdd,
-		"description":  serviceResponse.Description,
-		"labels":       serviceResponse.Labels,
-		"name":         serviceResponse.Name,
-		"service_tier": serviceResponse.ServiceTier,
+		"alert_on_add":             serviceResponse.AlertOnAdd,
+		"auto_add_responding_team": serviceResponse.AutoAddRespondingTeam,
+		"description":              serviceResponse.Description,
+		"labels":                   serviceResponse.Labels,
+		"name":                     serviceResponse.Name,
+		"service_tier":             serviceResponse.ServiceTier,
 	}
 
 	// Process any attributes that could be nil

--- a/provider/service_data_test.go
+++ b/provider/service_data_test.go
@@ -24,6 +24,8 @@ func TestAccServiceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_service.test_service", "alert_on_add", "false"),
 					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "auto_add_responding_team", "false"),
+					resource.TestCheckResourceAttr(
 						"data.firehydrant_service.test_service", "service_tier", "5"),
 				),
 			},
@@ -46,6 +48,8 @@ func TestAccServiceDataSource_allAttributes(t *testing.T) {
 						"data.firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rName)),
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"data.firehydrant_service.test_service", "auto_add_responding_team", "true"),
 					resource.TestCheckResourceAttr(
 						"data.firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
 					resource.TestCheckResourceAttr(
@@ -92,9 +96,10 @@ resource "firehydrant_team" "test_team3" {
 }
 
 resource "firehydrant_service" "test_service" {
-  name         = "test-service-%s"
-  alert_on_add = true
-  description  = "test-description-%s"
+  name                     = "test-service-%s"
+  alert_on_add             = true
+  auto_add_responding_team = true
+  description              = "test-description-%s"
   
   labels = {
     test = "test-label-%s"

--- a/provider/service_resource.go
+++ b/provider/service_resource.go
@@ -34,6 +34,11 @@ func resourceService() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"auto_add_responding_team": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -102,11 +107,12 @@ func readResourceFireHydrantService(ctx context.Context, d *schema.ResourceData,
 
 	// Set values in state
 	attributes := map[string]interface{}{
-		"name":         serviceResponse.Name,
-		"alert_on_add": serviceResponse.AlertOnAdd,
-		"description":  serviceResponse.Description,
-		"labels":       serviceResponse.Labels,
-		"service_tier": serviceResponse.ServiceTier,
+		"name":                     serviceResponse.Name,
+		"alert_on_add":             serviceResponse.AlertOnAdd,
+		"auto_add_responding_team": serviceResponse.AutoAddRespondingTeam,
+		"description":              serviceResponse.Description,
+		"labels":                   serviceResponse.Labels,
+		"service_tier":             serviceResponse.ServiceTier,
 	}
 
 	// Process any attributes that could be nil
@@ -147,11 +153,12 @@ func createResourceFireHydrantService(ctx context.Context, d *schema.ResourceDat
 
 	// Get attributes from config and construct the create request
 	createRequest := firehydrant.CreateServiceRequest{
-		Name:        d.Get("name").(string),
-		AlertOnAdd:  d.Get("alert_on_add").(bool),
-		Description: d.Get("description").(string),
-		Labels:      convertStringMap(d.Get("labels").(map[string]interface{})),
-		ServiceTier: d.Get("service_tier").(int),
+		Name:                  d.Get("name").(string),
+		AlertOnAdd:            d.Get("alert_on_add").(bool),
+		AutoAddRespondingTeam: d.Get("auto_add_responding_team").(bool),
+		Description:           d.Get("description").(string),
+		Labels:                convertStringMap(d.Get("labels").(map[string]interface{})),
+		ServiceTier:           d.Get("service_tier").(int),
 	}
 
 	// Process any optional attributes and add to the create request if necessary
@@ -195,11 +202,12 @@ func updateResourceFireHydrantService(ctx context.Context, d *schema.ResourceDat
 
 	// Construct the update request
 	updateRequest := firehydrant.UpdateServiceRequest{
-		Name:        d.Get("name").(string),
-		AlertOnAdd:  d.Get("alert_on_add").(bool),
-		Description: d.Get("description").(string),
-		Labels:      convertStringMap(d.Get("labels").(map[string]interface{})),
-		ServiceTier: d.Get("service_tier").(int),
+		Name:                  d.Get("name").(string),
+		AlertOnAdd:            d.Get("alert_on_add").(bool),
+		AutoAddRespondingTeam: d.Get("auto_add_responding_team").(bool),
+		Description:           d.Get("description").(string),
+		Labels:                convertStringMap(d.Get("labels").(map[string]interface{})),
+		ServiceTier:           d.Get("service_tier").(int),
 	}
 
 	// Process any optional attributes and add to the update request if necessary

--- a/provider/service_resource_test.go
+++ b/provider/service_resource_test.go
@@ -31,6 +31,8 @@ func TestAccServiceResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "false"),
 					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "false"),
+					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "5"),
 					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "0"),
 				),
@@ -58,6 +60,8 @@ func TestAccServiceResource_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "false"),
 					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "false"),
+					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "5"),
 					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "0"),
 				),
@@ -71,6 +75,8 @@ func TestAccServiceResource_update(t *testing.T) {
 						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "true"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
@@ -92,6 +98,8 @@ func TestAccServiceResource_update(t *testing.T) {
 						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "false"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "false"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "service_tier", "5"),
 					resource.TestCheckResourceAttr("firehydrant_service.test_service", "team_ids.#", "0"),
@@ -120,6 +128,8 @@ func TestAccServiceResource_updateLabels(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "true"),
 					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "true"),
+					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rName)),
@@ -140,6 +150,8 @@ func TestAccServiceResource_updateLabels(t *testing.T) {
 						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "true"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
@@ -163,6 +175,8 @@ func TestAccServiceResource_updateLabels(t *testing.T) {
 						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "false"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "false"),
 					// Make sure the labels are not set
 					resource.TestCheckNoResourceAttr(
 						"firehydrant_service.test_service", "labels.test1"),
@@ -196,6 +210,8 @@ func TestAccServiceResource_updateOwnerIDAndTeamIDs(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "true"),
 					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "true"),
+					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rName)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rName)),
@@ -216,6 +232,8 @@ func TestAccServiceResource_updateOwnerIDAndTeamIDs(t *testing.T) {
 						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "true"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "true"),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
@@ -238,6 +256,8 @@ func TestAccServiceResource_updateOwnerIDAndTeamIDs(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "true"),
 					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "true"),
+					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "labels.test1", fmt.Sprintf("test-label1-%s", rNameUpdated)),
@@ -258,6 +278,8 @@ func TestAccServiceResource_updateOwnerIDAndTeamIDs(t *testing.T) {
 						"firehydrant_service.test_service", "name", fmt.Sprintf("test-service-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "alert_on_add", "false"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_service.test_service", "auto_add_responding_team", "false"),
 					// Make sure owner_id is not set
 					resource.TestCheckResourceAttr(
 						"firehydrant_service.test_service", "owner_id", ""),
@@ -338,6 +360,11 @@ func testAccCheckServiceResourceExistsWithAttributes_basic(resourceName string) 
 			return fmt.Errorf("Unexpected alert_on_add. Expected: %s, got: %s", expected, got)
 		}
 
+		expected, got = serviceResource.Primary.Attributes["auto_add_responding_team"], fmt.Sprintf("%t", serviceResponse.AutoAddRespondingTeam)
+		if expected != got {
+			return fmt.Errorf("Unexpected auto_add_responding_team. Expected: %s, got: %s", expected, got)
+		}
+
 		if serviceResponse.Description != "" {
 			return fmt.Errorf("Unexpected description. Expected no description, got: %s", serviceResponse.Description)
 		}
@@ -396,6 +423,11 @@ func testAccCheckServiceResourceExistsWithAttributes_update(resourceName string)
 		expected, got = serviceResource.Primary.Attributes["alert_on_add"], fmt.Sprintf("%t", serviceResponse.AlertOnAdd)
 		if expected != got {
 			return fmt.Errorf("Unexpected alert_on_add. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = serviceResource.Primary.Attributes["auto_add_responding_team"], fmt.Sprintf("%t", serviceResponse.AutoAddRespondingTeam)
+		if expected != got {
+			return fmt.Errorf("Unexpected auto_add_responding_team. Expected: %s, got: %s", expected, got)
 		}
 
 		expected, got = serviceResource.Primary.Attributes["description"], serviceResponse.Description
@@ -489,9 +521,10 @@ resource "firehydrant_team" "test_team3" {
 }
 
 resource "firehydrant_service" "test_service" {
-  name         = "test-service-%s"
-  alert_on_add = true
-  description  = "test-description-%s"
+  name                     = "test-service-%s"
+  alert_on_add             = true
+  auto_add_responding_team = true
+  description              = "test-description-%s"
   labels = {
     test1 = "test-label1-%s",
   }
@@ -527,9 +560,10 @@ resource "firehydrant_team" "test_team3" {
 }
 
 resource "firehydrant_service" "test_service" {
-  name         = "test-service-%s"
-  alert_on_add = true
-  description  = "test-description-%s"
+  name                     = "test-service-%s"
+  alert_on_add             = true
+  auto_add_responding_team = true
+  description              = "test-description-%s"
   labels = {
     test1 = "test-label1-%s",
     test2 = "test-label2-%s"
@@ -566,9 +600,10 @@ resource "firehydrant_team" "test_team3" {
 }
 
 resource "firehydrant_service" "test_service" {
-  name         = "test-service-%s"
-  alert_on_add = true
-  description  = "test-description-%s"
+  name                     = "test-service-%s"
+  alert_on_add             = true
+  auto_add_responding_team = true
+  description              = "test-description-%s"
   labels = {
     test1 = "test-label1-%s"
   }

--- a/provider/services_data.go
+++ b/provider/services_data.go
@@ -62,12 +62,13 @@ func dataFireHydrantServices(ctx context.Context, d *schema.ResourceData, m inte
 	services := make([]interface{}, 0)
 	for _, service := range servicesResponse.Services {
 		attributes := map[string]interface{}{
-			"id":           service.ID,
-			"alert_on_add": service.AlertOnAdd,
-			"description":  service.Description,
-			"labels":       service.Labels,
-			"name":         service.Name,
-			"service_tier": service.ServiceTier,
+			"id":                       service.ID,
+			"alert_on_add":             service.AlertOnAdd,
+			"auto_add_responding_team": service.AutoAddRespondingTeam,
+			"description":              service.Description,
+			"labels":                   service.Labels,
+			"name":                     service.Name,
+			"service_tier":             service.ServiceTier,
 		}
 
 		// Process any attributes that could be nil


### PR DESCRIPTION
## Description

This pull request adds the `auto_add_responding_team` attribute to the `firehydrant_service` resource and `firehydrant_service`/`firehydrant_services` data sources.

## Testing plan

1. Unit tests should pass

## Related links

- [API documentation](https://developers.firehydrant.io/docs/api/96d0bb18d9cdc-create-a-service)

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.