### PR TITLE
Private runbooks field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Unreleased
+## 0.7.0
 
 ENHANCEMENTS:
 * **Added to Data Source**: `firehydrant_slack_channel`. Now you can pass either the channel id or the channel name to the data source. 
+* `firehydrant_runbook` now supports `restricted` field for private incidents runbook ([#149](https://github.com/firehydrant/terraform-provider-firehydrant/pull/149))
 
 ## 0.6.0
 

--- a/docs/resources/runbook.md
+++ b/docs/resources/runbook.md
@@ -109,6 +109,7 @@ The following arguments are supported:
   ```
 * `description` - (Optional) A description of the runbook.
 * `owner_id` - (Optional) The ID of the team that owns this runbook.
+* `restricted` - (Optional) Only apply this runbook to private incidents.
 
 The `steps` block supports:
 

--- a/firehydrant/runbooks.go
+++ b/firehydrant/runbooks.go
@@ -33,6 +33,7 @@ const RunbookAttachmentRuleDefaultJSON = `
 type CreateRunbookRequest struct {
 	Name        string       `json:"name"`
 	Type        string       `json:"type"`
+	Restricted  bool         `json:"auto_attach_to_restricted_incidents,omitempty"`
 	Description string       `json:"description"`
 	Owner       *RunbookTeam `json:"owner,omitempty"`
 
@@ -69,6 +70,7 @@ type RunbookStep struct {
 // URL: PATCH https://api.firehydrant.io/v1/runbooks/{id}
 type UpdateRunbookRequest struct {
 	Name           string                 `json:"name,omitempty"`
+	Restricted     bool                   `json:"auto_attach_to_restricted_incidents"`
 	Description    string                 `json:"description"`
 	Owner          *RunbookTeam           `json:"owner,omitempty"`
 	Steps          []RunbookStep          `json:"steps,omitempty"`
@@ -80,6 +82,7 @@ type UpdateRunbookRequest struct {
 type RunbookResponse struct {
 	ID          string        `json:"id"`
 	Name        string        `json:"name"`
+	Restricted  bool          `json:"auto_attach_to_restricted_incidents"`
 	Description string        `json:"description"`
 	Owner       *RunbookTeam  `json:"owner"`
 	Steps       []RunbookStep `json:"steps"`

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -144,6 +145,7 @@ func readResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceData,
 	attributes := map[string]interface{}{
 		"name":        runbookResponse.Name,
 		"description": runbookResponse.Description,
+		"restricted":  runbookResponse.Restricted,
 	}
 
 	if len(runbookResponse.AttachmentRule) > 0 {
@@ -211,6 +213,7 @@ func createResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceDat
 	createRequest := firehydrant.CreateRunbookRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
+		Restricted:  d.Get("restricted").(bool),
 	}
 
 	// Process any optional attributes and add to the create request if necessary
@@ -292,6 +295,7 @@ func updateResourceFireHydrantRunbook(ctx context.Context, d *schema.ResourceDat
 	updateRequest := firehydrant.UpdateRunbookRequest{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
+		Restricted:  d.Get("restricted").(bool),
 	}
 
 	// Process any optional attributes and add to the update request if necessary

--- a/provider/runbook_resource.go
+++ b/provider/runbook_resource.go
@@ -112,6 +112,10 @@ func resourceRunbook() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"restricted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"owner_id": {
 				Type:     schema.TypeString,
 				Optional: true,


### PR DESCRIPTION
## Description

Add `restricted` field for private runbooks. This feature is supported outside of Terraform and this changeset brings our Terraform provider to parity.

## Related links

Supersedes #142

## PR readiness 

- [ ] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [ ] An entry has been added to the changelog, if necessary.