### PR TITLE
intercept unmarshal for transposer example payload

### DIFF
--- a/firehydrant/transposers_test.go
+++ b/firehydrant/transposers_test.go
@@ -16,7 +16,7 @@ func expectedTransposersResponse() *TransposersResponse {
 	t := Transposer{
 		Name:           "Valid Transposer",
 		Slug:           "valid-transposer",
-		ExamplePayload: "",
+		ExamplePayload: `{"message": "Example signal data", "severity": "high", "timestamp": "2023-12-18T07:20:50.52Z"}`,
 		Expression:     "",
 		Expected:       "",
 		Website:        "",
@@ -32,7 +32,7 @@ func expectedTransposersResponse() *TransposersResponse {
 func expectedTransposerResponseJSON() string {
 	return `{
 	"data":[
-		{"name": "Valid Transposer", "slug": "valid-transposer", "example_payload": "", "expression": "", "expected": "", 
+		{"name": "Valid Transposer", "slug": "valid-transposer", "example_payload": {"message": "Example signal data", "severity": "high", "timestamp": "2023-12-18T07:20:50.52Z"}, "expression": "", "expected": "", 
 			"website": "", "description": "", "tags": [""], "ingest_url": "https://signals.firehydrant.com/v1/transpose/valid-transposer/some-long-jwt"}
 	]
 }`

--- a/firehydrant/types.go
+++ b/firehydrant/types.go
@@ -1,6 +1,7 @@
 package firehydrant
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"sort"
@@ -340,4 +341,39 @@ type Transposer struct {
 	Description    string   `json:"description"`
 	Tags           []string `json:"tags"`
 	IngestURL      string   `json:"ingest_url"`
+}
+
+// Intercepts the JSON unmarshalling and ensures that example_payload is properly stringified
+func (t *Transposer) UnmarshalJSON(data []byte) error {
+	type tempTransposer struct {
+		Name           string          `json:"name"`
+		Slug           string          `json:"slug"`
+		ExamplePayload json.RawMessage `json:"example_payload"`
+		Expression     string          `json:"expression"`
+		Expected       string          `json:"expected"`
+		Website        string          `json:"website"`
+		Description    string          `json:"description"`
+		Tags           []string        `json:"tags"`
+		IngestURL      string          `json:"ingest_url"`
+	}
+
+	var temp tempTransposer
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	t.Name = temp.Name
+	t.Slug = temp.Slug
+	t.Expression = temp.Expression
+	t.Expected = temp.Expected
+	t.Website = temp.Website
+	t.Description = temp.Description
+	t.Tags = temp.Tags
+	t.IngestURL = temp.IngestURL
+
+	if temp.ExamplePayload != nil {
+		t.ExamplePayload = string(temp.ExamplePayload)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description

Problem: API returns example payload as a hash, causing 500s on attempts to unmarshall. Slack thread for context.

Solution: Intercept unmarshall to stringify example_payload. String used over an object since terraform requires clear types and structure for items in terraform state. 