### PR TITLE
Allow re-triggered actions to use FH secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
## Description

Pulled shamelessly from https://michaelheap.com/access-secrets-from-forks/

The issue here is that PRs from forks don't run in github actions with permission to access the secrets that are in the main repo (see runs on #174 as an example).  I can't find a github-blessed way of dealing with this, but there is a check permission action that allows us to do some trickery here, as explained in the above blog post.  We're also being specific in how we handle the checkout in a deliberately insecure way, which is only made secure by the aforementioned permissions check.

