### PR TITLE
Add support for handoffs and restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.13.2
+
+BUG FIXES:
+* Fixes a bug where on-call schedule handoff days were not being updated in FireHydrant
+
+EHNANCEMENTS:
+* Adds a new `effective_at` attribute to the `firehydrant_on_call_schedule` resource to allow for scheduling changes to take effect at a future date
+
 ## 0.13.1
 
 BUG FIXES:

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -69,6 +69,7 @@ The following arguments are supported:
 * `time_zone` - (Required) The time zone that the on-call schedule is in.
 * `strategy` - (Required) A block to define the strategy for the on-call schedule.
 * `restrictions` - (Optional) A block to define a restriction for the on-call schedule.
+* `effective_at` - (Optional) The date and time that the on-call schedule becomes effective. Must be in `YYYY-MM-DDTHH:MM:SSZ` format. Defaults to the current date and time. If set to the past, the schedule will be effective immediately. This attribute is not stored in Terraform state.
 
 The `strategy` block supports:
 

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -76,7 +76,7 @@ The `strategy` block supports:
 * `type` - (Required) The type of strategy to use for the on-call schedule. Valid values are `weekly`, `daily`, or `custom`.
 * `handoff_time` - (Required) The time of day that the on-call schedule handoff occurs. Must be in `HH:MM:SS` format.
 * `handoff_day` - (Required) The day of the week that the on-call schedule handoff occurs. Valid values are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, and `saturday`.
-* `shift_duration` - (Optional) The duration of the on-call shift in ISO8601 format. Required for `custom` strategy.
+* `shift_duration` - (Optional) The duration of the on-call shift in [ISO8601 format](https://en.wikipedia.org/wiki/ISO_8601#Durations) (e.g. `PT8H`). Required for `custom` strategy.
 
 The `restrictions` block supports:
 

--- a/firehydrant/on_call_schedules.go
+++ b/firehydrant/on_call_schedules.go
@@ -61,10 +61,13 @@ type CreateOnCallScheduleRequest struct {
 }
 
 type UpdateOnCallScheduleRequest struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	MemberIDs   []string `json:"member_ids,omitempty"`
-	EffectiveAt string   `json:"effective_at,omitempty"`
+	Name         string                      `json:"name"`
+	Description  string                      `json:"description"`
+	MemberIDs    []string                    `json:"member_ids,omitempty"`
+	EffectiveAt  string                      `json:"effective_at,omitempty"`
+	Color        string                      `json:"color,omitempty"`
+	Strategy     *OnCallScheduleStrategy     `json:"strategy,omitempty"`
+	Restrictions []OnCallScheduleRestriction `json:"restrictions,omitempty"`
 }
 
 type OnCallScheduleRestriction struct {

--- a/firehydrant/on_call_schedules.go
+++ b/firehydrant/on_call_schedules.go
@@ -67,7 +67,7 @@ type UpdateOnCallScheduleRequest struct {
 	EffectiveAt  string                      `json:"effective_at,omitempty"`
 	Color        string                      `json:"color,omitempty"`
 	Strategy     *OnCallScheduleStrategy     `json:"strategy,omitempty"`
-	Restrictions []OnCallScheduleRestriction `json:"restrictions,omitempty"`
+	Restrictions []OnCallScheduleRestriction `json:"restrictions"`
 }
 
 type OnCallScheduleRestriction struct {

--- a/provider/on_call_schedule_resource_test.go
+++ b/provider/on_call_schedule_resource_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -411,4 +413,166 @@ func testAccOnCallScheduleConfig_withHandoffAndRestrictions(rName, handoffDay, h
 		}
 	}
 	`, rName, rName, handoffTime, handoffDay)
+}
+
+func TestAccOnCallScheduleResource_scheduleModifications(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckOnCallScheduleResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Initial configuration with restrictions
+				Config: testAccOnCallScheduleConfig_withHandoffAndRestrictions(rName, "monday", "09:00:00"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.type", "weekly"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_time", "09:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_day", "monday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "restrictions.#", "2"),
+				),
+			},
+			{
+				// Change just handoff day, keeping time and restrictions
+				Config: testAccOnCallScheduleConfig_withHandoffAndRestrictions(rName, "friday", "09:00:00"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_day", "friday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_time", "09:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "restrictions.#", "2"),
+				),
+			},
+			{
+				// Remove all restrictions but keep handoff settings
+				Config: testAccOnCallScheduleConfig_withHandoff(rName, "friday", "09:00:00"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_day", "friday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_time", "09:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "restrictions.#", "0"),
+				),
+			},
+			{
+				// Add different restriction pattern
+				Config: testAccOnCallScheduleConfig_withBusinessHours(rName, "friday", "09:00:00"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_day", "friday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_time", "09:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "restrictions.#", "1"),
+					// Check business hours restriction
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "restrictions.0.start_day", "monday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "restrictions.0.start_time", "09:00:00"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "restrictions.0.end_day", "friday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "restrictions.0.end_time", "17:00:00"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOnCallScheduleConfig_withBusinessHours(rName, handoffDay, handoffTime string) string {
+	return fmt.Sprintf(`
+	resource "firehydrant_team" "test_team" {
+		name = "test-team-%s"
+	}
+
+	resource "firehydrant_on_call_schedule" "test_schedule" {
+		team_id = firehydrant_team.test_team.id
+		name = "test-schedule-%s"
+		time_zone = "America/New_York"
+
+		strategy {
+			type         = "weekly"
+			handoff_time = "%s"
+			handoff_day  = "%s"
+		}
+
+		restrictions {
+			start_day = "monday"
+			start_time = "09:00:00"
+			end_day = "friday"
+			end_time = "17:00:00"
+		}
+	}
+	`, rName, rName, handoffTime, handoffDay)
+}
+
+func TestAccOnCallScheduleResource_effectiveAt(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlphaNum)
+	futureTime := time.Now().Add(24 * time.Hour).Format(time.RFC3339) // Tomorrow
+	pastTime := time.Now().Add(-24 * time.Hour).Format(time.RFC3339)  // Yesterday
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckOnCallScheduleResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Initial schedule setup
+				Config: testAccOnCallScheduleConfig_withHandoff(rName, "monday", "09:00:00"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_day", "monday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_time", "09:00:00"),
+				),
+			},
+			{
+				// Update with future effective_at
+				Config: testAccOnCallScheduleConfig_withEffectiveAt(rName, "friday", "13:00:00", futureTime),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_day", "friday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_time", "13:00:00"),
+					// effective_at shouldn't be in state
+					resource.TestCheckNoResourceAttr("firehydrant_on_call_schedule.test_schedule", "effective_at"),
+				),
+			},
+			{
+				// Update with past effective_at (should apply immediately)
+				Config: testAccOnCallScheduleConfig_withEffectiveAt(rName, "wednesday", "15:00:00", pastTime),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_day", "wednesday"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_schedule", "strategy.0.handoff_time", "15:00:00"),
+					// effective_at shouldn't be in state
+					resource.TestCheckNoResourceAttr("firehydrant_on_call_schedule.test_schedule", "effective_at"),
+				),
+			},
+			{
+				// Test invalid timestamp format
+				Config:      testAccOnCallScheduleConfig_withEffectiveAt(rName, "thursday", "10:00:00", "invalid-timestamp"),
+				ExpectError: regexp.MustCompile("effective_at must be a valid RFC3339 timestamp"),
+			},
+			{
+				// Verify plan is empty when effective_at changes but nothing else does
+				Config:   testAccOnCallScheduleConfig_withEffectiveAt(rName, "wednesday", "15:00:00", futureTime),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccOnCallScheduleConfig_withEffectiveAt(rName, handoffDay, handoffTime, effectiveAt string) string {
+	return fmt.Sprintf(`
+	resource "firehydrant_team" "test_team" {
+		name = "test-team-%s"
+	}
+
+	resource "firehydrant_on_call_schedule" "test_schedule" {
+		team_id = firehydrant_team.test_team.id
+		name = "test-schedule-%s"
+		time_zone = "America/New_York"
+
+		strategy {
+			type         = "weekly"
+			handoff_time = "%s"
+			handoff_day  = "%s"
+		}
+
+		effective_at = "%s"
+	}
+	`, rName, rName, handoffTime, handoffDay, effectiveAt)
 }


### PR DESCRIPTION
## Description

* Adds support for updating handoff and restrictions in on-call schedules
* Adds support for an `effective_at` attribute in resources to apply changes in the future

## PR readiness 

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.