### PR TITLE
Allow removing notification priority in signal rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.13.3 (Unreleased)
+## 0.13.3
 
 BUG FIXES:
 * Fixes a discrepancy between the FireHydrant API and `firehydrant_inbound_email` resource where the `target` attribute was erroneously being required.
+* Fixes a bug where `notification_priority_override` could not be unset on a `firehydrant_signal_rule` resource.
 
 ## 0.13.2
 

--- a/firehydrant/signals_rules.go
+++ b/firehydrant/signals_rules.go
@@ -17,15 +17,6 @@ const (
 	NotificationPriorityHigh   NotificationPriority = "HIGH"
 )
 
-// Validate checks if the NotificationPriority is valid
-func (np NotificationPriority) Validate() error {
-	switch np {
-	case NotificationPriorityLow, NotificationPriorityMedium, NotificationPriorityHigh:
-		return nil
-	}
-	return fmt.Errorf("invalid notification priority: %s", np)
-}
-
 type SignalsRules interface {
 	Get(ctx context.Context, teamID, id string) (*SignalsRuleResponse, error)
 	Create(ctx context.Context, teamID string, createReq CreateSignalsRuleRequest) (*SignalsRuleResponse, error)
@@ -76,7 +67,7 @@ type UpdateSignalsRuleRequest struct {
 	TargetType                   string               `json:"target_type"`
 	TargetID                     string               `json:"target_id"`
 	IncidentTypeID               string               `json:"incident_type_id,omitempty"`
-	NotificationPriorityOverride NotificationPriority `json:"notification_priority_override,omitempty"`
+	NotificationPriorityOverride NotificationPriority `json:"notification_priority_override"`
 }
 
 func (c *RESTSignalsRulesClient) restClient() *sling.Sling {

--- a/provider/signal_rule_resource.go
+++ b/provider/signal_rule_resource.go
@@ -87,13 +87,19 @@ func readResourceFireHydrantSignalRule(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("Error reading signal rule %s: %v", id, err)
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("Read signal rule %s", id), map[string]interface{}{
+		"id":                             id,
+		"notification_priority_override": signalRule.NotificationPriorityOverride,
+	})
+
 	// Gather values from API response
 	attributes := map[string]interface{}{
-		"name":             signalRule.Name,
-		"expression":       signalRule.Expression,
-		"target_type":      signalRule.Target.Type,
-		"target_id":        signalRule.Target.ID,
-		"incident_type_id": signalRule.IncidentType.ID,
+		"name":                           signalRule.Name,
+		"expression":                     signalRule.Expression,
+		"target_type":                    signalRule.Target.Type,
+		"target_id":                      signalRule.Target.ID,
+		"incident_type_id":               signalRule.IncidentType.ID,
+		"notification_priority_override": string(signalRule.NotificationPriorityOverride),
 	}
 
 	// Set the resource attributes to the values we got from the API
@@ -102,8 +108,6 @@ func readResourceFireHydrantSignalRule(ctx context.Context, d *schema.ResourceDa
 			return diag.Errorf("Error setting %s for signal rule %s: %v", key, id, err)
 		}
 	}
-
-	d.Set("notification_priority_override", string(signalRule.NotificationPriorityOverride))
 
 	return diag.Diagnostics{}
 }
@@ -154,7 +158,8 @@ func updateResourceFireHydrantSignalRule(ctx context.Context, d *schema.Resource
 
 	// Update the signal rule
 	tflog.Debug(ctx, fmt.Sprintf("Update signal rule: %s", d.Id()), map[string]interface{}{
-		"id": d.Id(),
+		"id":                             d.Id(),
+		"notification_priority_override": d.Get("notification_priority_override"),
 	})
 	_, err := firehydrantAPIClient.SignalsRules().Update(ctx, d.Get("team_id").(string), d.Id(), updateRequest)
 	if err != nil {


### PR DESCRIPTION
## Description

Fixes signal rules resource to allow removing a notification priority after it has been set.