### PR TITLE
Fix handoff step panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
-## 0.3.7 (Unreleased)
+## 4.0.2 (Unreleased)
+
+N/A
+
+## 4.0.1
+
+BUG FIXES:
+
+* Fixes a bug where handoff steps in escalation policies were assigning to the incorrect schema and causing a panic.
+
+## 4.0.0
 
 * Add labels to functionalities
+* Add initial Signals resources for beta period
 
 ## 0.3.6
 

--- a/firehydrant/escalation_policies.go
+++ b/firehydrant/escalation_policies.go
@@ -43,8 +43,12 @@ type EscalationPolicyStepTarget struct {
 }
 
 type EscalationPolicyHandoffStep struct {
-	ID   string `json:"target_id"`
+	Target EscalationPolicyTarget `json:"target"`
+}
+
+type CreateEscalationPolicyHandoffStep struct {
 	Type string `json:"target_type"`
+	ID   string `json:"target_id"`
 }
 
 type EscalationPolicyStepWithTarget struct {
@@ -68,21 +72,21 @@ type EscalationPolicyStep struct {
 }
 
 type CreateEscalationPolicyRequest struct {
-	Name        string                       `json:"name"`
-	Description string                       `json:"description"`
-	Default     bool                         `json:"default"`
-	Repetitions int                          `json:"repetitions"`
-	Steps       []EscalationPolicyStep       `json:"steps"`
-	HandoffStep *EscalationPolicyHandoffStep `json:"handoff_step,omitempty"`
+	Name        string                             `json:"name"`
+	Description string                             `json:"description"`
+	Default     bool                               `json:"default"`
+	Repetitions int                                `json:"repetitions"`
+	Steps       []EscalationPolicyStep             `json:"steps"`
+	HandoffStep *CreateEscalationPolicyHandoffStep `json:"handoff_step,omitempty"`
 }
 
 type UpdateEscalationPolicyRequest struct {
-	Name        string                       `json:"name"`
-	Description string                       `json:"description"`
-	Default     bool                         `json:"default"`
-	Repetitions int                          `json:"repetitions"`
-	Steps       []EscalationPolicyStep       `json:"steps"`
-	HandoffStep *EscalationPolicyHandoffStep `json:"handoff_step"`
+	Name        string                             `json:"name"`
+	Description string                             `json:"description"`
+	Default     bool                               `json:"default"`
+	Repetitions int                                `json:"repetitions"`
+	Steps       []EscalationPolicyStep             `json:"steps"`
+	HandoffStep *CreateEscalationPolicyHandoffStep `json:"handoff_step"`
 }
 
 func (c *RESTEscalationPoliciesClient) restClient() *sling.Sling {

--- a/provider/escalation_policy_resource.go
+++ b/provider/escalation_policy_resource.go
@@ -141,8 +141,8 @@ func readResourceFireHydrantEscalationPolicy(ctx context.Context, d *schema.Reso
 	// Set the handoff step
 	if escalationPolicy.HandoffStep != nil {
 		handoffStepMap := map[string]interface{}{
-			"target_type": escalationPolicy.HandoffStep.Type,
-			"target_id":   escalationPolicy.HandoffStep.ID,
+			"target_type": escalationPolicy.HandoffStep.Target.Type,
+			"target_id":   escalationPolicy.HandoffStep.Target.ID,
 		}
 
 		d.Set("handoff_step", []map[string]interface{}{handoffStepMap})
@@ -226,16 +226,16 @@ func deleteResourceFireHydrantEscalationPolicy(ctx context.Context, d *schema.Re
 	return nil
 }
 
-func getHandoffStepFromResourceData(d *schema.ResourceData) *firehydrant.EscalationPolicyHandoffStep {
+func getHandoffStepFromResourceData(d *schema.ResourceData) *firehydrant.CreateEscalationPolicyHandoffStep {
 	if v, ok := d.GetOk("handoff_step"); ok {
 		handoffStepList := v.([]interface{})
 
 		if len(handoffStepList) > 0 {
 			handoffStepMap := handoffStepList[0].(map[string]interface{})
 
-			handoffStep := &firehydrant.EscalationPolicyHandoffStep{
-				Type: handoffStepMap["type"].(string),
-				ID:   handoffStepMap["id"].(string),
+			handoffStep := &firehydrant.CreateEscalationPolicyHandoffStep{
+				Type: handoffStepMap["target_type"].(string),
+				ID:   handoffStepMap["target_id"].(string),
 			}
 
 			return handoffStep

--- a/provider/escalation_policy_resource_test.go
+++ b/provider/escalation_policy_resource_test.go
@@ -68,6 +68,11 @@ func testAccEscalationPolicyConfig_basic(rName string) string {
 				id   = firehydrant_on_call_schedule.test_on_call_schedule.id
 			}
 		}
+
+		handoff_step {
+			target_type = "Team"
+			target_id   = firehydrant_team.test-team.id
+		}
 	}
 	`, rName, rName, rName, rName)
 }


### PR DESCRIPTION
## Description

Fixes a panic in the escalation policy resource due to a mismatch in schema definition and map keys.

## Testing plan

* The test modification included reproduced the reported error from the customer. The changes applied brought it back to green.

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.