### PR TITLE
feat: add ability to pass name to slack channel data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+ENHANCEMENTS:
+* **Added to Data Source**: `firehydrant_slack_channel`. Now you can pass either the channel id or the channel name to the data source. 
+
 ## 0.6.0
 
 ENHANCEMENTS:

--- a/docs/data-sources/slack_channel.md
+++ b/docs/data-sources/slack_channel.md
@@ -11,7 +11,8 @@ Use this data source to pass Slack channel information to other resources.
 Basic usage:
 ```hcl
 data "firehydrant_slack_channel" "team_rocket" {
-  slack_channel_id = "C1234567890"
+  slack_channel_id   = "C1234567890"
+  slack_channel_name = "#team-rocket"
 }
 
 resource "firehydrant_escalation_policy" "team_rocket" {
@@ -30,7 +31,10 @@ resource "firehydrant_escalation_policy" "team_rocket" {
 
 The following arguments are supported:
 
-* `slack_channel_id` - (Required) Slack's channel ID.
+> You must provide one of these options and the `slack_channel_id` will take precedence if both are provided. 
+
+* `slack_channel_id` - (Optional) Slack's channel ID.
+* `slack_channel_name` - (Optional) Slack's channel name.
 
 ## Attributes Reference
 

--- a/docs/data-sources/slack_channel.md
+++ b/docs/data-sources/slack_channel.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 > You must provide one of these options and the `slack_channel_id` will take precedence if both are provided. 
 
 * `slack_channel_id` - (Optional) Slack's channel ID.
-* `slack_channel_name` - (Optional) Slack's channel name.
+* `slack_channel_name` - (Optional) Slack's channel name. We recommend using `slack_channel_id` where possible as Slack channel name may be changed and thus cause surprise state inconsistencies.
 
 ## Attributes Reference
 

--- a/docs/data-sources/slack_channel.md
+++ b/docs/data-sources/slack_channel.md
@@ -31,7 +31,7 @@ resource "firehydrant_escalation_policy" "team_rocket" {
 
 The following arguments are supported:
 
-> You must provide one of these options and the `slack_channel_id` will take precedence if both are provided. 
+> You must provide one of these options.
 
 * `slack_channel_id` - (Optional) Slack's channel ID.
 * `slack_channel_name` - (Optional) Slack's channel name. We recommend using `slack_channel_id` where possible as Slack channel name may be changed and thus cause surprise state inconsistencies.

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -28,7 +28,7 @@ const RunbookAttachmentRuleDefaultJSON = `
   "user_data": {}
 }`
 
-// CreateRunbookRequest is the payload for creating a runbook
+// CreateRunbookRequest is the payload for creating a service
 // URL: POST https://api.firehydrant.io/v1/runbooks
 type CreateRunbookRequest struct {
 	Name        string       `json:"name"`
@@ -40,8 +40,7 @@ type CreateRunbookRequest struct {
 
 	Severities []RunbookRelation `json:"severities"`
 
-	Steps      []RunbookStep `json:"steps,omitempty"`
-	Restricted bool          `json:"auto_attach_to_restricted_incidents,omitempty"`
+	Steps []RunbookStep `json:"steps,omitempty"`
 }
 
 // RunbookRelation associates a runbook to a type in FireHydrant (such as a severity)
@@ -87,9 +86,8 @@ type RunbookResponse struct {
 
 	AttachmentRule map[string]interface{} `json:"attachment_rule"`
 
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
-	Restricted bool      `json:"auto_attach_to_restricted_incidents,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // RunbooksClient is an interface for interacting with runbooks on FireHydrant

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -28,7 +28,7 @@ const RunbookAttachmentRuleDefaultJSON = `
   "user_data": {}
 }`
 
-// CreateRunbookRequest is the payload for creating a service
+// CreateRunbookRequest is the payload for creating a runbook
 // URL: POST https://api.firehydrant.io/v1/runbooks
 type CreateRunbookRequest struct {
 	Name        string       `json:"name"`
@@ -40,7 +40,8 @@ type CreateRunbookRequest struct {
 
 	Severities []RunbookRelation `json:"severities"`
 
-	Steps []RunbookStep `json:"steps,omitempty"`
+	Steps      []RunbookStep `json:"steps,omitempty"`
+	Restricted bool          `json:"auto_attach_to_restricted_incidents,omitempty"`
 }
 
 // RunbookRelation associates a runbook to a type in FireHydrant (such as a severity)
@@ -86,8 +87,9 @@ type RunbookResponse struct {
 
 	AttachmentRule map[string]interface{} `json:"attachment_rule"`
 
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	Restricted bool      `json:"auto_attach_to_restricted_incidents,omitempty"`
 }
 
 // RunbooksClient is an interface for interacting with runbooks on FireHydrant

--- a/firehydrant/slack_channels.go
+++ b/firehydrant/slack_channels.go
@@ -3,14 +3,20 @@ package firehydrant
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/dghubble/sling"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+type SlackChannelParams struct {
+	ID   string
+	Name string
+}
+
 // SlackChannelsClient is an interface for interacting with Slack channels
 type SlackChannelsClient interface {
-	Get(ctx context.Context, slackID string) (*SlackChannelResponse, error)
+	Get(ctx context.Context, params SlackChannelParams) (*SlackChannelResponse, error)
 }
 
 // RESTSlackChannelsClient implements the SlackChannelClient interface
@@ -26,10 +32,17 @@ func (c *RESTSlackChannelsClient) restClient() *sling.Sling {
 
 // Get retrieves a Slack channel from FireHydrant using Slack ID. This is useful for looking up
 // a Slack channel's internal ID.
-func (c *RESTSlackChannelsClient) Get(ctx context.Context, slackID string) (*SlackChannelResponse, error) {
+func (c *RESTSlackChannelsClient) Get(ctx context.Context, params SlackChannelParams) (*SlackChannelResponse, error) {
 	channels := &SlackChannelsResponse{}
 	apiError := &APIError{}
-	response, err := c.restClient().Get("integrations/slack/channels?slack_channel_id="+slackID).Receive(channels, apiError)
+
+	query := ""
+	if params.ID != "" {
+		query = fmt.Sprintf("slack_channel_id=%s", params.ID)
+	} else if params.Name != "" {
+		query = fmt.Sprintf("name=%s", strings.TrimPrefix(params.Name, "#"))
+	}
+	response, err := c.restClient().Get("integrations/slack/channels?"+query).Receive(channels, apiError)
 	if err != nil {
 		return nil, fmt.Errorf("could not get slack channel: %w", err)
 	}
@@ -40,17 +53,19 @@ func (c *RESTSlackChannelsClient) Get(ctx context.Context, slackID string) (*Sla
 	}
 
 	if channels.Channels == nil || len(channels.Channels) == 0 {
-		return nil, fmt.Errorf("no slack channel found with id '%s'", slackID)
+		return nil, fmt.Errorf("no slack channel found with options: name: %s, id: %s", params.Name, params.ID)
 	}
 	if channelCount := len(channels.Channels); channelCount > 1 {
 		// "at least" because it may paginate.
 		tflog.Error(ctx, "found more than one Slack channel", map[string]interface{}{
-			"id":    slackID,
-			"found": channelCount,
+			"query_id":   params.ID,
+			"query_name": params.Name,
+			"found":      channelCount,
 		})
 		for _, channel := range channels.Channels {
 			tflog.Error(ctx, "found Slack channel", map[string]interface{}{
-				"id":               channel.ID,
+				"query_id":         params.ID,
+				"query_name":       params.Name,
 				"slack_channel_id": channel.SlackChannelID,
 				"name":             channel.Name,
 			})
@@ -59,7 +74,8 @@ func (c *RESTSlackChannelsClient) Get(ctx context.Context, slackID string) (*Sla
 	}
 
 	tflog.Info(ctx, "found Slack channel", map[string]interface{}{
-		"id":               channels.Channels[0].ID,
+		"query_id":         channels.Channels[0].ID,
+		"query_name":       channels.Channels[0].Name,
 		"slack_channel_id": channels.Channels[0].SlackChannelID,
 		"name":             channels.Channels[0].Name,
 	})

--- a/firehydrant/slack_channels.go
+++ b/firehydrant/slack_channels.go
@@ -64,20 +64,20 @@ func (c *RESTSlackChannelsClient) Get(ctx context.Context, params SlackChannelPa
 		})
 		for _, channel := range channels.Channels {
 			tflog.Error(ctx, "found Slack channel", map[string]interface{}{
-				"id":         params.ID,
-				"name":       params.Name,
-				"slack_channel_id": channel.SlackChannelID,
-				"name":             channel.Name,
+				"id":                 params.ID,
+				"name":               params.Name,
+				"slack_channel_id":   channel.SlackChannelID,
+				"slack_channel_name": channel.Name,
 			})
 		}
 		return nil, fmt.Errorf("more than one Slack channel found: see Terraform logs for more information.")
 	}
 
 	tflog.Info(ctx, "found Slack channel", map[string]interface{}{
-		"id":         channels.Channels[0].ID,
-		"name":       channels.Channels[0].Name,
-		"slack_channel_id": channels.Channels[0].SlackChannelID,
-		"name":             channels.Channels[0].Name,
+		"id":                 channels.Channels[0].ID,
+		"name":               channels.Channels[0].Name,
+		"slack_channel_id":   channels.Channels[0].SlackChannelID,
+		"slack_channel_name": channels.Channels[0].Name,
 	})
 
 	return channels.Channels[0], nil

--- a/firehydrant/slack_channels.go
+++ b/firehydrant/slack_channels.go
@@ -58,9 +58,9 @@ func (c *RESTSlackChannelsClient) Get(ctx context.Context, params SlackChannelPa
 	if channelCount := len(channels.Channels); channelCount > 1 {
 		// "at least" because it may paginate.
 		tflog.Error(ctx, "found more than one Slack channel", map[string]interface{}{
-			"id":   params.ID,
-			"name": params.Name,
-			"found":      channelCount,
+			"id":    params.ID,
+			"name":  params.Name,
+			"found": channelCount,
 		})
 		for _, channel := range channels.Channels {
 			tflog.Error(ctx, "found Slack channel", map[string]interface{}{

--- a/firehydrant/slack_channels.go
+++ b/firehydrant/slack_channels.go
@@ -53,7 +53,7 @@ func (c *RESTSlackChannelsClient) Get(ctx context.Context, params SlackChannelPa
 	}
 
 	if channels.Channels == nil || len(channels.Channels) == 0 {
-		return nil, fmt.Errorf("no slack channel found with options: name: %s, id: %s", params.Name, params.ID)
+		return nil, fmt.Errorf("no slack channel found with options name '%s' and / or id '%s'", params.Name, params.ID)
 	}
 	if channelCount := len(channels.Channels); channelCount > 1 {
 		// "at least" because it may paginate.

--- a/firehydrant/slack_channels.go
+++ b/firehydrant/slack_channels.go
@@ -64,8 +64,8 @@ func (c *RESTSlackChannelsClient) Get(ctx context.Context, params SlackChannelPa
 		})
 		for _, channel := range channels.Channels {
 			tflog.Error(ctx, "found Slack channel", map[string]interface{}{
-				"query_id":         params.ID,
-				"query_name":       params.Name,
+				"id":         params.ID,
+				"name":       params.Name,
 				"slack_channel_id": channel.SlackChannelID,
 				"name":             channel.Name,
 			})
@@ -74,8 +74,8 @@ func (c *RESTSlackChannelsClient) Get(ctx context.Context, params SlackChannelPa
 	}
 
 	tflog.Info(ctx, "found Slack channel", map[string]interface{}{
-		"query_id":         channels.Channels[0].ID,
-		"query_name":       channels.Channels[0].Name,
+		"id":         channels.Channels[0].ID,
+		"name":       channels.Channels[0].Name,
 		"slack_channel_id": channels.Channels[0].SlackChannelID,
 		"name":             channels.Channels[0].Name,
 	})

--- a/firehydrant/slack_channels.go
+++ b/firehydrant/slack_channels.go
@@ -58,8 +58,8 @@ func (c *RESTSlackChannelsClient) Get(ctx context.Context, params SlackChannelPa
 	if channelCount := len(channels.Channels); channelCount > 1 {
 		// "at least" because it may paginate.
 		tflog.Error(ctx, "found more than one Slack channel", map[string]interface{}{
-			"query_id":   params.ID,
-			"query_name": params.Name,
+			"id":   params.ID,
+			"name": params.Name,
 			"found":      channelCount,
 		})
 		for _, channel := range channels.Channels {

--- a/provider/slack_channel_data.go
+++ b/provider/slack_channel_data.go
@@ -16,7 +16,12 @@ func dataSourceSlackChannel() *schema.Resource {
 			"slack_channel_id": {
 				Description: "ID of the channel, provided by Slack.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+			},
+			"slack_channel_name": {
+				Description: "Name of this Slack channel.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 			"id": {
 				Description: "FireHydrant internal ID for the Slack channel.",
@@ -32,8 +37,13 @@ func dataFireHydrantSlackChannelRead(ctx context.Context, d *schema.ResourceData
 	firehydrantAPIClient := m.(firehydrant.Client)
 
 	// Get the Slack channel
-	channelID := d.Get("slack_channel_id").(string)
-	slackChannel, err := firehydrantAPIClient.SlackChannels().Get(ctx, channelID)
+	slack_channel_id := d.Get("slack_channel_id").(string)
+	slack_channel_name := d.Get("slack_channel_name").(string)
+	params := firehydrant.SlackChannelParams{
+		ID:   slack_channel_id,
+		Name: slack_channel_name,
+	}
+	slackChannel, err := firehydrantAPIClient.SlackChannels().Get(ctx, params)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/slack_channel_data.go
+++ b/provider/slack_channel_data.go
@@ -43,6 +43,10 @@ func dataFireHydrantSlackChannelRead(ctx context.Context, d *schema.ResourceData
 		ID:   slack_channel_id,
 		Name: slack_channel_name,
 	}
+
+	if slack_channel_id == "" && slack_channel_name == "" {
+		return diag.Errorf("either `slack_channel_id` or `slack_channel_name` must be set")
+	}
 	slackChannel, err := firehydrantAPIClient.SlackChannels().Get(ctx, params)
 	if err != nil {
 		return diag.FromErr(err)

--- a/provider/slack_channel_data.go
+++ b/provider/slack_channel_data.go
@@ -17,11 +17,13 @@ func dataSourceSlackChannel() *schema.Resource {
 				Description: "ID of the channel, provided by Slack.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ConflictsWith: "slack_channel_name",
 			},
 			"slack_channel_name": {
 				Description: "Name of this Slack channel.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ConflictsWith: "slack_channel_id",
 			},
 			"id": {
 				Description: "FireHydrant internal ID for the Slack channel.",

--- a/provider/slack_channel_data.go
+++ b/provider/slack_channel_data.go
@@ -14,16 +14,16 @@ func dataSourceSlackChannel() *schema.Resource {
 		ReadContext: dataFireHydrantSlackChannelRead,
 		Schema: map[string]*schema.Schema{
 			"slack_channel_id": {
-				Description: "ID of the channel, provided by Slack.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				ConflictsWith: "slack_channel_name",
+				Description:   "ID of the channel, provided by Slack.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"slack_channel_name"},
 			},
 			"slack_channel_name": {
-				Description: "Name of this Slack channel.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				ConflictsWith: "slack_channel_id",
+				Description:   "Name of this Slack channel.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"slack_channel_id"},
 			},
 			"id": {
 				Description: "FireHydrant internal ID for the Slack channel.",

--- a/provider/slack_channel_data_test.go
+++ b/provider/slack_channel_data_test.go
@@ -29,7 +29,8 @@ func TestOfflineSlackChannelsReadMemberID(t *testing.T) {
 		return
 	}
 	r := schema.TestResourceDataRaw(t, dataSourceSlackChannel().Schema, map[string]interface{}{
-		"slack_channel_id": "C01010101Z",
+		"slack_channel_id":   "C01010101Z",
+		"slack_channel_name": "team-rocket",
 	})
 
 	d := dataFireHydrantSlackChannelRead(context.Background(), r, c)

--- a/provider/slack_channel_data_test.go
+++ b/provider/slack_channel_data_test.go
@@ -19,7 +19,7 @@ func offlineSlackChannelsMockServer() *httptest.Server {
 	}))
 }
 
-func TestOfflineSlackChannelsReadMemberID(t *testing.T) {
+func TestOfflineSlackChannelsSlackChannelID(t *testing.T) {
 	ts := offlineSlackChannelsMockServer()
 	defer ts.Close()
 
@@ -29,15 +29,51 @@ func TestOfflineSlackChannelsReadMemberID(t *testing.T) {
 		return
 	}
 	r := schema.TestResourceDataRaw(t, dataSourceSlackChannel().Schema, map[string]interface{}{
-		"slack_channel_id":   "C01010101Z",
+		"slack_channel_id": "C01010101Z",
+	})
+
+	d := dataFireHydrantSlackChannelRead(context.Background(), r, c)
+	if d.HasError() {
+		t.Fatalf("error reading slack channele: %v", d)
+	}
+	if id := r.Id(); id != "00000000-0000-4000-8000-000000000000" {
+		t.Fatalf("expected ID to be 00000000-0000-4000-8000-000000000000, got %s", id)
+	}
+}
+func TestOfflineSlackChannelsSlackChannelName(t *testing.T) {
+	ts := offlineSlackChannelsMockServer()
+	defer ts.Close()
+
+	c, err := firehydrant.NewRestClient("test-token-very-authorized", firehydrant.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatalf("Received error initializing API client: %s", err.Error())
+		return
+	}
+	r := schema.TestResourceDataRaw(t, dataSourceSlackChannel().Schema, map[string]interface{}{
 		"slack_channel_name": "team-rocket",
 	})
 
 	d := dataFireHydrantSlackChannelRead(context.Background(), r, c)
 	if d.HasError() {
-		t.Fatalf("error reading on-call schedule: %v", d)
+		t.Fatalf("error reading slack channel: %v", d)
 	}
 	if id := r.Id(); id != "00000000-0000-4000-8000-000000000000" {
 		t.Fatalf("expected ID to be 00000000-0000-4000-8000-000000000000, got %s", id)
+	}
+}
+func TestOfflineSlackChannelsSlackChannel_missing(t *testing.T) {
+	ts := offlineSlackChannelsMockServer()
+	defer ts.Close()
+
+	c, err := firehydrant.NewRestClient("test-token-very-authorized", firehydrant.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatalf("Received error initializing API client: %s", err.Error())
+		return
+	}
+	r := schema.TestResourceDataRaw(t, dataSourceSlackChannel().Schema, map[string]interface{}{})
+
+	d := dataFireHydrantSlackChannelRead(context.Background(), r, c)
+	if !d.HasError() {
+		t.Fatalf("didnt fail on reading slack channel: %v", d)
 	}
 }


### PR DESCRIPTION
## Description

Adding the ability to pass the channel name into the data source for slack channels. This will make our automations simpler as we mostly configure the slack channel via name, not id. 

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.