### PR TITLE
teams: support slug modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## Next (Unreleased)
+## 0.5.0 (Unreleased)
 
-N/A
+* `firehydrant_team` now supports `slug` attribute ([#145](https://github.com/firehydrant/terraform-provider-firehydrant/pull/145)).
 
 ## 0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0 (Unreleased)
+## 0.5.0
 
 * `firehydrant_team` now supports `slug` attribute ([#145](https://github.com/firehydrant/terraform-provider-firehydrant/pull/145)).
 

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -37,14 +37,15 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the team.
 * `description` - (Optional) A description for the team.
+* `slug` - (Optional) Team slug identifier. If not provided, it will be generated from the name.
 * `memberships` - (Optional) A resource to tie a schedule or user to a team via a incident role.
 
 The `memberships` block supports:
 
-Either the user_id or schedule_id is required for this block.
+Either the `user_id` or `schedule_id` is required for this block.
 
-* `user_id` - (Required) Id of the user.
-* `schedule_id` - (Required) Id of the schedule.
+* `user_id` - (Required) ID of the user.
+* `schedule_id` - (Required) ID of the schedule.
 * `default_incident_role_id` - (Optional) Incident role to assign the user or schedule.
 
 ## Attributes Reference

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -233,6 +233,7 @@ type TeamQuery struct {
 type CreateTeamRequest struct {
 	Name        string       `json:"name"`
 	Description string       `json:"description"`
+	Slug        string       `json:"slug,omitempty"`
 	Memberships []Membership `json:"memberships,omitempty"`
 }
 
@@ -246,6 +247,7 @@ type TeamService struct {
 type UpdateTeamRequest struct {
 	Name        string       `json:"name"`
 	Description string       `json:"description"`
+	Slug        string       `json:"slug,omitempty"`
 	Memberships []Membership `json:"memberships,omitempty"`
 }
 

--- a/provider/team_resource.go
+++ b/provider/team_resource.go
@@ -53,6 +53,11 @@ func resourceTeam() *schema.Resource {
 					},
 				},
 			},
+			"slug": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -82,6 +87,7 @@ func readResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, m 
 	attributes := map[string]interface{}{
 		"name":        teamResponse.Name,
 		"description": teamResponse.Description,
+		"slug":        teamResponse.Slug,
 	}
 
 	// Process any attributes that could be nil
@@ -112,6 +118,9 @@ func createResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 	createRequest := firehydrant.CreateTeamRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
+	}
+	if slug, ok := d.GetOk("slug"); ok {
+		createRequest.Slug = slug.(string)
 	}
 
 	// Process any optional attributes and add to the create request if necessary
@@ -149,6 +158,9 @@ func updateResourceFireHydrantTeam(ctx context.Context, d *schema.ResourceData, 
 	updateRequest := firehydrant.UpdateTeamRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
+	}
+	if slug, ok := d.GetOk("slug"); ok {
+		updateRequest.Slug = slug.(string)
 	}
 
 	// Process any optional attributes and add to the update request if necessary


### PR DESCRIPTION
## Description

Team slug is now part of public API to be modified by clients. Adding this for consistency of behavior.

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.