### PR TITLE
Bump sdk to v1.8.4; fix test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/firehydrant/firehydrant-go-sdk v1.7.1
+	github.com/firehydrant/firehydrant-go-sdk v1.8.4
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/firehydrant/firehydrant-go-sdk v1.7.1 h1:Zg3DiVi/rXdOhrsh6SbSYxxNzWyBirJlql+ma5lK1ws=
-github.com/firehydrant/firehydrant-go-sdk v1.7.1/go.mod h1:t1kMbRzhA0F2ULLTfv2lNg1RS5JIKbMpXsT9nwq5a2Q=
+github.com/firehydrant/firehydrant-go-sdk v1.8.4 h1:ivadOG4RITBhHX8lm0qMhdNhn+8ELNLthka9+JI0v3c=
+github.com/firehydrant/firehydrant-go-sdk v1.8.4/go.mod h1:t1kMbRzhA0F2ULLTfv2lNg1RS5JIKbMpXsT9nwq5a2Q=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=

--- a/provider/environment_resource.go
+++ b/provider/environment_resource.go
@@ -114,7 +114,7 @@ func updateResourceFireHydrantEnvironment(ctx context.Context, d *schema.Resourc
 	description := d.Get("description").(string)
 
 	updateRequest := components.UpdateEnvironment{
-		Name:        name,
+		Name:        &name,
 		Description: &description,
 	}
 


### PR DESCRIPTION
## Description

Bumps the sdk to v1.8.4, which includes the addition of (among other things) support for Functionality properties including but not limited to `service_tier` (which I -- and my organization -- need)

I didn't change the CHANGELOG, but will be happy to do so. Just let me know what version you're targeting next.

## Testing plan

I don't have a test FireHydrant account, so I'm going to have to lean on automated testing for this one, but I can say that the change didn't break any code (except for the one value that became a pointer, the sole reference to which I updated)

## PR readiness 

- [ ] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [ ] An entry has been added to the changelog, if necessary.

Edit: Tyop