### PR TITLE
use pull_request_target for actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ on:
   push:
     branches:
       - 'main'
-  pull_request:
-    branches:
-      - '*'
+  pull_request_target:
+    types: [opened, synchronize]
+    branches: ['*']
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

An extension of the fix attempted in #175, evidently the `pull_request` and `pull_request_target` triggers are subtly different and the context of the latter is what's required to make this work.