### PR TITLE
Prepare CHANGELOG.md for 0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 0.3.2 (Unreleased)
+## 0.3.2 
 
 ENHANCEMENTS: 
 
 * resource/service: Added `auto_add_responding_team` attribute to service ([#117](https://github.com/firehydrant/terraform-provider-firehydrant/pull/117))
 * data_source/service: Added `auto_add_responding_team` attribute to service ([#117](https://github.com/firehydrant/terraform-provider-firehydrant/pull/117))
 * data_source/services: Added `auto_add_responding_team` attribute to service ([#117](https://github.com/firehydrant/terraform-provider-firehydrant/pull/117))
+* resource/team: Add the ability to attach memberships to teams ([#116](https://github.com/firehydrant/terraform-provider-firehydrant/pull/116))
 
 ## 0.3.1
 


### PR DESCRIPTION
This PR prepares the changelog for the 0.3.2 release.


## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.