### PR TITLE
Added pagination to services, schedules, on_call_schedules and teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+ENHANCEMENTS:
+
+* Pagination support for services, schedules, on_call_schedules and teams
+
 ## 0.15.0
 
 BREAKING CHANGES:

--- a/provider/on_call_schedules_data.go
+++ b/provider/on_call_schedules_data.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
 	"github.com/firehydrant/firehydrant-go-sdk/models/operations"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -56,15 +57,25 @@ func dataFireHydrantOnCallSchedules(ctx context.Context, d *schema.ResourceData,
 	if query != "" {
 		request.Query = &query
 	}
-	schedulesResponse, err := client.Sdk.Signals.ListTeamOnCallSchedules(ctx, request)
 
+	allSchedules, err := fetchAllPages(ctx,
+		func(ctx context.Context, req operations.ListTeamOnCallSchedulesRequest) ([]components.SignalsAPIOnCallScheduleEntity, *components.NullablePaginationEntity, error) {
+			resp, err := client.Sdk.Signals.ListTeamOnCallSchedules(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+			return resp.GetData(), resp.GetPagination(), nil
+		},
+		func(req *operations.ListTeamOnCallSchedulesRequest, page int) { req.Page = &page },
+		request,
+	)
 	if err != nil {
 		return diag.Errorf("Error reading on-call schedules: %v", err)
 	}
 
 	// Set the data source attributes to the values we got from the API
 	schedules := make([]interface{}, 0)
-	for _, schedule := range schedulesResponse.GetData() {
+	for _, schedule := range allSchedules {
 		schedules = append(schedules, dataFireHydrantOnCallScheduleToAttributesMap(teamID, schedule))
 	}
 	if err = d.Set("on_call_schedules", schedules); err != nil {

--- a/provider/pagination.go
+++ b/provider/pagination.go
@@ -1,0 +1,49 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
+)
+
+// maxPages is a safety cap to prevent infinite loops if the API returns a
+// perpetually non-nil Next pointer.
+const maxPages = 1000
+
+// fetchAllPages iterates through all pages of a paginated SDK list endpoint and
+// returns the concatenated items from every page.
+//
+// Parameters:
+//   - fetch: calls the SDK, returns (items, pagination, error) for the current request.
+//   - setPage: mutates the request's Page field to the given page number.
+//   - req: the initial request value; Page will be set to 1 on the first call.
+func fetchAllPages[Req any, Item any](
+	ctx context.Context,
+	fetch func(ctx context.Context, req Req) ([]Item, *components.NullablePaginationEntity, error),
+	setPage func(req *Req, page int),
+	req Req,
+) ([]Item, error) {
+	var all []Item
+
+	for page := 1; page <= maxPages; page++ {
+		setPage(&req, page)
+
+		items, pagination, err := fetch(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, items...)
+
+		if pagination == nil || pagination.GetNext() == nil || *pagination.GetNext() == 0 {
+			break
+		}
+
+		if page == maxPages {
+			return nil, fmt.Errorf("exceeded maximum page limit of %d while paginating", maxPages)
+		}
+	}
+
+	return all, nil
+}

--- a/provider/pagination_test.go
+++ b/provider/pagination_test.go
@@ -1,0 +1,127 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRequest struct {
+	Page *int
+}
+
+func intPtr(i int) *int { return &i }
+
+func makeFetcher(pages [][]string, failOnPage int) func(ctx context.Context, req fakeRequest) ([]string, *components.NullablePaginationEntity, error) {
+	return func(ctx context.Context, req fakeRequest) ([]string, *components.NullablePaginationEntity, error) {
+		page := 1
+		if req.Page != nil {
+			page = *req.Page
+		}
+
+		if failOnPage > 0 && page == failOnPage {
+			return nil, nil, errors.New("simulated API error")
+		}
+
+		idx := page - 1
+		if idx < 0 || idx >= len(pages) {
+			return []string{}, &components.NullablePaginationEntity{}, nil
+		}
+
+		items := pages[idx]
+		pagination := &components.NullablePaginationEntity{}
+		if page < len(pages) {
+			next := page + 1
+			pagination.Next = &next
+		}
+
+		return items, pagination, nil
+	}
+}
+
+func TestFetchAllPages_SinglePage(t *testing.T) {
+	fetch := makeFetcher([][]string{{"a", "b", "c"}}, 0)
+	req := fakeRequest{}
+
+	got, err := fetchAllPages(context.Background(), fetch, func(r *fakeRequest, p int) { r.Page = intPtr(p) }, req)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+}
+
+func TestFetchAllPages_MultiplePages(t *testing.T) {
+	fetch := makeFetcher([][]string{{"a", "b"}, {"c", "d"}, {"e"}}, 0)
+	req := fakeRequest{}
+
+	got, err := fetchAllPages(context.Background(), fetch, func(r *fakeRequest, p int) { r.Page = intPtr(p) }, req)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, got)
+}
+
+func TestFetchAllPages_EmptyResult(t *testing.T) {
+	fetch := makeFetcher([][]string{{}}, 0)
+	req := fakeRequest{}
+
+	got, err := fetchAllPages(context.Background(), fetch, func(r *fakeRequest, p int) { r.Page = intPtr(p) }, req)
+
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestFetchAllPages_ErrorOnFirstPage(t *testing.T) {
+	fetch := makeFetcher([][]string{{"a"}, {"b"}}, 1)
+	req := fakeRequest{}
+
+	got, err := fetchAllPages(context.Background(), fetch, func(r *fakeRequest, p int) { r.Page = intPtr(p) }, req)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.EqualError(t, err, "simulated API error")
+}
+
+func TestFetchAllPages_ErrorOnSubsequentPage(t *testing.T) {
+	fetch := makeFetcher([][]string{{"a"}, {"b"}, {"c"}}, 2)
+	req := fakeRequest{}
+
+	got, err := fetchAllPages(context.Background(), fetch, func(r *fakeRequest, p int) { r.Page = intPtr(p) }, req)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.EqualError(t, err, "simulated API error")
+}
+
+func TestFetchAllPages_NilPaginationStopsLoop(t *testing.T) {
+	calls := 0
+	fetch := func(ctx context.Context, req fakeRequest) ([]string, *components.NullablePaginationEntity, error) {
+		calls++
+		return []string{"x"}, nil, nil
+	}
+	req := fakeRequest{}
+
+	got, err := fetchAllPages(context.Background(), fetch, func(r *fakeRequest, p int) { r.Page = intPtr(p) }, req)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, []string{"x"}, got)
+}
+
+func TestFetchAllPages_MaxPageSafetyCap(t *testing.T) {
+	// Fetcher always reports a next page -- should hit the safety cap.
+	infiniteNext := 999
+	fetch := func(ctx context.Context, req fakeRequest) ([]string, *components.NullablePaginationEntity, error) {
+		pagination := &components.NullablePaginationEntity{Next: &infiniteNext}
+		return []string{"item"}, pagination, nil
+	}
+	req := fakeRequest{}
+
+	got, err := fetchAllPages(context.Background(), fetch, func(r *fakeRequest, p int) { r.Page = intPtr(p) }, req)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "exceeded maximum page limit")
+}

--- a/provider/schedule_data.go
+++ b/provider/schedule_data.go
@@ -41,12 +41,24 @@ func dataFireHydrantSchedule(ctx context.Context, d *schema.ResourceData, m inte
 		"id": name,
 	})
 
-	scheduleResponse, err := client.Sdk.Teams.ListSchedules(ctx, &name, nil, nil)
+	type schedulePageRequest struct {
+		Page *int
+	}
+
+	schedules, err := fetchAllPages(ctx,
+		func(ctx context.Context, req schedulePageRequest) ([]components.ScheduleEntity, *components.NullablePaginationEntity, error) {
+			resp, err := client.Sdk.Teams.ListSchedules(ctx, &name, req.Page, nil)
+			if err != nil {
+				return nil, nil, err
+			}
+			return resp.GetData(), resp.GetPagination(), nil
+		},
+		func(req *schedulePageRequest, page int) { req.Page = &page },
+		schedulePageRequest{},
+	)
 	if err != nil {
 		return diag.Errorf("Error fetching schedule '%s': %v", name, err)
 	}
-
-	schedules := scheduleResponse.GetData()
 	if len(schedules) == 0 {
 		return diag.Errorf("Did not find schedule matching '%s'", name)
 	}

--- a/provider/services_data.go
+++ b/provider/services_data.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 
 	"github.com/firehydrant/firehydrant-go-sdk/models/operations"
@@ -70,14 +71,24 @@ func dataFireHydrantServices(ctx context.Context, d *schema.ResourceData, m inte
 		request.Labels = &labelsStr
 	}
 
-	servicesResponse, err := client.Sdk.CatalogEntries.ListServices(ctx, request)
+	allServices, err := fetchAllPages(ctx,
+		func(ctx context.Context, req operations.ListServicesRequest) ([]components.ServiceEntity, *components.NullablePaginationEntity, error) {
+			resp, err := client.Sdk.CatalogEntries.ListServices(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+			return resp.Data, resp.Pagination, nil
+		},
+		func(req *operations.ListServicesRequest, page int) { req.Page = &page },
+		request,
+	)
 	if err != nil {
 		return diag.Errorf("Error reading services: %v", err)
 	}
 
 	// Set the data source attributes to the values we got from the API
 	services := make([]interface{}, 0)
-	for _, service := range servicesResponse.Data {
+	for _, service := range allServices {
 		// Unmarshal labels from SDK struct to map[string]string
 		labelsMap, err := unmarshalLabels(service.Labels)
 		if err != nil {

--- a/provider/teams_data.go
+++ b/provider/teams_data.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
 	"github.com/firehydrant/firehydrant-go-sdk/models/operations"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -47,14 +48,24 @@ func dataFireHydrantTeams(ctx context.Context, d *schema.ResourceData, m interfa
 		request.Query = &query
 	}
 
-	teamsResponse, err := client.Sdk.Teams.ListTeams(ctx, request)
+	allTeams, err := fetchAllPages(ctx,
+		func(ctx context.Context, req operations.ListTeamsRequest) ([]components.TeamEntity, *components.NullablePaginationEntity, error) {
+			resp, err := client.Sdk.Teams.ListTeams(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+			return resp.GetData(), resp.GetPagination(), nil
+		},
+		func(req *operations.ListTeamsRequest, page int) { req.Page = &page },
+		request,
+	)
 	if err != nil {
 		return diag.Errorf("Error reading teams: %v", err)
 	}
 
 	// Set the data source attributes to the values we got from the API
 	teams := make([]interface{}, 0)
-	for _, team := range teamsResponse.GetData() {
+	for _, team := range allTeams {
 		attributes := map[string]interface{}{
 			"id":          *team.GetID(),
 			"name":        *team.GetName(),

--- a/provider/test_resources.go
+++ b/provider/test_resources.go
@@ -288,12 +288,22 @@ func (r *SharedTestResources) LoadFromAPI() error {
 // loadTeamsFromAPI discovers teams with tf-test-shared- prefix
 func (r *SharedTestResources) loadTeamsFromAPI(ctx context.Context, client *firehydrant.APIClient) error {
 	request := operations.ListTeamsRequest{}
-	teamsResponse, err := client.Sdk.Teams.ListTeams(ctx, request)
+	allTeams, err := fetchAllPages(ctx,
+		func(ctx context.Context, req operations.ListTeamsRequest) ([]components.TeamEntity, *components.NullablePaginationEntity, error) {
+			resp, err := client.Sdk.Teams.ListTeams(ctx, req)
+			if err != nil {
+				return nil, nil, err
+			}
+			return resp.GetData(), resp.GetPagination(), nil
+		},
+		func(req *operations.ListTeamsRequest, page int) { req.Page = &page },
+		request,
+	)
 	if err != nil {
 		return err
 	}
 
-	for _, team := range teamsResponse.GetData() {
+	for _, team := range allTeams {
 		if team.GetName() != nil && len(*team.GetName()) > 12 && (*team.GetName())[:12] == "tf-test-shared" {
 			r.Teams[*team.GetName()] = *team.GetID()
 		}


### PR DESCRIPTION
## Description

There's no pagination on some `data` resources: data.firehydrant_services`, `data.firehydrant_on_call_schedules` `data.firehydrant_schedule` and `data.firehydrant_teams`. So, if you have more than 20 items in one of those data sources, you will only get the first 20 ones.

This PR implements pagination on those `data` resources.

## Testing plan

1. Create 21 teams in a FH instance.
1. Create a minimal terraform code to get all the teams.
```terraform
data "firehydrant_user" "users" {
  for_each = toset(var.users)
  email    = each.key
}

data "firehydrant_teams" "all_teams" {}

locals {
  team_ids = {
    for team in data.firehydrant_teams.all_teams.teams : team.slug => team.id
  }
}

output "teams" {
  value = local.team_ids
}
```
1. Actually you get 20 teams. You should get the whole 21 teams you defined above.

## Related links

- [Teams API documentation](hhttps://docs.firehydrant.com/reference/list_teams)
- [Schedules API documentation](https://docs.firehydrant.com/reference/list_schedules)
- [Schedules API documentation](https://docs.firehydrant.com/reference/list_services)
- [Schedules API documentation](https://docs.firehydrant.com/reference/list_team_on_call_schedules)

## PR readiness 

- [X] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [X] An entry has been added to the changelog, if necessary.