### PR TITLE
Set ID to nothing if the policy is gone on the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.1
+
+BUG FIXES:
+* Fixes a bug where escalation policy resources were not being removed from state if deleted outside of Terraform
+
 ## 0.13.0
 
 ENHANCEMENTS:

--- a/provider/escalation_policy_resource.go
+++ b/provider/escalation_policy_resource.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
@@ -106,6 +108,14 @@ func readResourceFireHydrantEscalationPolicy(ctx context.Context, d *schema.Reso
 
 	escalationPolicy, err := firehydrantAPIClient.EscalationPolicies().Get(ctx, teamID, id)
 	if err != nil {
+		if errors.Is(err, firehydrant.ErrorNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("Escalation Policy %s no longer exists", id), map[string]interface{}{
+				"id": id,
+			})
+			d.SetId("")
+			return nil
+		}
+
 		return diag.Errorf("Error reading escalation policy %s: %v", id, err)
 	}
 


### PR DESCRIPTION
## Description

Addresses a bug for when an escalation policy has been deleted in FireHydrant outside of Terraform, an error will occur on re-apply for the plan.

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.