### PR TITLE
document how to use attachment_rule for automatic attachment

### DIFF
--- a/docs/guides/runbooks_steps.md
+++ b/docs/guides/runbooks_steps.md
@@ -8,9 +8,19 @@ subcategory: "Runbooks"
 FireHydrant runbooks allow you to configure and automate your incident response process by defining a workflow
 to be followed when an incident occurs. Runbooks actually initiate actions that are fundamental steps to
 resolving an incident. Such actions might be creating a Slack channel, starting a Zoom meeting, or opening
-a Jira ticket. These actions are defined as steps in runbooks and each type of step requires different 
-configuration. FireHydrant has a number of integrations, each with different possible steps you can add 
-to your runbook. 
+a Jira ticket. These actions are defined as steps in runbooks and each type of step requires different
+configuration. FireHydrant has a number of integrations, each with different possible steps you can add
+to your runbook.
+
+## Attachment Rule
+
+To have a runbook automatically attach, set `attachment_rule` to an empty JSON chunk.
+
+```
+attachment_rule = jsonencode({})
+```
+
+Explicitly null values will assume the provider default, which is manual attachment.
 
 ## Step Configuration by Integration
 


### PR DESCRIPTION
## Description

Document how to do automatic runbook attachment with `attachment_rule`

## Testing plan

1. _Describe how to replicate the conditions_
1. _under which your code performs its purpose,_
1. _including example Terraform configs where necessary._

## Related links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developers.firehydrant.io/docs/api/xxxx)
- [Related PR](https://github.com/firehydrant/firehydrant/pull/xxxx)

## PR readiness 

- [ ] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [ ] An entry has been added to the changelog, if necessary.