### PR TITLE
Add custom event source resource and tests

### DIFF
--- a/provider/custom_event_source_resource.go
+++ b/provider/custom_event_source_resource.go
@@ -1,0 +1,139 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
+	"github.com/firehydrant/firehydrant-go-sdk/models/sdkerrors"
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceCustomEventSource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createResourceCustomEventSource,
+		ReadContext:   readResourceCustomEventSource,
+		UpdateContext: updateResourceCustomEventSource,
+		DeleteContext: deleteResourceCustomEventSource,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"slug": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"javascript": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func createResourceCustomEventSource(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*firehydrant.APIClient)
+
+	description := d.Get("description").(string)
+
+	request := components.CreateSignalsEventSource{
+		Name:        d.Get("name").(string),
+		Slug:        d.Get("slug").(string),
+		Description: &description,
+		Javascript:  d.Get("javascript").(string),
+	}
+
+	tflog.Debug(ctx, "Create new Custom Event Source")
+	response, err := client.Sdk.Signals.CreateSignalsEventSource(ctx, request)
+	if err != nil {
+		return diag.Errorf("Error creating new Custom Event Source: %v", err)
+	}
+
+	d.SetId(*response.Slug)
+
+	return readResourceCustomEventSource(ctx, d, m)
+}
+
+func readResourceCustomEventSource(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*firehydrant.APIClient)
+
+	slug := d.Id()
+	tflog.Debug(ctx, fmt.Sprintf("Read custom event source: %s", slug), map[string]interface{}{
+		"slug": slug,
+	})
+
+	response, err := client.Sdk.Signals.GetSignalsEventSource(ctx, slug)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	attributes := map[string]interface{}{
+		"name":        *response.Name,
+		"slug":        *response.Slug,
+		"description": *response.Description,
+		"javascript":  *response.Expression,
+	}
+
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
+			return diag.Errorf("Error setting %s for custom_event_source %s: %v", key, slug, err)
+		}
+	}
+
+	return diag.Diagnostics{}
+}
+
+func updateResourceCustomEventSource(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*firehydrant.APIClient)
+
+	description := d.Get("description").(string)
+	slug := d.Get("slug").(string)
+
+	//we don't have an update api call in the client, but the API says that we create via a PUT, so I'm guessing this is correct?
+	request := components.CreateSignalsEventSource{
+		Name:        d.Get("name").(string),
+		Slug:        slug,
+		Description: &description,
+		Javascript:  d.Get("javascript").(string),
+	}
+
+	tflog.Debug(ctx, "Update Custom Event Source")
+	response, err := client.Sdk.Signals.CreateSignalsEventSource(ctx, request)
+	if err != nil {
+		return diag.Errorf("Error updating Custom Event Source %s: %v", slug, err)
+	}
+
+	d.SetId(*response.Slug)
+
+	return readResourceCustomEventSource(ctx, d, m)
+}
+
+func deleteResourceCustomEventSource(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*firehydrant.APIClient)
+
+	slug := d.Id()
+	tflog.Debug(ctx, fmt.Sprintf("Delete custom event source: %s", slug), map[string]interface{}{
+		"slug": slug,
+	})
+	err := client.Sdk.Signals.DeleteSignalsEventSource(ctx, slug)
+	if err != nil {
+		if err.(*sdkerrors.SDKError).StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error deleting custom event source %s: %v", slug, err)
+	}
+
+	return diag.Diagnostics{}
+}

--- a/provider/custom_event_source_resource_test.go
+++ b/provider/custom_event_source_resource_test.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	fhsdk "github.com/firehydrant/firehydrant-go-sdk"
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccCustomEventSourceResource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckCustomEventSourceResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomEventSourceResourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCustomEventSourceResourceExistsWithAttributes_basic("firehydrant_custom_event_source.foo_transposer"),
+					resource.TestCheckResourceAttrSet("firehydrant_custom_event_source.foo_transposer", "id"),
+					resource.TestCheckResourceAttr(
+						"ffirehydrant_custom_event_source.foo_transposer", "name", "The Foo Transposer"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_custom_event_source.foo_transposer", "slug", "foo"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_custom_event_source.foo_transposer", "description", "This is the foo transposer"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_custom_event_source.foo_transposer", "javascript", "function transpose(input) {\n  return input.data;\n}"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCustomEventSourceResource_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: defaultProviderFactories(),
+		CheckDestroy:      testAccCheckCustomEventSourceResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomEventSourceResourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCustomEventSourceResourceExistsWithAttributes_basic("firehydrant_custom_event_source.foo_transposer"),
+					resource.TestCheckResourceAttrSet("firehydrant_custom_event_source.foo_transposer", "id"),
+					resource.TestCheckResourceAttr(
+						"ffirehydrant_custom_event_source.foo_transposer", "name", "The Foo Transposer"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_custom_event_source.foo_transposer", "slug", "foo"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_custom_event_source.foo_transposer", "description", "A new foo transposer description"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_custom_event_source.foo_transposer", "javascript", "function transpose(input) {\n  return input.data;\n}"),
+				),
+			},
+			{
+				Config: testAccCustomEventSourceResourceConfig_update(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCustomEventSourceResourceExistsWithAttributes_basic("firehydrant_custom_event_source.foo_transposer"),
+					resource.TestCheckResourceAttrSet("firehydrant_custom_event_source.foo_transposer", "id"),
+					resource.TestCheckResourceAttr(
+						"ffirehydrant_custom_event_source.foo_transposer", "name", "The Foo Transposer"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_custom_event_source.foo_transposer", "slug", "foo"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_custom_event_source.foo_transposer", "description", "This is the foo transposer"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_custom_event_source.foo_transposer", "javascript", "function transpose(input) {\n  return input.foo;\n}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCustomEventSourceResourceExistsWithAttributes_basic(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		customEventSourceResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if customEventSourceResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client := fhsdk.New(fhsdk.WithSecurity(components.Security{APIKey: os.Getenv("FIREHYDRANT_API_KEY")}))
+
+		response, err := client.Signals.GetSignalsEventSource(context.TODO(), customEventSourceResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		expected, got := customEventSourceResource.Primary.Attributes["name"], *response.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = customEventSourceResource.Primary.Attributes["slug"], *response.Slug
+		if expected != got {
+			return fmt.Errorf("Unexpected max_delay. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = customEventSourceResource.Primary.Attributes["description"], *response.Description
+		if expected != got {
+			return fmt.Errorf("Unexpected priority. Expected: %s, got: %s", expected, got)
+		}
+
+		expected, got = customEventSourceResource.Primary.Attributes["javascript"], *response.Expression
+		if expected != got {
+			return fmt.Errorf("Unexpected priority. Expected: %s, got: %s", expected, got)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCustomEventSourceResourceDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := fhsdk.New(fhsdk.WithSecurity(components.Security{APIKey: os.Getenv("FIREHYDRANT_API_KEY")}))
+
+		for _, stateResource := range s.RootModule().Resources {
+			if stateResource.Type != "firehydrant_custom_event_source" {
+				continue
+			}
+
+			if stateResource.Primary.ID == "" {
+				return fmt.Errorf("No instance ID is set")
+			}
+
+			_, err := client.Signals.GetSignalsEventSource(context.TODO(), stateResource.Primary.ID)
+			if err == nil {
+				return fmt.Errorf("Custom Event Source %s still exists", stateResource.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCustomEventSourceResourceConfig_basic() string {
+	return `
+resource "firehydrant_custom_event_source" "foo_transposer" {
+  name = "The Foo Transposer"
+	slug = "foo"
+	description = "This is the foo transposer"
+	javascript = "function transpose(input) {\n  return input.data;\n}"
+}`
+}
+
+func testAccCustomEventSourceResourceConfig_update() string {
+	return `
+resource "firehydrant_custom_event_source" "foo_transposer" {
+  name = "The Foo Transposer"
+	slug = "foo"
+	description = "A new foo transposer description"
+	javascript = "function transpose(input) {\n  return input.foo;\n}"
+}`
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -49,6 +49,7 @@ func Provider() *schema.Provider {
 			"firehydrant_escalation_policy":      resourceEscalationPolicy(),
 			"firehydrant_status_update_template": resourceStatusUpdateTemplate(),
 			"firehydrant_inbound_email":          resourceInboundEmail(),
+			"firehydrant_custom_event_source":    resourceCustomEventSource(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"firehydrant_environment":       dataSourceEnvironment(),


### PR DESCRIPTION
https://firehydrant.atlassian.net/browse/FH-454

Adds support for relay transposers, which our UI also calls Custom Event Sources.  This is the first working attempt at a resource using the new go sdk, so hopefully it all goes smoothly.