### PR TITLE
Add oncall schedule import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.14.3
+
+ENHANCEMENTS:
+
+* `firehydrant_on_call_schedule` and `firehydrant_rotation` now support imports.
+
 ## 0.14.2
 
 ENHANCEMENTS:

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -122,7 +122,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Rotations can be imported; use `<TeamID>:<ScheduleID>` as the import ID. For example:
+On-call schedules can be imported; use `<TeamID>:<ScheduleID>` as the import ID. For example:
 
 ```shell
 terraform import firehydrant_rotation.example_rotation 3638b647-b99c-5051-b715-eda2c912c42e:12345678-90ab-cdef-1234-567890abcdef

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -125,5 +125,5 @@ In addition to all arguments above, the following attributes are exported:
 On-call schedules can be imported; use `<TeamID>:<ScheduleID>` as the import ID. For example:
 
 ```shell
-terraform import firehydrant_rotation.example_rotation 3638b647-b99c-5051-b715-eda2c912c42e:12345678-90ab-cdef-1234-567890abcdef
+terraform import firehydrant_on_call_schedule.example_schedule 3638b647-b99c-5051-b715-eda2c912c42e:12345678-90ab-cdef-1234-567890abcdef
 ```

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -119,3 +119,11 @@ The `restrictions` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the on-call schedule.
+
+## Import
+
+Rotations can be imported; use `<TeamID>:<ScheduleID>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_rotation.example_rotation 3638b647-b99c-5051-b715-eda2c912c42e:12345678-90ab-cdef-1234-567890abcdef
+```

--- a/docs/resources/rotation.md
+++ b/docs/resources/rotation.md
@@ -105,3 +105,11 @@ The `restrictions` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the rotation.
+
+## Import
+
+Rotations can be imported; use `<TeamID>:<ScheduleID>:<RotationID>` as the import ID. For example:
+
+```shell
+terraform import firehydrant_rotation.example_rotation 3638b647-b99c-5051-b715-eda2c912c42e:12345678-90ab-cdef-1234-567890abcdef:3638b647-b99c-5051-b715-eda2c912c42e
+```

--- a/provider/on_call_schedule_resource.go
+++ b/provider/on_call_schedule_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
@@ -19,9 +20,9 @@ func resourceOnCallSchedule() *schema.Resource {
 		ReadContext:   readResourceFireHydrantOnCallSchedule,
 		UpdateContext: updateResourceFireHydrantOnCallSchedule,
 		DeleteContext: deleteResourceFireHydrantOnCallSchedule,
-		// Importer: &schema.ResourceImporter{
-		// 	StateContext: schema.ImportStatePassthroughContext,
-		// },
+		Importer: &schema.ResourceImporter{
+			StateContext: importResourceFireHydrantOnCallSchedule,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"team_id": {
@@ -406,6 +407,28 @@ func deleteResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.Reso
 	d.SetId("")
 
 	return diag.Diagnostics{}
+}
+
+func importResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	team_id, id, err := resourceFireHydrantOnCallScheduleParseId(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("team_id", team_id)
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceFireHydrantOnCallScheduleParseId(id string) (string, string, error) {
+	parts := strings.SplitN(id, ":", 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected Team_ID:Schedule_ID", id)
+	}
+
+	return parts[0], parts[1], nil
 }
 
 func strategyToMap(strategy firehydrant.OnCallScheduleStrategy) []map[string]interface{} {

--- a/provider/on_call_schedule_resource_test.go
+++ b/provider/on_call_schedule_resource_test.go
@@ -579,7 +579,7 @@ func TestAccOnCallScheduleResourceImport_basic(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("Not found: %s", resourceName)
 					}
-					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["id"], rs.Primary.Attributes["team_id"]), nil
+					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["team_id"], rs.Primary.Attributes["id"]), nil
 				},
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/provider/on_call_schedule_resource_test.go
+++ b/provider/on_call_schedule_resource_test.go
@@ -558,3 +558,32 @@ func testAccOnCallScheduleConfig_withEffectiveAt(rName, handoffDay, handoffTime,
 	}
 	`, rName, rName, handoffTime, handoffDay, effectiveAt)
 }
+
+func TestAccExampleModelResourceImport_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlphaNum)
+
+	resourceName := "firehydrant_on_call_schedule.test_on_call_schedule"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckOnCallScheduleResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnCallScheduleConfig_basic(rName),
+			},
+			{
+				ResourceName: resourceName,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("Not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["team_id"], rs.Primary.Attributes["id"]), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/provider/on_call_schedule_resource_test.go
+++ b/provider/on_call_schedule_resource_test.go
@@ -559,7 +559,7 @@ func testAccOnCallScheduleConfig_withEffectiveAt(rName, handoffDay, handoffTime,
 	`, rName, rName, handoffTime, handoffDay, effectiveAt)
 }
 
-func TestAccExampleModelResourceImport_basic(t *testing.T) {
+func TestAccOnCallScheduleResourceImport_basic(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlphaNum)
 
 	resourceName := "firehydrant_on_call_schedule.test_on_call_schedule"
@@ -579,7 +579,7 @@ func TestAccExampleModelResourceImport_basic(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("Not found: %s", resourceName)
 					}
-					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["team_id"], rs.Primary.Attributes["id"]), nil
+					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["id"], rs.Primary.Attributes["team_id"]), nil
 				},
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/provider/rotation_resource_test.go
+++ b/provider/rotation_resource_test.go
@@ -620,3 +620,32 @@ func testAccRotationConfig_withEffectiveAt(rName, handoffDay, handoffTime, effec
 	}
 	`, rName, rName, rName, handoffTime, handoffDay, effectiveAt)
 }
+
+func TestAccRotationResourceImport_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlphaNum)
+
+	resourceName := "firehydrant_rotation.test_rotation"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckRotationResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRotationConfig_basic(rName),
+			},
+			{
+				ResourceName: resourceName,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("Not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s:%s:%s", rs.Primary.Attributes["team_id"], rs.Primary.Attributes["schedule_id"], rs.Primary.Attributes["id"]), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
https://firehydrant.atlassian.net/browse/FH-1646

Adding support for importing on-call schedules and rotations via the `terraform import` cli command.  Because the API calls to read these items require additional IDs (for the team, and in the case of rotations, the schedule), the import will require a complex string that will be parsed into these IDs.  All other operations remain the same.