### PR TITLE
Update goreleaser config to clear deprecation warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2.5.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,5 +53,5 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true
 


### PR DESCRIPTION
We had two deprecation warnings when running the last release.  These changes should eliminate both:

- changelog: `skip` changed to `disable` https://goreleaser.com/deprecations/#__tabbed_6_1
- `--rm-dist` changed to `--clean` https://goreleaser.com/deprecations/#-rm-dist
