### PR TITLE
Incident types for rules

### DIFF
--- a/docs/resources/signal_rule.md
+++ b/docs/resources/signal_rule.md
@@ -42,6 +42,7 @@ The following arguments are supported:
 * `expression` - (Required) The expression to evaluate incoming events against.
 * `target_type` - (Required) The type of resource to send alerts to. Valid values are `EscalationPolicy`, `OnCallSchedule`, and `User`.
 * `target_id` - (Required) The ID of the resource to send alerts to.
+* `incident_type_id` - (Optional) The ID of the incident type associated with this rule.
 
 ## Attributes Reference
 

--- a/firehydrant/signals_rules.go
+++ b/firehydrant/signals_rules.go
@@ -27,28 +27,36 @@ type SignalRuleTarget struct {
 	Type string `json:"type"`
 }
 
+type SignalRuleIncidentType struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 type SignalsRuleResponse struct {
-	ID         string           `json:"id"`
-	Name       string           `json:"name"`
-	Expression string           `json:"expression"`
-	Target     SignalRuleTarget `json:"target"`
+	ID           string                 `json:"id"`
+	Name         string                 `json:"name"`
+	Expression   string                 `json:"expression"`
+	Target       SignalRuleTarget       `json:"target"`
+	IncidentType SignalRuleIncidentType `json:"incident_type"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type CreateSignalsRuleRequest struct {
-	Name       string `json:"name"`
-	Expression string `json:"expression"`
-	TargetType string `json:"target_type"`
-	TargetID   string `json:"target_id"`
+	Name           string `json:"name"`
+	Expression     string `json:"expression"`
+	TargetType     string `json:"target_type"`
+	TargetID       string `json:"target_id"`
+	IncidentTypeID string `json:"incident_type_id,omitempty"`
 }
 
 type UpdateSignalsRuleRequest struct {
-	Name       string `json:"name"`
-	Expression string `json:"expression"`
-	TargetType string `json:"target_type"`
-	TargetID   string `json:"target_id"`
+	Name           string `json:"name"`
+	Expression     string `json:"expression"`
+	TargetType     string `json:"target_type"`
+	TargetID       string `json:"target_id"`
+	IncidentTypeID string `json:"incident_type_id,omitempty"`
 }
 
 func (c *RESTSignalsRulesClient) restClient() *sling.Sling {

--- a/firehydrant/signals_rules_test.go
+++ b/firehydrant/signals_rules_test.go
@@ -1,0 +1,59 @@
+package firehydrant
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+func expectedSignalsRuleResponse() *SignalsRuleResponse {
+	return &SignalsRuleResponse{
+		ID:         "00000000-0000-4000-8000-000000000000",
+		Name:       "Test Rule",
+		Expression: "signal.summary.contains(\"foo\")",
+		Target: SignalRuleTarget{
+			ID:   "00000000-0000-4000-8000-000000000000",
+			Type: "User",
+		},
+		IncidentType: SignalRuleIncidentType{
+			ID:   "00000000-0000-4000-8000-000000000000",
+			Name: "Test incident type",
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+func expectedSignalsRuleJSON() string {
+	return `{
+		"id": "00000000-0000-4000-8000-000000000000",
+		"name": "Test Rule",
+		"expression": "signal.summary.contains(\"foo\")",
+		"target": {
+			"id": "00000000-0000-4000-8000-000000000000",
+			"type": "User",
+		},
+		"created_at": "2024-01-01T12:00:00.000Z",
+		"updated_at": "2024-01-01T12:00:00.000Z",
+		"incident_type": {
+			"id": "00000000-0000-4000-8000-000000000000",
+			"name": "Test incident type"
+		}
+	}`
+}
+
+func transposerMockServer(path *string) *httptest.Server {
+	h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		*path = req.URL.Path
+
+		if *path == "teams/00000000-0000-4000-8000-000000000000/signal_rules/00000000-0000-4000-8000-000000000000" ||
+			*path == "teams/00000000-0000-4000-8000-000000000000/signal_rules" {
+			w.Write([]byte(expectedSignalsRuleJSON()))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	ts := httptest.NewServer(h)
+	return ts
+}

--- a/firehydrant/signals_rules_test.go
+++ b/firehydrant/signals_rules_test.go
@@ -1,14 +1,20 @@
 package firehydrant
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
 	"time"
 )
 
 func expectedSignalsRuleResponse() *SignalsRuleResponse {
+	timestamp, _ := time.Parse(time.RFC3339, "2024-01-01T12:00:00.000Z")
 	return &SignalsRuleResponse{
-		ID:         "00000000-0000-4000-8000-000000000000",
+		ID:         "00000000-0000-8000-4000-000000000000",
 		Name:       "Test Rule",
 		Expression: "signal.summary.contains(\"foo\")",
 		Target: SignalRuleTarget{
@@ -19,19 +25,19 @@ func expectedSignalsRuleResponse() *SignalsRuleResponse {
 			ID:   "00000000-0000-4000-8000-000000000000",
 			Name: "Test incident type",
 		},
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		CreatedAt: timestamp,
+		UpdatedAt: timestamp,
 	}
 }
 
 func expectedSignalsRuleJSON() string {
 	return `{
-		"id": "00000000-0000-4000-8000-000000000000",
+		"id": "00000000-0000-8000-4000-000000000000",
 		"name": "Test Rule",
 		"expression": "signal.summary.contains(\"foo\")",
 		"target": {
 			"id": "00000000-0000-4000-8000-000000000000",
-			"type": "User",
+			"type": "User"
 		},
 		"created_at": "2024-01-01T12:00:00.000Z",
 		"updated_at": "2024-01-01T12:00:00.000Z",
@@ -42,12 +48,11 @@ func expectedSignalsRuleJSON() string {
 	}`
 }
 
-func transposerMockServer(path *string) *httptest.Server {
+func signalsRulesMockServer(path *string) *httptest.Server {
 	h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		*path = req.URL.Path
 
-		if *path == "teams/00000000-0000-4000-8000-000000000000/signal_rules/00000000-0000-4000-8000-000000000000" ||
-			*path == "teams/00000000-0000-4000-8000-000000000000/signal_rules" {
+		if strings.Contains(*path, "teams/00000000-0000-4000-8000-000000000000/signal_rules/00000000-0000-8000-4000-000000000000") {
 			w.Write([]byte(expectedSignalsRuleJSON()))
 		} else {
 			w.WriteHeader(http.StatusNotFound)
@@ -56,4 +61,49 @@ func transposerMockServer(path *string) *httptest.Server {
 
 	ts := httptest.NewServer(h)
 	return ts
+}
+
+func TestSignalsRulesGet(t *testing.T) {
+	var requestPath string
+	team_id := "00000000-0000-4000-8000-000000000000"
+	rule_id := "00000000-0000-8000-4000-000000000000"
+	ts := signalsRulesMockServer(&requestPath)
+	defer ts.Close()
+
+	c, err := NewRestClient("test-token-very-authorized", WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatalf("Received error initializing API client: %s", err.Error())
+		return
+	}
+	res, err := c.SignalsRules().Get(context.Background(), team_id, rule_id)
+	if err != nil {
+		t.Fatalf("error retrieving signal rule: %s", err.Error())
+	}
+
+	if expected := fmt.Sprintf("/teams/%s/signal_rules/%s", team_id, rule_id); expected != requestPath {
+		t.Fatalf("request path mismatch: expected '%s', got: '%s'", expected, requestPath)
+	}
+
+	expectedResponse := expectedSignalsRuleResponse()
+	if !reflect.DeepEqual(expectedResponse, res) {
+		t.Fatalf("response mismatch: expected '%+v', got: '%+v'", expectedResponse, res)
+	}
+}
+
+func TestSignalsRulesGet_NotFound(t *testing.T) {
+	var requestPath string
+	team_id := "invalid_team_id"
+	rule_id := "00000000-0000-8000-4000-000000000000"
+	ts := signalsRulesMockServer(&requestPath)
+	defer ts.Close()
+
+	c, err := NewRestClient("test-token-very-authorized", WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatalf("Received error initializing API client: %s", err.Error())
+		return
+	}
+	_, err = c.SignalsRules().Get(context.Background(), team_id, rule_id)
+	if err == nil {
+		t.Fatalf("expected ErrorNotFound in retrieving slack channel, got nil")
+	}
 }

--- a/provider/signal_rule_resource.go
+++ b/provider/signal_rule_resource.go
@@ -44,6 +44,10 @@ func resourceSignalRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"incident_type_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -75,10 +79,11 @@ func readResourceFireHydrantSignalRule(ctx context.Context, d *schema.ResourceDa
 
 	// Gather values from API response
 	attributes := map[string]interface{}{
-		"name":        signalRule.Name,
-		"expression":  signalRule.Expression,
-		"target_type": signalRule.Target.Type,
-		"target_id":   signalRule.Target.ID,
+		"name":             signalRule.Name,
+		"expression":       signalRule.Expression,
+		"target_type":      signalRule.Target.Type,
+		"target_id":        signalRule.Target.ID,
+		"incident_type_id": signalRule.IncidentType.ID,
 	}
 
 	// Set the resource attributes to the values we got from the API
@@ -97,10 +102,11 @@ func createResourceFireHydrantSignalRule(ctx context.Context, d *schema.Resource
 
 	// Construct the create request
 	createRequest := firehydrant.CreateSignalsRuleRequest{
-		Name:       d.Get("name").(string),
-		Expression: d.Get("expression").(string),
-		TargetType: d.Get("target_type").(string),
-		TargetID:   d.Get("target_id").(string),
+		Name:           d.Get("name").(string),
+		Expression:     d.Get("expression").(string),
+		TargetType:     d.Get("target_type").(string),
+		TargetID:       d.Get("target_id").(string),
+		IncidentTypeID: d.Get("incident_type_id").(string),
 	}
 
 	// Create the signal rule
@@ -125,10 +131,11 @@ func updateResourceFireHydrantSignalRule(ctx context.Context, d *schema.Resource
 
 	// Construct the update request
 	updateRequest := firehydrant.UpdateSignalsRuleRequest{
-		Name:       d.Get("name").(string),
-		Expression: d.Get("expression").(string),
-		TargetType: d.Get("target_type").(string),
-		TargetID:   d.Get("target_id").(string),
+		Name:           d.Get("name").(string),
+		Expression:     d.Get("expression").(string),
+		TargetType:     d.Get("target_type").(string),
+		TargetID:       d.Get("target_id").(string),
+		IncidentTypeID: d.Get("incident_type_id").(string),
 	}
 
 	// Update the signal rule

--- a/provider/signal_rule_resource_test.go
+++ b/provider/signal_rule_resource_test.go
@@ -45,6 +45,41 @@ func testAccFireHydrantSignalRuleConfigBasic() string {
 	`, os.Getenv("EXISTING_USER_EMAIL"))
 }
 
+func TestAccFireHydrantSignalRule_IncidentTypeIDMissing(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFireHydrantSignalRuleConfigIncidentTypeIDMissing(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFireHydrantSignalRuleExists("firehydrant_signal_rule.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFireHydrantSignalRuleConfigIncidentTypeIDMissing() string {
+	return fmt.Sprintf(`
+	data "firehydrant_user" "test_user" {
+		email = "%s"
+	}
+
+	resource "firehydrant_team" "test" {
+		name = "test-team"
+	}
+
+	resource "firehydrant_signal_rule" "test" {
+		team_id = firehydrant_team.test.id
+		name = "test-signal-rule"
+		expression = "signal.summary == 'test-signal-summary'"
+		target_type = "User"
+		target_id = data.firehydrant_user.test_user.id
+	}
+	`, os.Getenv("EXISTING_USER_EMAIL"))
+}
+
 func testAccCheckFireHydrantSignalRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/provider/signal_rule_resource_test.go
+++ b/provider/signal_rule_resource_test.go
@@ -40,6 +40,7 @@ func testAccFireHydrantSignalRuleConfigBasic() string {
 		expression = "signal.summary == 'test-signal-summary'"
 		target_type = "User"
 		target_id = data.firehydrant_user.test_user.id
+		incident_type_id = "00000000-0000-4000-8000-000000000000"
 	}
 	`, os.Getenv("EXISTING_USER_EMAIL"))
 }

--- a/provider/signal_rule_resource_test.go
+++ b/provider/signal_rule_resource_test.go
@@ -40,7 +40,7 @@ func testAccFireHydrantSignalRuleConfigBasic() string {
 		expression = "signal.summary == 'test-signal-summary'"
 		target_type = "User"
 		target_id = data.firehydrant_user.test_user.id
-		incident_type_id = "00000000-0000-4000-8000-000000000000"
+		incident_type_id = "3314f092-8632-4412-aba8-677ba88d035b"
 	}
 	`, os.Getenv("EXISTING_USER_EMAIL"))
 }

--- a/provider/signal_rule_resource_test.go
+++ b/provider/signal_rule_resource_test.go
@@ -40,7 +40,7 @@ func testAccFireHydrantSignalRuleConfigBasic() string {
 		expression = "signal.summary == 'test-signal-summary'"
 		target_type = "User"
 		target_id = data.firehydrant_user.test_user.id
-		incident_type_id = "3314f092-8632-4412-aba8-677ba88d035b"
+		incident_type_id = "daa50f24-a2ba-4e66-a58d-16bca2353453"
 	}
 	`, os.Getenv("EXISTING_USER_EMAIL"))
 }


### PR DESCRIPTION
https://firehydrant.atlassian.net/browse/PDE-1440

This extends the existing signals rules resource to allow an incident type ID to be set for a signals rule.  Also, tests were missing for the signals rules client, so I added something basic in there.