### PR TITLE
on_call: fix inconsistencies of `member_ids` and `members`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
-## 4.0.2 (Unreleased)
+## Next (Unreleased)
 
 N/A
 
-## 4.0.1
+## 4.0.2
+
+BUG FIXES:
+
+* Resource `firehydrant_on_call_schedule` now handles `member_ids` correctly. Field `members` has been deprecated. ([#143](https://github.com/firehydrant/terraform-provider-firehydrant/pull/143))
+
+## 0.4.1
 
 BUG FIXES:
 
 * Fixes a bug where handoff steps in escalation policies were assigning to the incorrect schema and causing a panic.
 
-## 4.0.0
+## 0.4.0
 
 * Add labels to functionalities
 * Add initial Signals resources for beta period

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -65,6 +65,7 @@ The following arguments are supported:
 * `description` - (Optional) A description for the on-call schedule.
 * `team_id` - (Required) The ID of the team that the on-call schedule belongs to.
 * `member_ids` - (Required) A list of user IDs that are on-call for the on-call schedule.
+* `members` - (Deprecated) use `member_ids` instead.
 * `time_zone` - (Required) The time zone that the on-call schedule is in.
 * `strategy` - (Required) A block to define the strategy for the on-call schedule.
 * `restrictions` - (Optional) A block to define a restriction for the on-call schedule.

--- a/firehydrant/on_call_schedules.go
+++ b/firehydrant/on_call_schedules.go
@@ -57,8 +57,9 @@ type CreateOnCallScheduleRequest struct {
 }
 
 type UpdateOnCallScheduleRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	MemberIDs   []string `json:"member_ids,omitempty"`
 }
 
 type OnCallScheduleRestriction struct {

--- a/firehydrant/on_call_schedules_test.go
+++ b/firehydrant/on_call_schedules_test.go
@@ -1,0 +1,99 @@
+package firehydrant
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func expectedOnCallScheduleResponse() *OnCallScheduleResponse {
+	return &OnCallScheduleResponse{
+		ID:          "schedule-id",
+		Name:        "A pleasant on-call schedule",
+		Description: "Managed by Terraform. Contact @platform-eng for changes.",
+		TimeZone:    "America/New_York",
+		Strategy: OnCallScheduleStrategy{
+			Type:        "weekly",
+			HandoffTime: "09:00:00",
+			HandoffDay:  "monday",
+		},
+		Members: []OnCallScheduleMember{
+			{
+				ID:   "77779528-690b-4161-84ca-312e932c626e",
+				Name: "Frederick Graff",
+			},
+		},
+		Restrictions: []OnCallScheduleRestriction{
+			{
+				StartDay:  "monday",
+				StartTime: "09:00:00",
+				EndDay:    "friday",
+				EndTime:   "17:00:00",
+			},
+		},
+	}
+}
+
+func expectedOnCallScheduleResponseJSON() string {
+	return `{
+  "id": "schedule-id",
+  "name": "A pleasant on-call schedule",
+  "description": "Managed by Terraform. Contact @platform-eng for changes.",
+  "members": [
+    {
+      "id": "77779528-690b-4161-84ca-312e932c626e",
+      "name": "Frederick Graff"
+    }
+  ],
+  "team": {
+    "id": "44498724-9ccf-4e9a-b18f-5458ffad979a",
+    "name": "Philadelphia"
+  },
+ "strategy": {
+    "handoff_day": "monday",
+    "handoff_time": "09:00:00",
+    "type": "weekly"
+  },
+  "time_zone": "America/New_York",
+  "restrictions": [
+    {
+      "end_day": "friday",
+      "end_time": "17:00:00",
+      "start_day": "monday",
+      "start_time": "09:00:00"
+    }
+  ]
+}`
+}
+
+func TestOnCallSchedulesGet(t *testing.T) {
+	var requestPath string
+	h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestPath = req.URL.Path
+		w.Write([]byte(expectedOnCallScheduleResponseJSON()))
+	})
+
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	c, err := NewRestClient("test-token-very-authorized", WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatalf("Received error initializing API client: %s", err.Error())
+		return
+	}
+	res, err := c.OnCallSchedules().Get(context.TODO(), "team-id", "schedule-id")
+	if err != nil {
+		t.Fatalf("error retrieving on-call schedule: %s", err.Error())
+	}
+
+	if expected := "/teams/team-id/on_call_schedules/schedule-id"; expected != requestPath {
+		t.Fatalf("request path mismatch: expected '%s', got: '%s'", expected, requestPath)
+	}
+
+	expectedResponse := expectedOnCallScheduleResponse()
+	if !reflect.DeepEqual(expectedResponse, res) {
+		t.Fatalf("response mismatch: expected '%+v', got: '%+v'", expectedResponse, res)
+	}
+}

--- a/provider/on_call_schedule_resource.go
+++ b/provider/on_call_schedule_resource.go
@@ -241,11 +241,6 @@ func updateResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.Reso
 	}
 	onCallSchedule.MemberIDs = memberIDs
 
-	tflog.Debug(ctx, "Updating on-call schedule properties", map[string]interface{}{
-		"id":         id,
-		"properties": fmt.Sprintf("%+v", onCallSchedule),
-	})
-
 	// Update the on-call schedule
 	_, err := firehydrantAPIClient.OnCallSchedules().Update(ctx, teamID, id, onCallSchedule)
 	if err != nil {


### PR DESCRIPTION
## Description

We weren't consistent between the usage of `members` and `member_ids` in `firehydrant_on_call_schedule`. Documentation says `member_ids`, but code only accept `members`.

Despite that, it seems like `members` could not produce idempotent state as Terraform will perpetually try to reconcile with `member_ids`.

As such, this change deprecated `members` and using `member_ids` is recommended going forward.

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.