### PR TITLE
Get all pages of services from query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.2 (Unreleased)
+
+BUG FIXES:
+* `firehydrant_services` data source pulls all services correctly
+
 ## 0.9.1
 
 BUG FIXES:

--- a/firehydrant/services.go
+++ b/firehydrant/services.go
@@ -48,14 +48,24 @@ func (c *RESTServicesClient) Get(ctx context.Context, id string) (*ServiceRespon
 func (c *RESTServicesClient) List(ctx context.Context, req *ServiceQuery) (*ServicesResponse, error) {
 	servicesResponse := &ServicesResponse{}
 	apiError := &APIError{}
-	response, err := c.restClient().Get("services").QueryStruct(req).Receive(servicesResponse, apiError)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get services")
-	}
+	curPage := 1
 
-	err = checkResponseStatusCode(response, apiError)
-	if err != nil {
-		return nil, err
+	for {
+		req.Page = curPage
+		response, err := c.restClient().Get("services").QueryStruct(req).Receive(servicesResponse, apiError)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get services")
+		}
+
+		err = checkResponseStatusCode(response, apiError)
+		if err != nil {
+			return nil, err
+		}
+
+		if servicesResponse.Pagination == nil || servicesResponse.Pagination.Last == curPage {
+			break
+		}
+		curPage += 1
 	}
 
 	return servicesResponse, nil

--- a/firehydrant/services_test.go
+++ b/firehydrant/services_test.go
@@ -88,7 +88,7 @@ func TestGetServices(t *testing.T) {
 		t.Fatalf("Received error hitting ping endpoint: %s", err.Error())
 	}
 
-	if expected := "/services?labels=key1%3Dval1%2Ckey2%3Dval2&query=hello-world"; expected != requestPathRcvd {
+	if expected := "/services?labels=key1%3Dval1%2Ckey2%3Dval2&page=1&query=hello-world"; expected != requestPathRcvd {
 		t.Fatalf("Expected %s, Got: %s for request path", expected, requestPathRcvd)
 	}
 }

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -117,6 +117,7 @@ type ServiceQuery struct {
 	Query          string         `url:"query,omitempty"`
 	ServiceTier    int            `url:"int,service_tier,omitempty"`
 	LabelsSelector LabelsSelector `url:"labels,omitempty"`
+	Page           int            `url:"page,omitempty"`
 }
 
 type LabelsSelector map[string]string
@@ -146,7 +147,8 @@ var _ query.Encoder = LabelsSelector{}
 
 // ServicesResponse is the payload for retrieving a list of services
 type ServicesResponse struct {
-	Services []ServiceResponse `json:"data"`
+	Services   []ServiceResponse `json:"data"`
+	Pagination *Pagination       `json:"pagination,omitempty"`
 }
 
 // UserResponse is the payload for a user


### PR DESCRIPTION
https://firehydrant.atlassian.net/browse/PDE-2328

Based on how the teams List() endpoint works, this should be all that's needed to get all pages of the services response.  The actual provider code for the data resource shouldn't need to change.
