### PR TITLE
Adds initial Signal resources for FireHydrant

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -7,13 +7,13 @@ may require access to the Enterprise tier of FireHydrant to run successfully.
 
 1. `FIREHYDRANT_API_KEY` - (Required) A [bot token](https://support.firehydrant.com/hc/en-us/articles/360057722832-Creating-a-Bot-User)
    to use for testing in FireHydrant.
-2. `FIREHYDRANT_BASE_URL` - (Optional) The FireHydrant API URL to connect to for testing. 
+2. `FIREHYDRANT_BASE_URL` - (Optional) The FireHydrant API URL to connect to for testing.
    Defaults to `https://api.firehydrant.io/v1/`
 
-You can set your environment variables using whatever method you'd like. 
+You can set your environment variables using whatever method you'd like.
 The following are instructions for setting up environment variables using [envchain](https://github.com/sorah/envchain).
 
-1. Make sure you have envchain installed. 
+1. Make sure you have envchain installed.
    [Instructions for this can be found in the envchain README](https://github.com/sorah/envchain#installation).
 2. Pick a namespace for storing your environment variables. I suggest `terraform-provider-firehydrant`.
 3. For each environment variable you need to set, run the following command:

--- a/docs/resources/escalation_policy.md
+++ b/docs/resources/escalation_policy.md
@@ -1,0 +1,84 @@
+---
+page_title: "FireHydrant Resource: firehydrant_escalation_policy"
+subcategory: "Signals"
+---
+
+# firehydrant_escalation_policy Resource
+
+FireHydrant escalation policies are used to define the order in which teams are notified of an alert.
+
+## Example Usage
+
+Basic usage:
+```hcl
+data "firehydrant_user" "my-user" {
+  email = "user@example.com"
+}
+
+resource "firehydrant_team" "example-team" {
+  name        = "example-team"
+  description = "This is an example team"
+
+  memberships {
+    user_id          = data.firehydrant_user.my-user.id
+  }
+}
+
+resource "firehydrant_escalation_policy" "default_policy" {
+  name = "Default Policy"
+  description = "This is an example escalation policy"
+  team_id = firehydrant_team.example-team.id
+
+  step {
+    timeout     = "PT1M"
+
+    targets {
+      type = "OnCallSchedule"
+      id   = firehydrant_on_call_schedule.primary.id
+    }
+
+    targets {
+      type = "User"
+      id   = data.firehydrant_user.my-user.id
+    }
+  }
+
+  repetitions = 2
+
+  handoff_step {
+    target_type = "User"
+    target_id   = data.firehydrant_user.my-user.id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the escalation policy.
+* `description` - (Optional) A description for the escalation policy.
+* `team_id` - (Required) The ID of the team to associate the escalation policy with.
+* `step` - (Required) A block to define a step in the escalation policy. (a minimum of one is required)
+* `handoff_step` - (Optional) A block to define a handoff step in the escalation policy.
+
+The `step` block supports:
+
+* `timeout` - (Required) The amount of time to wait before escalating to the next step. Must be in ISO 8601 duration format.
+* `targets` - (Required) A block to define a target for the step. (a minimum of one is required)
+
+The `targets` block supports:
+
+* `repetitions` - (Required) The number of times to repeat the escalation policy. Defaults to 0.
+* `handoff_step` - (Optional) A block to define a handoff step in the escalation policy.
+
+The `handoff_step` block supports:
+
+* `target_id` - (Required) The ID of the target to handoff to.
+* `target_type` - (Required) The type of target to handoff to. Must be one of `User`, `Team`, or `OnCallSchedule`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the escalation policy.

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -1,0 +1,89 @@
+---
+page_title: "FireHydrant Resource: firehydrant_on_call_schedule"
+subcategory: "Signals"
+---
+
+# firehydrant_on_call_schedule Resource
+
+FireHydrant on-call schedules are used to define who is on-call for a given time period.
+
+## Example Usage
+
+Basic usage:
+```hcl
+data "firehydrant_user" "my-user" {
+  email = "user@example.com"
+}
+
+resource "firehydrant_team" "example-team" {
+  name        = "example-team"
+  description = "This is an example team"
+
+  memberships {
+    user_id          = data.firehydrant_user.my-user.id
+  }
+}
+
+resource "firehydrant_on_call_schedule" "primary" {
+  name        = "Primary On-Call Schedule"
+  description = "This is an example on-call schedule"
+  team_id     = firehydrant_team.example-team.id
+
+  member_ids = [
+    data.firehydrant_user.my-user.id,
+  ]
+
+  time_zone   = "America/New_York"
+
+  strategy {
+    type         = "weekly"
+    handoff_time = "10:00:00"
+    handoff_day  = "thursday"
+  }
+
+  restrictions {
+    start_day = "monday"
+    end_day = "monday"
+    start_time = "10:00:00"
+    end_time = "14:00:00"
+  }
+
+  restrictions {
+    start_day = "tuesday"
+    end_day = "tuesday"
+    start_time = "12:00:00"
+    end_time = "23:00:00"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the on-call schedule.
+* `description` - (Optional) A description for the on-call schedule.
+* `team_id` - (Required) The ID of the team that the on-call schedule belongs to.
+* `member_ids` - (Required) A list of user IDs that are on-call for the on-call schedule.
+* `time_zone` - (Required) The time zone that the on-call schedule is in.
+* `strategy` - (Required) A block to define the strategy for the on-call schedule.
+* `restrictions` - (Optional) A block to define a restriction for the on-call schedule.
+
+The `strategy` block supports:
+
+* `type` - (Required) The type of strategy to use for the on-call schedule. Valid values are `weekly` and `daily`.
+* `handoff_time` - (Required) The time of day that the on-call schedule handoff occurs. Must be in `HH:MM:SS` format.
+* `handoff_day` - (Required) The day of the week that the on-call schedule handoff occurs. Valid values are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, and `saturday`.
+
+The `restrictions` block supports:
+
+* `start_day` - (Required) The day of the week that the restriction starts. Valid values are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, and `saturday`.
+* `end_day` - (Required) The day of the week that the restriction ends. Valid values are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, and `saturday`.
+* `start_time` - (Required) The time of day that the restriction starts. Must be in `HH:MM:SS` format.
+* `end_time` - (Required) The time of day that the restriction ends. Must be in `HH:MM:SS` format.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the on-call schedule.

--- a/docs/resources/signal_rule.md
+++ b/docs/resources/signal_rule.md
@@ -1,0 +1,50 @@
+---
+page_title: "FireHydrant Resource: firehydrant_signal_rule"
+subcategory: "Signals"
+---
+
+# firehydrant_signal_rule Resource
+
+FireHydrant signal rules are used to convert incoming events into outbound alerts sent to a specified destination.
+
+## Example Usage
+
+Basic usage:
+```hcl
+data "firehydrant_user" "my-user" {
+  email = "example@firehydrant.io"
+}
+
+resource "firehydrant_team" "example-team" {
+  name        = "example-team"
+  description = "This is an example team"
+
+  memberships {
+    user_id          = data.firehydrant_user.my-user.id
+  }
+}
+
+resource "firehydrant_signal_rule" "datadog_source" {
+  team_id = firehydrant_team.example-team.id
+  name = "Datadog Source"
+  expression = "signal.summary.contains(\"[Triggered]\")"
+  target_type = "EscalationPolicy"
+  target_id = firehydrant_escalation_policy.default_policy.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `team_id` - (Required) The ID of the team to associate the signal rule with.
+* `name` - (Required) The name of the signal rule.
+* `expression` - (Required) The expression to evaluate incoming events against.
+* `target_type` - (Required) The type of resource to send alerts to. Valid values are `EscalationPolicy`, `OnCallSchedule`, and `User`.
+* `target_id` - (Required) The ID of the resource to send alerts to.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the signal rule.

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -69,6 +69,11 @@ type Client interface {
 
 	// Schedules
 	GetSchedules(ctx context.Context, params GetScheduleParams) (*ScheduleResponse, error)
+
+	// Signals
+	SignalsRules() SignalsRules
+	OnCallSchedules() OnCallSchedules
+	EscalationPolicies() EscalationPolicies
 }
 
 // OptFunc is a function that sets a setting on a client
@@ -186,6 +191,19 @@ func (c *APIClient) TaskLists() TaskListsClient {
 // Teams returns a TeamsClient interface for interacting with teams in FireHydrant
 func (c *APIClient) Teams() TeamsClient {
 	return &RESTTeamsClient{client: c}
+}
+
+// SignalsRules returns a SignalsRules interface for interacting with signals rules in FireHydrant
+func (c *APIClient) SignalsRules() SignalsRules {
+	return &RESTSignalsRulesClient{client: c}
+}
+
+func (c *APIClient) OnCallSchedules() OnCallSchedules {
+	return &RESTOnCallSchedulesClient{client: c}
+}
+
+func (c *APIClient) EscalationPolicies() EscalationPolicies {
+	return &RESTEscalationPoliciesClient{client: c}
 }
 
 // GetUsers gets matching users in FireHydrant

--- a/firehydrant/escalation_policies.go
+++ b/firehydrant/escalation_policies.go
@@ -1,0 +1,152 @@
+package firehydrant
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dghubble/sling"
+)
+
+type EscalationPolicies interface {
+	Get(ctx context.Context, teamID, id string) (*EscalationPolicyResponse, error)
+	Create(ctx context.Context, teamID string, createReq CreateEscalationPolicyRequest) (*EscalationPolicyResponse, error)
+	Update(ctx context.Context, teamID, id string, updateReq UpdateEscalationPolicyRequest) (*EscalationPolicyResponse, error)
+	Delete(ctx context.Context, teamID, id string) error
+}
+
+type RESTEscalationPoliciesClient struct {
+	client *APIClient
+}
+
+var _ EscalationPolicies = &RESTEscalationPoliciesClient{}
+
+type EscalationPolicyResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Default     bool   `json:"default"`
+	Repetitions int    `json:"repetitions"`
+
+	Steps []EscalationPolicyStepWithTarget `json:"steps"`
+
+	HandoffStep *EscalationPolicyHandoffStep `json:"handoff_step"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type EscalationPolicyStepTarget struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
+}
+
+type EscalationPolicyHandoffStep struct {
+	ID   string `json:"target_id"`
+	Type string `json:"target_type"`
+}
+
+type EscalationPolicyStepWithTarget struct {
+	ID       string                   `json:"id"`
+	Position int                      `json:"position"`
+	Timeout  string                   `json:"timeout"`
+	Targets  []EscalationPolicyTarget `json:"targets"`
+}
+
+type EscalationPolicyTarget struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type EscalationPolicyStep struct {
+	ID       string                   `json:"id"`
+	Position int                      `json:"position"`
+	Timeout  string                   `json:"timeout"`
+	Targets  []EscalationPolicyTarget `json:"targets"`
+}
+
+type CreateEscalationPolicyRequest struct {
+	Name        string                       `json:"name"`
+	Description string                       `json:"description"`
+	Default     bool                         `json:"default"`
+	Repetitions int                          `json:"repetitions"`
+	Steps       []EscalationPolicyStep       `json:"steps"`
+	HandoffStep *EscalationPolicyHandoffStep `json:"handoff_step,omitempty"`
+}
+
+type UpdateEscalationPolicyRequest struct {
+	Name        string                       `json:"name"`
+	Description string                       `json:"description"`
+	Default     bool                         `json:"default"`
+	Repetitions int                          `json:"repetitions"`
+	Steps       []EscalationPolicyStep       `json:"steps"`
+	HandoffStep *EscalationPolicyHandoffStep `json:"handoff_step"`
+}
+
+func (c *RESTEscalationPoliciesClient) restClient() *sling.Sling {
+	return c.client.client()
+}
+
+func (c *RESTEscalationPoliciesClient) Create(ctx context.Context, teamID string, createReq CreateEscalationPolicyRequest) (*EscalationPolicyResponse, error) {
+	escalationPolicyResponse := &EscalationPolicyResponse{}
+	apiError := &APIError{}
+
+	response, err := c.restClient().Post(fmt.Sprintf("teams/%s/escalation_policies", teamID)).BodyJSON(createReq).Receive(escalationPolicyResponse, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return escalationPolicyResponse, nil
+}
+
+func (c *RESTEscalationPoliciesClient) Get(ctx context.Context, teamID, id string) (*EscalationPolicyResponse, error) {
+	escalationPolicyResponse := &EscalationPolicyResponse{}
+	apiError := &APIError{}
+
+	response, err := c.restClient().Get(fmt.Sprintf("teams/%s/escalation_policies/%s", teamID, id)).Receive(escalationPolicyResponse, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return escalationPolicyResponse, nil
+}
+
+func (c *RESTEscalationPoliciesClient) Update(ctx context.Context, teamID, id string, updateReq UpdateEscalationPolicyRequest) (*EscalationPolicyResponse, error) {
+	escalationPolicyResponse := &EscalationPolicyResponse{}
+	apiError := &APIError{}
+
+	response, err := c.restClient().Patch(fmt.Sprintf("teams/%s/escalation_policies/%s", teamID, id)).BodyJSON(updateReq).Receive(escalationPolicyResponse, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return escalationPolicyResponse, nil
+}
+
+func (c *RESTEscalationPoliciesClient) Delete(ctx context.Context, teamID, id string) error {
+	apiError := &APIError{}
+
+	_, err := c.restClient().Delete(fmt.Sprintf("teams/%s/escalation_policies/%s", teamID, id)).Receive(nil, apiError)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/firehydrant/on_call_schedules.go
+++ b/firehydrant/on_call_schedules.go
@@ -1,0 +1,140 @@
+package firehydrant
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dghubble/sling"
+	"github.com/pkg/errors"
+)
+
+type OnCallSchedules interface {
+	Get(ctx context.Context, teamID, id string) (*OnCallScheduleResponse, error)
+	Create(ctx context.Context, teamID string, createReq CreateOnCallScheduleRequest) (*OnCallScheduleResponse, error)
+	Update(ctx context.Context, teamID, id string, updateReq UpdateOnCallScheduleRequest) (*OnCallScheduleResponse, error)
+	Delete(ctx context.Context, teamID, id string) error
+}
+
+type RESTOnCallSchedulesClient struct {
+	client *APIClient
+}
+
+var _ OnCallSchedules = &RESTOnCallSchedulesClient{}
+
+type OnCallScheduleStrategy struct {
+	Type          string `json:"type"`
+	HandoffTime   string `json:"handoff_time"`
+	HandoffDay    string `json:"handoff_day"`
+	ShiftDuration string `json:"shift_duration"`
+}
+
+type OnCallScheduleMember struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type OnCallScheduleResponse struct {
+	ID           string                      `json:"id"`
+	Name         string                      `json:"name"`
+	Description  string                      `json:"description"`
+	TimeZone     string                      `json:"time_zone"`
+	Strategy     OnCallScheduleStrategy      `json:"strategy"`
+	Members      []OnCallScheduleMember      `json:"members"`
+	Restrictions []OnCallScheduleRestriction `json:"restrictions"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type CreateOnCallScheduleRequest struct {
+	Name         string                      `json:"name"`
+	Description  string                      `json:"description"`
+	TimeZone     string                      `json:"time_zone"`
+	Strategy     OnCallScheduleStrategy      `json:"strategy"`
+	Restrictions []OnCallScheduleRestriction `json:"restrictions"`
+	MemberIDs    []string                    `json:"member_ids"`
+}
+
+type UpdateOnCallScheduleRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type OnCallScheduleRestriction struct {
+	StartDay  string `json:"start_day"`
+	StartTime string `json:"start_time"`
+	EndDay    string `json:"end_day"`
+	EndTime   string `json:"end_time"`
+}
+
+func (c *RESTOnCallSchedulesClient) restClient() *sling.Sling {
+	return c.client.client()
+}
+
+func (c *RESTOnCallSchedulesClient) Create(ctx context.Context, teamID string, createReq CreateOnCallScheduleRequest) (*OnCallScheduleResponse, error) {
+	onCallScheduleResponse := &OnCallScheduleResponse{}
+	apiError := &APIError{}
+
+	response, err := c.restClient().Post(fmt.Sprintf("teams/%s/on_call_schedules", teamID)).BodyJSON(createReq).Receive(onCallScheduleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create on-call schedule")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return onCallScheduleResponse, nil
+}
+
+func (c *RESTOnCallSchedulesClient) Get(ctx context.Context, teamID, id string) (*OnCallScheduleResponse, error) {
+	onCallScheduleResponse := &OnCallScheduleResponse{}
+	apiError := &APIError{}
+
+	response, err := c.restClient().Get(fmt.Sprintf("teams/%s/on_call_schedules/%s", teamID, id)).Receive(onCallScheduleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get on-call schedule")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return onCallScheduleResponse, nil
+}
+
+func (c *RESTOnCallSchedulesClient) Update(ctx context.Context, teamID, id string, updateReq UpdateOnCallScheduleRequest) (*OnCallScheduleResponse, error) {
+	onCallScheduleResponse := &OnCallScheduleResponse{}
+	apiError := &APIError{}
+
+	response, err := c.restClient().Patch(fmt.Sprintf("teams/%s/on_call_schedules/%s", teamID, id)).BodyJSON(updateReq).Receive(onCallScheduleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not update on-call schedule")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return onCallScheduleResponse, nil
+}
+
+func (c *RESTOnCallSchedulesClient) Delete(ctx context.Context, teamID, id string) error {
+	apiError := &APIError{}
+
+	response, err := c.restClient().Delete(fmt.Sprintf("teams/%s/on_call_schedules/%s", teamID, id)).Receive(nil, apiError)
+	if err != nil {
+		return errors.Wrap(err, "could not delete on-call schedule")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/firehydrant/signals_rules.go
+++ b/firehydrant/signals_rules.go
@@ -1,0 +1,119 @@
+package firehydrant
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dghubble/sling"
+	"github.com/pkg/errors"
+)
+
+type SignalsRules interface {
+	Get(ctx context.Context, teamID, id string) (*SignalsRuleResponse, error)
+	Create(ctx context.Context, teamID string, createReq CreateSignalsRuleRequest) (*SignalsRuleResponse, error)
+	Update(ctx context.Context, teamID, id string, updateReq UpdateSignalsRuleRequest) (*SignalsRuleResponse, error)
+	Delete(ctx context.Context, teamID, id string) error
+}
+
+type RESTSignalsRulesClient struct {
+	client *APIClient
+}
+
+var _ SignalsRules = &RESTSignalsRulesClient{}
+
+type SignalRuleTarget struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+type SignalsRuleResponse struct {
+	ID         string           `json:"id"`
+	Name       string           `json:"name"`
+	Expression string           `json:"expression"`
+	Target     SignalRuleTarget `json:"target"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type CreateSignalsRuleRequest struct {
+	Name       string `json:"name"`
+	Expression string `json:"expression"`
+	TargetType string `json:"target_type"`
+	TargetID   string `json:"target_id"`
+}
+
+type UpdateSignalsRuleRequest struct {
+	Name       string `json:"name"`
+	Expression string `json:"expression"`
+	TargetType string `json:"target_type"`
+	TargetID   string `json:"target_id"`
+}
+
+func (c *RESTSignalsRulesClient) restClient() *sling.Sling {
+	return c.client.client()
+}
+
+func (c *RESTSignalsRulesClient) Create(ctx context.Context, teamID string, createReq CreateSignalsRuleRequest) (*SignalsRuleResponse, error) {
+	signalRuleResponse := &SignalsRuleResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Post(fmt.Sprintf("teams/%s/signal_rules", teamID)).BodyJSON(&createReq).Receive(signalRuleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create signal rule")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return signalRuleResponse, nil
+}
+
+func (c *RESTSignalsRulesClient) Get(ctx context.Context, teamID, id string) (*SignalsRuleResponse, error) {
+	signalRuleResponse := &SignalsRuleResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Get(fmt.Sprintf("teams/%s/signal_rules/%s", teamID, id)).Receive(signalRuleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get signal rule")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return signalRuleResponse, nil
+}
+
+func (c *RESTSignalsRulesClient) Update(ctx context.Context, teamID, id string, updateReq UpdateSignalsRuleRequest) (*SignalsRuleResponse, error) {
+	signalRuleResponse := &SignalsRuleResponse{}
+	apiError := &APIError{}
+	response, err := c.restClient().Patch(fmt.Sprintf("teams/%s/signal_rules/%s", teamID, id)).BodyJSON(&updateReq).Receive(signalRuleResponse, apiError)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not update signal rule")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return nil, err
+	}
+
+	return signalRuleResponse, nil
+}
+
+func (c *RESTSignalsRulesClient) Delete(ctx context.Context, teamID, id string) error {
+	apiError := &APIError{}
+	response, err := c.restClient().Delete(fmt.Sprintf("teams/%s/signal_rules/%s", teamID, id)).Receive(nil, apiError)
+	if err != nil {
+		return errors.Wrap(err, "could not delete signal rule")
+	}
+
+	err = checkResponseStatusCode(response, apiError)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/provider/escalation_policy_resource.go
+++ b/provider/escalation_policy_resource.go
@@ -1,0 +1,280 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceEscalationPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createResourceFireHydrantEscalationPolicy,
+		UpdateContext: updateResourceFireHydrantEscalationPolicy,
+		ReadContext:   readResourceFireHydrantEscalationPolicy,
+		DeleteContext: deleteResourceFireHydrantEscalationPolicy,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"team_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"repetitions": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"step": {
+				Type:     schema.TypeList, // or TypeSet if ordering is not important
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"timeout": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"targets": {
+							Type:     schema.TypeList,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"handoff_step": {
+				Type:     schema.TypeList,
+				Optional: true, // or Required based on your API
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"target_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func readResourceFireHydrantEscalationPolicy(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get the escalation policy
+	id := d.Id()
+	teamID := d.Get("team_id").(string)
+	tflog.Debug(ctx, "Read escalation policy", map[string]interface{}{
+		"id":      id,
+		"team_id": teamID,
+	})
+
+	escalationPolicy, err := firehydrantAPIClient.EscalationPolicies().Get(ctx, teamID, id)
+	if err != nil {
+		return diag.Errorf("Error reading escalation policy %s: %v", id, err)
+	}
+
+	// Update the resource data
+	d.Set("name", escalationPolicy.Name)
+	d.Set("description", escalationPolicy.Description)
+	d.Set("default", escalationPolicy.Default)
+	d.Set("repetitions", escalationPolicy.Repetitions)
+
+	// Set the steps
+	var steps []map[string]interface{}
+	for _, step := range escalationPolicy.Steps {
+		targets := []map[string]interface{}{}
+		for _, target := range step.Targets {
+			targetMap := map[string]interface{}{
+				"type": target.Type,
+				"id":   target.ID,
+			}
+
+			targets = append(targets, targetMap)
+		}
+
+		stepMap := map[string]interface{}{
+			"timeout": step.Timeout,
+			"targets": targets,
+		}
+
+		steps = append(steps, stepMap)
+	}
+
+	d.Set("step", steps)
+
+	// Set the handoff step
+	if escalationPolicy.HandoffStep != nil {
+		handoffStepMap := map[string]interface{}{
+			"target_type": escalationPolicy.HandoffStep.Type,
+			"target_id":   escalationPolicy.HandoffStep.ID,
+		}
+
+		d.Set("handoff_step", []map[string]interface{}{handoffStepMap})
+	}
+
+	return diag.Diagnostics{}
+}
+
+// creates an escalation policy for a team using the firehydrant api client
+func createResourceFireHydrantEscalationPolicy(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Create the escalation policy
+	teamID := d.Get("team_id").(string)
+	createReq := firehydrant.CreateEscalationPolicyRequest{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Default:     d.Get("default").(bool),
+		Repetitions: d.Get("repetitions").(int),
+		Steps:       getStepsFromResourceData(d),
+		HandoffStep: getHandoffStepFromResourceData(d),
+	}
+
+	tflog.Debug(ctx, "Creating escalation policy", map[string]interface{}{
+		"team_id": teamID,
+		"request": createReq,
+	})
+
+	escalationPolicy, err := firehydrantAPIClient.EscalationPolicies().Create(ctx, teamID, createReq)
+	if err != nil {
+		return diag.Errorf("Error creating signal rule %s: %v", d.Id(), err)
+	}
+
+	// Set the ID of the escalation policy
+	d.SetId(escalationPolicy.ID)
+	return readResourceFireHydrantEscalationPolicy(ctx, d, m)
+}
+
+func updateResourceFireHydrantEscalationPolicy(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Update the escalation policy
+	teamID := d.Get("team_id").(string)
+	updateReq := firehydrant.UpdateEscalationPolicyRequest{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Default:     d.Get("default").(bool),
+		Repetitions: d.Get("repetitions").(int),
+		Steps:       getStepsFromResourceData(d),
+		HandoffStep: getHandoffStepFromResourceData(d),
+	}
+
+	tflog.Debug(ctx, "Updating escalation policy", map[string]interface{}{
+		"team_id": teamID,
+		"request": spew.Sdump(updateReq),
+	})
+
+	_, err := firehydrantAPIClient.EscalationPolicies().Update(ctx, teamID, d.Id(), updateReq)
+	if err != nil {
+		return diag.Errorf("Error updating escalation policy %s: %v", d.Id(), err)
+	}
+
+	return readResourceFireHydrantEscalationPolicy(ctx, d, m)
+}
+
+func deleteResourceFireHydrantEscalationPolicy(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Delete the escalation policy
+	teamID := d.Get("team_id").(string)
+	tflog.Debug(ctx, "Deleting escalation policy", map[string]interface{}{
+		"team_id": teamID,
+		"id":      d.Id(),
+	})
+
+	err := firehydrantAPIClient.EscalationPolicies().Delete(ctx, teamID, d.Id())
+	if err != nil {
+		return diag.Errorf("Error deleting escalation policy %s: %v", d.Id(), err)
+	}
+
+	return nil
+}
+
+func getHandoffStepFromResourceData(d *schema.ResourceData) *firehydrant.EscalationPolicyHandoffStep {
+	if v, ok := d.GetOk("handoff_step"); ok {
+		handoffStepList := v.([]interface{})
+
+		if len(handoffStepList) > 0 {
+			handoffStepMap := handoffStepList[0].(map[string]interface{})
+
+			handoffStep := &firehydrant.EscalationPolicyHandoffStep{
+				Type: handoffStepMap["type"].(string),
+				ID:   handoffStepMap["id"].(string),
+			}
+
+			return handoffStep
+		}
+	}
+
+	return nil
+}
+
+func getStepsFromResourceData(d *schema.ResourceData) []firehydrant.EscalationPolicyStep {
+	var steps []firehydrant.EscalationPolicyStep
+
+	if v, ok := d.GetOk("step"); ok {
+		stepList := v.([]interface{})
+		for position, stepItem := range stepList {
+			stepMap := stepItem.(map[string]interface{})
+			targets := stepMap["targets"].([]interface{})
+
+			var stepTargets []firehydrant.EscalationPolicyTarget
+			for _, targetItem := range targets {
+				targetMap := targetItem.(map[string]interface{})
+				target := firehydrant.EscalationPolicyTarget{
+					// ID is not provided in resource data, so it's not set here
+					Type: targetMap["type"].(string),
+					ID:   targetMap["id"].(string),
+				}
+
+				stepTargets = append(stepTargets, target)
+			}
+
+			step := firehydrant.EscalationPolicyStep{
+				Position: position,
+				Timeout:  stepMap["timeout"].(string),
+				Targets:  stepTargets,
+			}
+
+			steps = append(steps, step)
+		}
+	}
+
+	return steps
+}

--- a/provider/escalation_policy_resource_test.go
+++ b/provider/escalation_policy_resource_test.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccEscalationPolicyResource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckEscalationPolicyResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEscalationPolicyConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_escalation_policy.test_escalation_policy", "id"),
+					resource.TestCheckResourceAttr("firehydrant_escalation_policy.test_escalation_policy", "name", fmt.Sprintf("test-escalation-policy-%s", rName)),
+					resource.TestCheckResourceAttr("firehydrant_escalation_policy.test_escalation_policy", "description", fmt.Sprintf("test-description-%s", rName)),
+					resource.TestCheckResourceAttr("firehydrant_escalation_policy.test_escalation_policy", "step.0.timeout", "PT1M"),
+					resource.TestCheckResourceAttr("firehydrant_escalation_policy.test_escalation_policy", "step.0.targets.0.type", "OnCallSchedule"),
+					resource.TestCheckResourceAttrSet("firehydrant_escalation_policy.test_escalation_policy", "step.0.targets.0.id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEscalationPolicyConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+	resource "firehydrant_team" "team_team" {
+		name = "test-team-%s"
+	}
+
+	resource "firehydrant_on_call_schedule" "test_on_call_schedule" {
+		team_id = firehydrant_team.team_team.id
+		name = "test-on-call-schedule-restrictions-%s"
+		time_zone = "America/New_York"
+
+		strategy {
+			type         = "weekly"
+			handoff_time = "10:00:00"
+			handoff_day  = "thursday"
+		}
+	}
+
+	resource "firehydrant_escalation_policy" "test_escalation_policy" {
+		team_id = firehydrant_team.team_team.id
+		name = "test-escalation-policy-%s"
+		description = "test-description-%s"
+		repetitions = 1
+
+		step {
+			timeout     = "PT1M"
+
+			targets {
+				type = "OnCallSchedule"
+				id   = firehydrant_on_call_schedule.test_on_call_schedule.id
+			}
+		}
+	}
+	`, rName, rName, rName, rName)
+}
+
+func testAccCheckEscalationPolicyResourceDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		for _, stateResource := range s.RootModule().Resources {
+			if stateResource.Type != "firehydrant_escalation_policy" {
+				continue
+			}
+
+			if stateResource.Primary.ID == "" {
+				return fmt.Errorf("No instance ID is set")
+			}
+
+			// Normally we'd check if err == nil here, because we'd expect a 404 if we try to get a resource
+			// that has been deleted. However, the incident role API will still return deleted/archived incident
+			// roles instead of returning 404. So, to check for incident roles that are deleted, we have to check
+			// for incident roles that have a DiscardedAt timestamp
+			_, err := client.EscalationPolicies().Get(context.TODO(), stateResource.Primary.Attributes["team_id"], stateResource.Primary.ID)
+			if err != nil && !errors.Is(err, firehydrant.ErrorNotFound) {
+				return fmt.Errorf("Escalation policy %s still exists", stateResource.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}

--- a/provider/escalation_policy_resource_test.go
+++ b/provider/escalation_policy_resource_test.go
@@ -38,12 +38,12 @@ func TestAccEscalationPolicyResource_basic(t *testing.T) {
 
 func testAccEscalationPolicyConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-	resource "firehydrant_team" "team_team" {
+	resource "firehydrant_team" "test-team" {
 		name = "test-team-%s"
 	}
 
 	resource "firehydrant_on_call_schedule" "test_on_call_schedule" {
-		team_id = firehydrant_team.team_team.id
+		team_id = firehydrant_team.test-team.id
 		name = "test-on-call-schedule-restrictions-%s"
 		time_zone = "America/New_York"
 
@@ -55,7 +55,7 @@ func testAccEscalationPolicyConfig_basic(rName string) string {
 	}
 
 	resource "firehydrant_escalation_policy" "test_escalation_policy" {
-		team_id = firehydrant_team.team_team.id
+		team_id = firehydrant_team.test-team.id
 		name = "test-escalation-policy-%s"
 		description = "test-description-%s"
 		repetitions = 1

--- a/provider/on_call_schedule_resource.go
+++ b/provider/on_call_schedule_resource.go
@@ -1,0 +1,282 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceOnCallSchedule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createResourceFireHydrantOnCallSchedule,
+		ReadContext:   readResourceFireHydrantOnCallSchedule,
+		UpdateContext: updateResourceFireHydrantOnCallSchedule,
+		DeleteContext: deleteResourceFireHydrantOnCallSchedule,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"team_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"members": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"time_zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"strategy": {
+				Type:     schema.TypeList, // Using TypeList to simulate a map
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"handoff_time": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"handoff_day": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"color": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"restrictions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start_day": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"start_time": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"end_day": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"end_time": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Create the on-call schedule
+	teamID := d.Get("team_id").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Create on-call schedule: %s", teamID), map[string]interface{}{
+		"team_id": teamID,
+	})
+
+	memberIds := make([]string, len(d.Get("members").([]interface{})))
+	for i, member := range d.Get("members").([]interface{}) {
+		memberIds[i] = member.(string)
+	}
+
+	// Gather values from API response
+	onCallSchedule := firehydrant.CreateOnCallScheduleRequest{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		TimeZone:    d.Get("time_zone").(string),
+		Strategy: firehydrant.OnCallScheduleStrategy{
+			Type:        d.Get("strategy.0.type").(string),
+			HandoffTime: d.Get("strategy.0.handoff_time").(string),
+			HandoffDay:  d.Get("strategy.0.handoff_day").(string),
+		},
+		MemberIDs:    memberIds,
+		Restrictions: oncallRestrictionsFromData(d),
+	}
+
+	// Create the on-call schedule
+	createdOnCallSchedule, err := firehydrantAPIClient.OnCallSchedules().Create(ctx, teamID, onCallSchedule)
+	if err != nil {
+		return diag.Errorf("Error creating on-call schedule %s: %v", teamID, err)
+	}
+
+	// Set the on-call schedule's ID in state
+	d.SetId(createdOnCallSchedule.ID)
+
+	return readResourceFireHydrantOnCallSchedule(ctx, d, m)
+}
+
+func readResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get the signal rule
+	id := d.Id()
+	teamID := d.Get("team_id").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Read signal rule: %s", id), map[string]interface{}{
+		"id":      id,
+		"team_id": teamID,
+	})
+
+	onCallSchedule, err := firehydrantAPIClient.OnCallSchedules().Get(ctx, teamID, id)
+	if err != nil {
+		if errors.Is(err, firehydrant.ErrorNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("On-call schedule %s no longer exists", id), map[string]interface{}{
+				"id":      id,
+				"team_id": teamID,
+			})
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error reading on-call schedule %s: %v", id, err)
+	}
+
+	// Gather values from API response
+	memberIds := make([]string, len(onCallSchedule.Members))
+	for i, member := range onCallSchedule.Members {
+		memberIds[i] = member.ID
+	}
+
+	attributes := map[string]interface{}{
+		"name":         onCallSchedule.Name,
+		"description":  onCallSchedule.Description,
+		"time_zone":    onCallSchedule.TimeZone,
+		"strategy":     strategyToMap(onCallSchedule.Strategy),
+		"members":      memberIds,
+		"restrictions": restrictionsToData(onCallSchedule.Restrictions),
+	}
+
+	// Set the data source attributes to the values we got from the API
+	for key, val := range attributes {
+		if err := d.Set(key, val); err != nil {
+			return diag.Errorf("Error setting %s for on-call schedule %s: %v", key, id, err)
+		}
+	}
+
+	// Set the on-call schedule's ID in state
+	d.SetId(onCallSchedule.ID)
+
+	return diag.Diagnostics{}
+}
+
+func updateResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	id := d.Id()
+	teamID := d.Get("team_id").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Update on-call schedule: %s", id), map[string]interface{}{
+		"id":      id,
+		"team_id": teamID,
+	})
+
+	onCallSchedule := firehydrant.UpdateOnCallScheduleRequest{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+
+	// Update the on-call schedule
+	_, err := firehydrantAPIClient.OnCallSchedules().Update(ctx, teamID, id, onCallSchedule)
+	if err != nil {
+		return diag.Errorf("Error updating on-call schedule %s: %v", id, err)
+	}
+
+	return readResourceFireHydrantOnCallSchedule(ctx, d, m)
+}
+
+func deleteResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	id := d.Id()
+	teamID := d.Get("team_id").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Delete on-call schedule: %s", id), map[string]interface{}{
+		"id":      id,
+		"team_id": teamID,
+	})
+
+	// Delete the on-call schedule
+	err := firehydrantAPIClient.OnCallSchedules().Delete(ctx, teamID, id)
+	if err != nil {
+		return diag.Errorf("Error deleting on-call schedule %s: %v", id, err)
+	}
+
+	// Remove the on-call schedule's ID from state
+	d.SetId("")
+
+	return diag.Diagnostics{}
+}
+
+func strategyToMap(strategy firehydrant.OnCallScheduleStrategy) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"type":         strategy.Type,
+			"handoff_time": strategy.HandoffTime,
+			"handoff_day":  strategy.HandoffDay,
+		},
+	}
+}
+
+func oncallRestrictionsFromData(d *schema.ResourceData) []firehydrant.OnCallScheduleRestriction {
+	restrictions := make([]firehydrant.OnCallScheduleRestriction, 0)
+	for _, restriction := range d.Get("restrictions").([]interface{}) {
+		restrictionMap := restriction.(map[string]interface{})
+		restrictions = append(restrictions, firehydrant.OnCallScheduleRestriction{
+			StartDay:  restrictionMap["start_day"].(string),
+			StartTime: restrictionMap["start_time"].(string),
+			EndDay:    restrictionMap["end_day"].(string),
+			EndTime:   restrictionMap["end_time"].(string),
+		})
+	}
+	return restrictions
+}
+
+func restrictionsToData(restrictions []firehydrant.OnCallScheduleRestriction) []map[string]interface{} {
+	restrictionMaps := make([]map[string]interface{}, 0)
+	for _, restriction := range restrictions {
+		restrictionMaps = append(restrictionMaps, map[string]interface{}{
+			"start_day":  restriction.StartDay,
+			"start_time": restriction.StartTime,
+			"end_day":    restriction.EndDay,
+			"end_time":   restriction.EndTime,
+		})
+	}
+	return restrictionMaps
+}

--- a/provider/on_call_schedule_resource_test.go
+++ b/provider/on_call_schedule_resource_test.go
@@ -1,0 +1,140 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccOnCallScheduleResource_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckOnCallScheduleResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnCallScheduleConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_on_call_schedule", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule", "name", fmt.Sprintf("test-on-call-schedule-%s", rName)),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule", "strategy.0.type", "weekly"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule", "strategy.0.handoff_time", "10:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule", "strategy.0.handoff_day", "thursday"),
+				),
+			},
+			{
+				Config: testAccOnCallScheduleConfig_restrictions(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "name", fmt.Sprintf("test-on-call-schedule-restrictions-%s", rName)),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "strategy.0.type", "weekly"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "strategy.0.handoff_time", "10:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "strategy.0.handoff_day", "thursday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "restrictions.0.start_day", "monday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "restrictions.0.start_time", "09:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "restrictions.0.end_day", "monday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "restrictions.0.end_time", "14:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "restrictions.1.start_day", "tuesday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "restrictions.1.start_time", "12:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "restrictions.1.end_day", "tuesday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_on_call_schedule_with_restrictions", "restrictions.1.end_time", "18:00:00"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOnCallScheduleConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+	resource "firehydrant_team" "team_team" {
+		name = "test-team-%s"
+	}
+
+	resource "firehydrant_on_call_schedule" "test_on_call_schedule" {
+		team_id = firehydrant_team.team_team.id
+		name = "test-on-call-schedule-%s"
+		description = "test-description-%s"
+		time_zone = "America/New_York"
+
+		strategy {
+			type         = "weekly"
+			handoff_time = "10:00:00"
+			handoff_day  = "thursday"
+		}
+	}
+	`, rName, rName, rName)
+}
+
+func testAccOnCallScheduleConfig_restrictions(rName string) string {
+	return fmt.Sprintf(`
+	resource "firehydrant_team" "team_team" {
+		name = "test-team-%s"
+	}
+
+	resource "firehydrant_on_call_schedule" "test_on_call_schedule_with_restrictions" {
+		team_id = firehydrant_team.team_team.id
+		name = "test-on-call-schedule-restrictions-%s"
+		description = "test-description-%s"
+		time_zone = "America/New_York"
+
+		strategy {
+			type         = "weekly"
+			handoff_time = "10:00:00"
+			handoff_day  = "thursday"
+		}
+
+		restrictions {
+			start_day = "monday"
+			start_time = "09:00:00"
+			end_day = "monday"
+			end_time = "14:00:00"
+		}
+
+		restrictions {
+			start_day = "tuesday"
+			start_time = "12:00:00"
+			end_day = "tuesday"
+			end_time = "18:00:00"
+		}
+	}
+	`, rName, rName, rName)
+}
+
+func testAccCheckOnCallScheduleResourceDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := firehydrant.NewRestClient(os.Getenv("FIREHYDRANT_API_KEY"))
+		if err != nil {
+			return err
+		}
+
+		for _, stateResource := range s.RootModule().Resources {
+			if stateResource.Type != "firehydrant_on_call_schedule" {
+				continue
+			}
+
+			if stateResource.Primary.ID == "" {
+				return fmt.Errorf("No instance ID is set")
+			}
+
+			// Normally we'd check if err == nil here, because we'd expect a 404 if we try to get a resource
+			// that has been deleted. However, the incident role API will still return deleted/archived incident
+			// roles instead of returning 404. So, to check for incident roles that are deleted, we have to check
+			// for incident roles that have a DiscardedAt timestamp
+			_, err := client.OnCallSchedules().Get(context.TODO(), stateResource.Primary.Attributes["team_id"], stateResource.Primary.ID)
+			if err != nil && !errors.Is(err, firehydrant.ErrorNotFound) {
+				return fmt.Errorf("On-call schedule %s still exists", stateResource.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -52,6 +52,9 @@ func Provider() *schema.Provider {
 			"firehydrant_severity":           resourceSeverity(),
 			"firehydrant_task_list":          resourceTaskList(),
 			"firehydrant_team":               resourceTeam(),
+			"firehydrant_signal_rule":        resourceSignalRule(),
+			"firehydrant_on_call_schedule":   resourceOnCallSchedule(),
+			"firehydrant_escalation_policy":  resourceEscalationPolicy(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"firehydrant_environment":    dataSourceEnvironment(),

--- a/provider/signal_rule_resource.go
+++ b/provider/signal_rule_resource.go
@@ -1,0 +1,161 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceSignalRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createResourceFireHydrantSignalRule,
+		UpdateContext: updateResourceFireHydrantSignalRule,
+		ReadContext:   readResourceFireHydrantSignalRule,
+		DeleteContext: deleteResourceFireHydrantSignalRule,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			// Required
+			"team_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"expression": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func readResourceFireHydrantSignalRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Get the signal rule
+	id := d.Id()
+	teamID := d.Get("team_id").(string)
+	tflog.Debug(ctx, fmt.Sprintf("Read signal rule: %s", id), map[string]interface{}{
+		"id":      id,
+		"team_id": teamID,
+	})
+
+	signalRule, err := firehydrantAPIClient.SignalsRules().Get(ctx, teamID, id)
+	if err != nil {
+		if errors.Is(err, firehydrant.ErrorNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("Signal rule %s no longer exists", id), map[string]interface{}{
+				"id":      id,
+				"team_id": teamID,
+			})
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error reading signal rule %s: %v", id, err)
+	}
+
+	// Gather values from API response
+	attributes := map[string]interface{}{
+		"name":        signalRule.Name,
+		"expression":  signalRule.Expression,
+		"target_type": signalRule.Target.Type,
+		"target_id":   signalRule.Target.ID,
+	}
+
+	// Set the resource attributes to the values we got from the API
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
+			return diag.Errorf("Error setting %s for signal rule %s: %v", key, id, err)
+		}
+	}
+
+	return diag.Diagnostics{}
+}
+
+func createResourceFireHydrantSignalRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Construct the create request
+	createRequest := firehydrant.CreateSignalsRuleRequest{
+		Name:       d.Get("name").(string),
+		Expression: d.Get("expression").(string),
+		TargetType: d.Get("target_type").(string),
+		TargetID:   d.Get("target_id").(string),
+	}
+
+	// Create the signal rule
+	tflog.Debug(ctx, fmt.Sprintf("Create signal rule: %s", d.Id()), map[string]interface{}{
+		"id": d.Id(),
+	})
+	signalRuleResponse, err := firehydrantAPIClient.SignalsRules().Create(ctx, d.Get("team_id").(string), createRequest)
+	if err != nil {
+		return diag.Errorf("Error creating signal rule %s: %v", d.Id(), err)
+	}
+
+	// Set the ID of the resource to the ID of the newly created signal rule
+	d.SetId(signalRuleResponse.ID)
+
+	// Update state with the latest information from the API
+	return readResourceFireHydrantSignalRule(ctx, d, m)
+}
+
+func updateResourceFireHydrantSignalRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Construct the update request
+	updateRequest := firehydrant.UpdateSignalsRuleRequest{
+		Name:       d.Get("name").(string),
+		Expression: d.Get("expression").(string),
+		TargetType: d.Get("target_type").(string),
+		TargetID:   d.Get("target_id").(string),
+	}
+
+	// Update the signal rule
+	tflog.Debug(ctx, fmt.Sprintf("Update signal rule: %s", d.Id()), map[string]interface{}{
+		"id": d.Id(),
+	})
+	_, err := firehydrantAPIClient.SignalsRules().Update(ctx, d.Get("team_id").(string), d.Id(), updateRequest)
+	if err != nil {
+		return diag.Errorf("Error updating signal rule %s: %v", d.Id(), err)
+	}
+
+	// Update state with the latest information from the API
+	return readResourceFireHydrantSignalRule(ctx, d, m)
+}
+
+func deleteResourceFireHydrantSignalRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	firehydrantAPIClient := m.(firehydrant.Client)
+
+	// Delete the signal rule
+	tflog.Debug(ctx, fmt.Sprintf("Delete signal rule: %s", d.Id()), map[string]interface{}{
+		"id": d.Id(),
+	})
+	err := firehydrantAPIClient.SignalsRules().Delete(ctx, d.Get("team_id").(string), d.Id())
+	if err != nil {
+		return diag.Errorf("Error deleting signal rule %s: %v", d.Id(), err)
+	}
+
+	return diag.Diagnostics{}
+}

--- a/provider/signal_rule_resource_test.go
+++ b/provider/signal_rule_resource_test.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccFireHydrantSignalRule_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFireHydrantSignalRuleConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFireHydrantSignalRuleExists("firehydrant_signal_rule.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFireHydrantSignalRuleConfigBasic() string {
+	return fmt.Sprintf(`
+	data "firehydrant_user" "test_user" {
+		email = "%s"
+	}
+
+	resource "firehydrant_team" "test" {
+		name = "test-team"
+	}
+
+	resource "firehydrant_signal_rule" "test" {
+		team_id = firehydrant_team.test.id
+		name = "test-signal-rule"
+		expression = "signal.summary == 'test-signal-summary'"
+		target_type = "User"
+		target_id = data.firehydrant_user.test_user.id
+	}
+	`, os.Getenv("EXISTING_USER_EMAIL"))
+}
+
+func testAccCheckFireHydrantSignalRuleExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no resource ID is set")
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
## Description

Adds resources to the FireHydrant Terraform provider to create:

* On-call Schedules
* Escalation Policies
* Signal Rules

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.