### PR TITLE
FH-1185: Migrate incident role resource, data

### DIFF
--- a/provider/incident_role_resource.go
+++ b/provider/incident_role_resource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -43,14 +44,14 @@ func resourceIncidentRole() *schema.Resource {
 
 func readResourceFireHydrantIncidentRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	// Get the API client
-	firehydrantAPIClient := m.(firehydrant.Client)
+	client := m.(*firehydrant.APIClient)
 
 	// Get the incident role
 	incidentRoleID := d.Id()
 	tflog.Debug(ctx, fmt.Sprintf("Read incident role: %s", incidentRoleID), map[string]interface{}{
 		"id": incidentRoleID,
 	})
-	incidentRoleResponse, err := firehydrantAPIClient.IncidentRoles().Get(ctx, incidentRoleID)
+	incidentRole, err := client.Sdk.IncidentSettings.GetIncidentRole(ctx, incidentRoleID)
 	if err != nil {
 		if errors.Is(err, firehydrant.ErrorNotFound) {
 			tflog.Debug(ctx, fmt.Sprintf("Incident role %s no longer exists", incidentRoleID), map[string]interface{}{
@@ -64,7 +65,7 @@ func readResourceFireHydrantIncidentRole(ctx context.Context, d *schema.Resource
 	// Currently, the incident role API will still return deleted/archived incident roles instead of returning
 	// 404. So, to check for incident roles that are deleted, we have to check for incident roles that have
 	// a DiscardedAt timestamp
-	if !incidentRoleResponse.DiscardedAt.IsZero() {
+	if incidentRole.GetDiscardedAt() != nil && !incidentRole.GetDiscardedAt().IsZero() {
 		tflog.Debug(ctx, fmt.Sprintf("Incident role %s has been archived", incidentRoleID), map[string]interface{}{
 			"id": incidentRoleID,
 		})
@@ -74,9 +75,13 @@ func readResourceFireHydrantIncidentRole(ctx context.Context, d *schema.Resource
 
 	// Gather values from API response
 	attributes := map[string]interface{}{
-		"description": incidentRoleResponse.Description,
-		"name":        incidentRoleResponse.Name,
-		"summary":     incidentRoleResponse.Summary,
+		"name":    *incidentRole.GetName(),
+		"summary": *incidentRole.GetSummary(),
+	}
+
+	// Handle optional description field
+	if description := incidentRole.GetDescription(); description != nil {
+		attributes["description"] = *description
 	}
 
 	// Set the resource attributes to the values we got from the API
@@ -91,26 +96,30 @@ func readResourceFireHydrantIncidentRole(ctx context.Context, d *schema.Resource
 
 func createResourceFireHydrantIncidentRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	// Get the API client
-	firehydrantAPIClient := m.(firehydrant.Client)
+	client := m.(*firehydrant.APIClient)
 
 	// Get attributes from config and construct the create request
-	createRequest := firehydrant.CreateIncidentRoleRequest{
-		Name:        d.Get("name").(string),
-		Summary:     d.Get("summary").(string),
-		Description: d.Get("description").(string),
+	createReq := components.CreateIncidentRole{
+		Name:    d.Get("name").(string),
+		Summary: d.Get("summary").(string),
+	}
+
+	// Handle optional description field
+	if desc := d.Get("description").(string); desc != "" {
+		createReq.Description = &desc
 	}
 
 	// Create the new incident role
-	tflog.Debug(ctx, fmt.Sprintf("Create incident role: %s", createRequest.Name), map[string]interface{}{
-		"name": createRequest.Name,
+	tflog.Debug(ctx, fmt.Sprintf("Create incident role: %s", createReq.Name), map[string]interface{}{
+		"name": createReq.Name,
 	})
-	incidentRoleResponse, err := firehydrantAPIClient.IncidentRoles().Create(ctx, createRequest)
+	incidentRole, err := client.Sdk.IncidentSettings.CreateIncidentRole(ctx, createReq)
 	if err != nil {
-		return diag.Errorf("Error creating incident role %s: %v", createRequest.Name, err)
+		return diag.Errorf("Error creating incident role %s: %v", createReq.Name, err)
 	}
 
 	// Set the new incident role's ID in state
-	d.SetId(incidentRoleResponse.ID)
+	d.SetId(*incidentRole.GetID())
 
 	// Update state with the latest information from the API
 	return readResourceFireHydrantIncidentRole(ctx, d, m)
@@ -118,20 +127,27 @@ func createResourceFireHydrantIncidentRole(ctx context.Context, d *schema.Resour
 
 func updateResourceFireHydrantIncidentRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	// Get the API client
-	firehydrantAPIClient := m.(firehydrant.Client)
+	client := m.(*firehydrant.APIClient)
 
-	// Construct the update request
-	updateRequest := firehydrant.UpdateIncidentRoleRequest{
-		Name:        d.Get("name").(string),
-		Summary:     d.Get("summary").(string),
-		Description: d.Get("description").(string),
+	// Construct the update request (all fields optional with pointers)
+	updateReq := components.UpdateIncidentRole{}
+	name := d.Get("name").(string)
+	updateReq.Name = &name
+	summary := d.Get("summary").(string)
+	updateReq.Summary = &summary
+
+	// Handle optional description field
+	// TODO: The Go SDK uses omitempty, so we cannot send empty strings to clear fields.
+	// This isn't a big deal since it's just the description field, but we should fix this in the future
+	if desc := d.Get("description").(string); desc != "" {
+		updateReq.Description = &desc
 	}
 
 	// Update the incident role
 	tflog.Debug(ctx, fmt.Sprintf("Update incident role: %s", d.Id()), map[string]interface{}{
 		"id": d.Id(),
 	})
-	_, err := firehydrantAPIClient.IncidentRoles().Update(ctx, d.Id(), updateRequest)
+	_, err := client.Sdk.IncidentSettings.UpdateIncidentRole(ctx, d.Id(), updateReq)
 	if err != nil {
 		return diag.Errorf("Error updating incident role %s: %v", d.Id(), err)
 	}
@@ -142,14 +158,14 @@ func updateResourceFireHydrantIncidentRole(ctx context.Context, d *schema.Resour
 
 func deleteResourceFireHydrantIncidentRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	// Get the API client
-	firehydrantAPIClient := m.(firehydrant.Client)
+	client := m.(*firehydrant.APIClient)
 
 	// Delete the incident role
 	incidentRoleID := d.Id()
 	tflog.Debug(ctx, fmt.Sprintf("Delete incident role: %s", incidentRoleID), map[string]interface{}{
 		"id": incidentRoleID,
 	})
-	err := firehydrantAPIClient.IncidentRoles().Delete(ctx, incidentRoleID)
+	err := client.Sdk.IncidentSettings.DeleteIncidentRole(ctx, incidentRoleID)
 	if err != nil {
 		if errors.Is(err, firehydrant.ErrorNotFound) {
 			return nil

--- a/provider/incident_role_resource_test.go
+++ b/provider/incident_role_resource_test.go
@@ -29,6 +29,8 @@ func TestAccIncidentRoleResource_basic(t *testing.T) {
 						"firehydrant_incident_role.test_incident_role", "name", fmt.Sprintf("test-incident-role-%s", rName)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_incident_role.test_incident_role", "summary", fmt.Sprintf("test-summary-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "description", fmt.Sprintf("test-description-%s", rName)),
 				),
 			},
 		},
@@ -53,6 +55,8 @@ func TestAccIncidentRoleResource_update(t *testing.T) {
 						"firehydrant_incident_role.test_incident_role", "name", fmt.Sprintf("test-incident-role-%s", rName)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_incident_role.test_incident_role", "summary", fmt.Sprintf("test-summary-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "description", fmt.Sprintf("test-description-%s", rName)),
 				),
 			},
 			{
@@ -77,6 +81,8 @@ func TestAccIncidentRoleResource_update(t *testing.T) {
 						"firehydrant_incident_role.test_incident_role", "name", fmt.Sprintf("test-incident-role-%s", rNameUpdated)),
 					resource.TestCheckResourceAttr(
 						"firehydrant_incident_role.test_incident_role", "summary", fmt.Sprintf("test-summary-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_incident_role.test_incident_role", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
 				),
 			},
 		},
@@ -136,23 +142,24 @@ func testAccCheckIncidentRoleResourceExistsWithAttributes_basic(resourceName str
 			return err
 		}
 
-		incidentRoleResponse, err := client.IncidentRoles().Get(context.TODO(), incidentRoleResource.Primary.ID)
+		incidentRole, err := client.Sdk.IncidentSettings.GetIncidentRole(context.TODO(), incidentRoleResource.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		expected, got := incidentRoleResource.Primary.Attributes["name"], incidentRoleResponse.Name
+		expected, got := incidentRoleResource.Primary.Attributes["name"], *incidentRole.GetName()
 		if expected != got {
 			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
 		}
 
-		expected, got = incidentRoleResource.Primary.Attributes["summary"], incidentRoleResponse.Summary
+		expected, got = incidentRoleResource.Primary.Attributes["summary"], *incidentRole.GetSummary()
 		if expected != got {
 			return fmt.Errorf("Unexpected summary. Expected: %s, got: %s", expected, got)
 		}
 
-		if incidentRoleResponse.Description != "" {
-			return fmt.Errorf("Unexpected description. Expected no description, got: %s", incidentRoleResponse.Description)
+		expected, got = incidentRoleResource.Primary.Attributes["description"], *incidentRole.GetDescription()
+		if expected != got {
+			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
 		}
 
 		return nil
@@ -174,22 +181,22 @@ func testAccCheckIncidentRoleResourceExistsWithAttributes_update(resourceName st
 			return err
 		}
 
-		incidentRoleResponse, err := client.IncidentRoles().Get(context.TODO(), incidentRoleResource.Primary.ID)
+		incidentRole, err := client.Sdk.IncidentSettings.GetIncidentRole(context.TODO(), incidentRoleResource.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		expected, got := incidentRoleResource.Primary.Attributes["name"], incidentRoleResponse.Name
+		expected, got := incidentRoleResource.Primary.Attributes["name"], *incidentRole.GetName()
 		if expected != got {
 			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
 		}
 
-		expected, got = incidentRoleResource.Primary.Attributes["summary"], incidentRoleResponse.Summary
+		expected, got = incidentRoleResource.Primary.Attributes["summary"], *incidentRole.GetSummary()
 		if expected != got {
 			return fmt.Errorf("Unexpected summary. Expected: %s, got: %s", expected, got)
 		}
 
-		expected, got = incidentRoleResource.Primary.Attributes["description"], incidentRoleResponse.Description
+		expected, got = incidentRoleResource.Primary.Attributes["description"], *incidentRole.GetDescription()
 		if expected != got {
 			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
 		}
@@ -218,8 +225,8 @@ func testAccCheckIncidentRoleResourceDestroy() resource.TestCheckFunc {
 			// that has been deleted. However, the incident role API will still return deleted/archived incident
 			// roles instead of returning 404. So, to check for incident roles that are deleted, we have to check
 			// for incident roles that have a DiscardedAt timestamp
-			incidentRoleResponse, _ := client.IncidentRoles().Get(context.TODO(), stateResource.Primary.ID)
-			if incidentRoleResponse.DiscardedAt.IsZero() {
+			incidentRole, _ := client.Sdk.IncidentSettings.GetIncidentRole(context.TODO(), stateResource.Primary.ID)
+			if incidentRole.GetDiscardedAt() == nil || incidentRole.GetDiscardedAt().IsZero() {
 				return fmt.Errorf("Incident role %s still exists", stateResource.Primary.ID)
 			}
 		}
@@ -231,9 +238,10 @@ func testAccCheckIncidentRoleResourceDestroy() resource.TestCheckFunc {
 func testAccIncidentRoleResourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "firehydrant_incident_role" "test_incident_role" {
-  name    = "test-incident-role-%s"
-  summary = "test-summary-%s"
-}`, rName, rName)
+  name        = "test-incident-role-%s"
+  summary     = "test-summary-%s"
+  description = "test-description-%s"
+}`, rName, rName, rName)
 }
 
 func testAccIncidentRoleResourceConfig_update(rName string) string {


### PR DESCRIPTION
Ticket: https://firehydrant.atlassian.net/browse/FH-1158

Migrating incident role resource and data source

Initially explored this because of a test failure, but other tests worked independently. Small enough to go ahead and update as well