### PR TITLE
support managing private runbooks for private incidents

### DIFF
--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -33,6 +33,7 @@ const RunbookAttachmentRuleDefaultJSON = `
 type CreateRunbookRequest struct {
 	Name        string       `json:"name"`
 	Type        string       `json:"type"`
+	Restricted  bool         `json:"auto_attach_to_restricted_incidents,omitempty"`
 	Description string       `json:"description"`
 	Owner       *RunbookTeam `json:"owner,omitempty"`
 
@@ -69,6 +70,7 @@ type RunbookStep struct {
 // URL: PATCH https://api.firehydrant.io/v1/runbooks/{id}
 type UpdateRunbookRequest struct {
 	Name           string                 `json:"name,omitempty"`
+	Restricted     bool                   `json:"auto_attach_to_restricted_incidents"`
 	Description    string                 `json:"description"`
 	Owner          *RunbookTeam           `json:"owner,omitempty"`
 	Steps          []RunbookStep          `json:"steps,omitempty"`
@@ -80,6 +82,7 @@ type UpdateRunbookRequest struct {
 type RunbookResponse struct {
 	ID          string        `json:"id"`
 	Name        string        `json:"name"`
+	Restricted  bool          `json:"auto_attach_to_restricted_incidents"`
 	Description string        `json:"description"`
 	Owner       *RunbookTeam  `json:"owner"`
 	Steps       []RunbookStep `json:"steps"`

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -144,6 +145,7 @@ func readResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceData,
 	attributes := map[string]interface{}{
 		"name":        runbookResponse.Name,
 		"description": runbookResponse.Description,
+		"restricted":  runbookResponse.Restricted,
 	}
 
 	if len(runbookResponse.AttachmentRule) > 0 {
@@ -211,6 +213,7 @@ func createResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceDat
 	createRequest := firehydrant.CreateRunbookRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
+		Restricted:  d.Get("restricted").(bool),
 	}
 
 	// Process any optional attributes and add to the create request if necessary
@@ -292,6 +295,7 @@ func updateResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceDat
 	updateRequest := firehydrant.UpdateRunbookRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
+		Restricted:  d.Get("restricted").(bool),
 	}
 
 	// Process any optional attributes and add to the update request if necessary


### PR DESCRIPTION
## Description

Provider is missing the ability to create a private runbook which is needed for private incidents

## Testing plan

1. _Describe how to replicate the conditions_
1. _under which your code performs its purpose,_
1. _including example Terraform configs where necessary._

## Related links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developers.firehydrant.io/docs/api/xxxx)
- [Related PR](https://github.com/firehydrant/firehydrant/pull/xxxx)

## PR readiness 

- [ ] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [ ] An entry has been added to the changelog, if necessary.