### PR TITLE
Fix broken docs link to ISO 8601 duration format

### DIFF
--- a/docs/guides/runbooks_steps_firehydrant.md
+++ b/docs/guides/runbooks_steps_firehydrant.md
@@ -60,7 +60,7 @@ resource "firehydrant_runbook" "firehydrant_add_services_related_to_functionalit
 * `repeats` - (Optional) Whether this step should repeat. Defaults to `false`.
   When this value is `true`, `repeats_duration` _must_ be provided.
 * `repeats_duration` - (Optional) How often this step should repeat in ISO8601.
-  Example: PT10M [Format Spec](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)
+  Example: PT10M [Format Spec](https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm)
   This value _must_ be provided if `repeats` is `true`. This value _must not_ be provided if `repeats` is `false`.
 * `rule` - (Optional) JSON string representing the rule configuration for the runbook step.
   For more information on the conditional logic used in `rule`, see the

--- a/docs/guides/runbooks_steps_firehydrant.md
+++ b/docs/guides/runbooks_steps_firehydrant.md
@@ -60,8 +60,8 @@ resource "firehydrant_runbook" "firehydrant_add_services_related_to_functionalit
 * `repeats` - (Optional) Whether this step should repeat. Defaults to `false`.
   When this value is `true`, `repeats_duration` _must_ be provided.
 * `repeats_duration` - (Optional) How often this step should repeat in ISO8601.
-  Example: PT10M [Format Spec](https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm)
   This value _must_ be provided if `repeats` is `true`. This value _must not_ be provided if `repeats` is `false`.
+  Example: `PT10M` ([Format Spec](https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm))
 * `rule` - (Optional) JSON string representing the rule configuration for the runbook step.
   For more information on the conditional logic used in `rule`, see the
   [Runbooks - Conditional Logic](./runbooks_conditional_logic.md) documentation.


### PR DESCRIPTION
## Description
Very minor change to a broken external docs link to the ISO 8601 timestamp format.

## Testing plan

N/A - make sure new link works. See:

<img width="726" alt="image" src="https://github.com/firehydrant/terraform-provider-firehydrant/assets/2441695/a0c06a7c-529e-43ad-887f-e66d5d6a2a0d">


## Related links
- [Old, broken link](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)
- [New, fixed link](https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm)

## PR readiness 
- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.
  - Does this require a changelog entry??
