### PR TITLE
Adding pagination for the Teams data source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ fmtcheck:
 .PHONY: test
 test: fmtcheck
 	go test -v $(TEST) || exit 1
-	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=60s -parallel=4
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 .PHONY: testacc
 testacc: fmtcheck

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ fmtcheck:
 .PHONY: test
 test: fmtcheck
 	go test -v $(TEST) || exit 1
-	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=60s -parallel=4
 
 .PHONY: testacc
 testacc: fmtcheck

--- a/provider/internal/pagination/pagination.go
+++ b/provider/internal/pagination/pagination.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/firehydrant/firehydrant-go-sdk/models/components"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/firehydrant/terraform-provider-firehydrant/provider/internal/ptr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
@@ -33,7 +34,7 @@ type PaginateResponse[TEntity any] interface {
 // Paginate is the function that will paginate the API response for SDK-based calls to the API
 func Paginate[TRequest any, TEntity any](ctx context.Context, options PaginateRequestOptions[TRequest, TEntity]) ([]TEntity, diag.Diagnostics) {
 	results := []TEntity{}
-	page := toIntPointer(1)
+	page := ptr.Of(1)
 
 	for page != nil {
 		if options.GetPageDelay > 0 {
@@ -61,8 +62,4 @@ func Paginate[TRequest any, TEntity any](ctx context.Context, options PaginateRe
 	}
 	return results, nil
 
-}
-
-func toIntPointer(v int) *int {
-	return &v
 }

--- a/provider/internal/pagination/pagination.go
+++ b/provider/internal/pagination/pagination.go
@@ -1,0 +1,62 @@
+package pagination
+
+import (
+	"context"
+
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+// PaginateRequestOptions is the options for the Paginate function
+type PaginateRequestOptions[TRequest any, TEntity any] struct {
+	// Client is the API client to use for the pagination
+	Client *firehydrant.APIClient
+	// Request is the request to use for the pagination
+	Request *TRequest
+	// SetRequestPageFunc is the function to use to set the page on the request
+	SetRequestPageFunc func(request *TRequest, page *int)
+	// GetPageFunc is the function to use to get the page from the API
+	GetPageFunc func(ctx context.Context, client *firehydrant.APIClient, request *TRequest) (PaginateResponse[TEntity], diag.Diagnostics)
+}
+
+// PaginateResponse is an interface that the response from the API must implement.
+// The SDK will return this on every response that is paginated
+type PaginateResponse[TEntity any] interface {
+	GetData() []TEntity
+	GetPagination() *components.NullablePaginationEntity
+}
+
+// Paginate is the function that will paginate the API response for SDK-based calls to the API
+func Paginate[TRequest any, TEntity any](ctx context.Context, options PaginateRequestOptions[TRequest, TEntity]) ([]TEntity, diag.Diagnostics) {
+	results := []TEntity{}
+	page := toIntPointer(1)
+
+	for page != nil {
+		if options.SetRequestPageFunc != nil {
+			options.SetRequestPageFunc(options.Request, page)
+		}
+		response, err := options.GetPageFunc(ctx, options.Client, options.Request)
+		if err != nil {
+			return nil, err
+		}
+
+		if response == nil {
+			return nil, diag.Errorf("unexpected respsonse")
+		}
+
+		results = append(results, response.GetData()...)
+
+		if response.GetPagination() != nil {
+			page = response.GetPagination().GetNext()
+		} else {
+			page = nil
+		}
+	}
+	return results, nil
+
+}
+
+func toIntPointer(v int) *int {
+	return &v
+}

--- a/provider/internal/pagination/pagination.go
+++ b/provider/internal/pagination/pagination.go
@@ -2,6 +2,7 @@ package pagination
 
 import (
 	"context"
+	"time"
 
 	"github.com/firehydrant/firehydrant-go-sdk/models/components"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
@@ -18,6 +19,8 @@ type PaginateRequestOptions[TRequest any, TEntity any] struct {
 	SetRequestPageFunc func(request *TRequest, page *int)
 	// GetPageFunc is the function to use to get the page from the API
 	GetPageFunc func(ctx context.Context, client *firehydrant.APIClient, request *TRequest) (PaginateResponse[TEntity], diag.Diagnostics)
+	// GetPageDelay is an optional duration to sleep between pages to avoid rate limits
+	GetPageDelay time.Duration
 }
 
 // PaginateResponse is an interface that the response from the API must implement.
@@ -33,6 +36,9 @@ func Paginate[TRequest any, TEntity any](ctx context.Context, options PaginateRe
 	page := toIntPointer(1)
 
 	for page != nil {
+		if options.GetPageDelay > 0 {
+			time.Sleep(options.GetPageDelay)
+		}
 		if options.SetRequestPageFunc != nil {
 			options.SetRequestPageFunc(options.Request, page)
 		}

--- a/provider/internal/pagination/pagination_test.go
+++ b/provider/internal/pagination/pagination_test.go
@@ -1,0 +1,144 @@
+package pagination
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+type testRequest struct {
+	Page *int
+}
+
+type testResponse struct {
+	Items      []int
+	Pagination *components.NullablePaginationEntity
+}
+
+func (r *testResponse) GetData() []int {
+	return r.Items
+}
+
+func (r *testResponse) GetPagination() *components.NullablePaginationEntity {
+	return r.Pagination
+}
+
+func TestPaginate_Success(t *testing.T) {
+	// Assemble
+	page1Items := []int{1, 2, 3, 4, 5}
+	page2Items := []int{6, 7, 8, 9, 10}
+	expectedItems := append(page1Items, page2Items...)
+
+	setPageFunc := func(request *testRequest, page *int) {
+		request.Page = page
+	}
+	requestFunc := func(ctx context.Context, client *firehydrant.APIClient, request *testRequest) (PaginateResponse[int], diag.Diagnostics) {
+		if request.Page == nil || *request.Page == 1 {
+			return &testResponse{Items: page1Items, Pagination: &components.NullablePaginationEntity{Next: toIntPointer(2)}}, nil
+		} else if *request.Page == 2 {
+			return &testResponse{Items: page2Items}, nil
+		}
+		return nil, diag.Errorf("unexpected page: %d", *request.Page)
+	}
+
+	// Act
+	result, err := Paginate(context.Background(), PaginateRequestOptions[testRequest, int]{
+		Client:             nil,
+		Request:            &testRequest{},
+		SetRequestPageFunc: setPageFunc,
+		GetPageFunc:        requestFunc,
+	})
+
+	// Assert
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+	if len(result) != len(page1Items)+len(page2Items) {
+		t.Errorf("expected %d items, got %d", len(page1Items)+len(page2Items), len(result))
+	}
+	for _, item := range result {
+		if !slices.Contains(expectedItems, item) {
+			t.Errorf("unexpected item: %d", item)
+		}
+	}
+}
+
+func TestPaginate_NilResponse(t *testing.T) {
+	// Assemble
+	requestFunc := func(ctx context.Context, client *firehydrant.APIClient, request *testRequest) (PaginateResponse[int], diag.Diagnostics) {
+		return nil, nil
+	}
+
+	// Act
+	result, err := Paginate(context.Background(), PaginateRequestOptions[testRequest, int]{
+		Client:      nil,
+		Request:     &testRequest{},
+		GetPageFunc: requestFunc,
+	})
+
+	// Assert
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected 0 items, got %d", len(result))
+	}
+}
+
+func TestPaginate_Error(t *testing.T) {
+	// Assemble
+	requestFunc := func(ctx context.Context, client *firehydrant.APIClient, request *testRequest) (PaginateResponse[int], diag.Diagnostics) {
+		return nil, diag.Errorf("test error")
+	}
+
+	// Act
+	result, err := Paginate(context.Background(), PaginateRequestOptions[testRequest, int]{
+		Client:      nil,
+		Request:     &testRequest{},
+		GetPageFunc: requestFunc,
+	})
+
+	// Assert
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected 0 items, got %d", len(result))
+	}
+}
+
+func TestPaginateRequest_ErrorOnSecondPage(t *testing.T) {
+	// Assemble
+	setPageFunc := func(request *testRequest, page *int) {
+		request.Page = page
+	}
+	requestFunc := func(ctx context.Context, client *firehydrant.APIClient, request *testRequest) (PaginateResponse[int], diag.Diagnostics) {
+		if request.Page == nil || *request.Page == 1 {
+			return &testResponse{Items: []int{1, 2}, Pagination: &components.NullablePaginationEntity{Next: toIntPointer(2)}}, nil
+		} else if *request.Page == 2 {
+			return nil, diag.Errorf("test error")
+		}
+		return nil, diag.Errorf("unexpected page: %d", *request.Page)
+	}
+
+	// Act
+	result, err := Paginate(context.Background(), PaginateRequestOptions[testRequest, int]{
+		Client:             nil,
+		Request:            &testRequest{},
+		SetRequestPageFunc: setPageFunc,
+		GetPageFunc:        requestFunc,
+	})
+
+	// Assert
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected 0 items, got %d", len(result))
+	}
+}

--- a/provider/internal/pagination/pagination_test.go
+++ b/provider/internal/pagination/pagination_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/firehydrant/firehydrant-go-sdk/models/components"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/firehydrant/terraform-provider-firehydrant/provider/internal/ptr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
@@ -38,7 +39,7 @@ func TestPaginate_Success(t *testing.T) {
 	}
 	requestFunc := func(ctx context.Context, client *firehydrant.APIClient, request *testRequest) (PaginateResponse[int], diag.Diagnostics) {
 		if request.Page == nil || *request.Page == 1 {
-			return &testResponse{Items: page1Items, Pagination: &components.NullablePaginationEntity{Next: toIntPointer(2)}}, nil
+			return &testResponse{Items: page1Items, Pagination: &components.NullablePaginationEntity{Next: ptr.Of(2)}}, nil
 		} else if *request.Page == 2 {
 			return &testResponse{Items: page2Items}, nil
 		}
@@ -119,7 +120,7 @@ func TestPaginateRequest_ErrorOnSecondPage(t *testing.T) {
 	}
 	requestFunc := func(ctx context.Context, client *firehydrant.APIClient, request *testRequest) (PaginateResponse[int], diag.Diagnostics) {
 		if request.Page == nil || *request.Page == 1 {
-			return &testResponse{Items: []int{1, 2}, Pagination: &components.NullablePaginationEntity{Next: toIntPointer(2)}}, nil
+			return &testResponse{Items: []int{1, 2}, Pagination: &components.NullablePaginationEntity{Next: ptr.Of(2)}}, nil
 		} else if *request.Page == 2 {
 			return nil, diag.Errorf("test error")
 		}

--- a/provider/internal/ptr/pointers.go
+++ b/provider/internal/ptr/pointers.go
@@ -1,0 +1,5 @@
+package ptr
+
+func Of[T any](v T) *T {
+	return &v
+}

--- a/provider/internal/ptr/pointers_test.go
+++ b/provider/internal/ptr/pointers_test.go
@@ -1,0 +1,22 @@
+package ptr_test
+
+import (
+	"testing"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/provider/internal/ptr"
+)
+
+func TestOf_Int(t *testing.T) {
+	// Assemble
+	input := 42
+
+	// Act
+	result := ptr.Of(input)
+
+	// Assert
+	if result == nil {
+		t.Errorf("expected pointer to int, got nil")
+	} else if *result != input {
+		t.Errorf("expected %d, got %d", input, *result)
+	}
+}

--- a/provider/teams_data.go
+++ b/provider/teams_data.go
@@ -5,8 +5,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
 	"github.com/firehydrant/firehydrant-go-sdk/models/operations"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/firehydrant/terraform-provider-firehydrant/provider/internal/pagination"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -47,14 +49,28 @@ func dataFireHydrantTeams(ctx context.Context, d *schema.ResourceData, m interfa
 		request.Query = &query
 	}
 
-	teamsResponse, err := client.Sdk.Teams.ListTeams(ctx, request)
+	opts := pagination.PaginateRequestOptions[operations.ListTeamsRequest, components.TeamEntity]{
+		Client:  client,
+		Request: &request,
+		SetRequestPageFunc: func(request *operations.ListTeamsRequest, page *int) {
+			request.Page = page
+		},
+		GetPageFunc: func(ctx context.Context, client *firehydrant.APIClient, request *operations.ListTeamsRequest) (pagination.PaginateResponse[components.TeamEntity], diag.Diagnostics) {
+			response, err := client.Sdk.Teams.ListTeams(ctx, *request)
+			if err != nil {
+				return nil, diag.Errorf("Error reading teams: %v", err)
+			}
+			return response, nil
+		},
+	}
+	teamsResponse, err := pagination.Paginate(ctx, opts)
 	if err != nil {
 		return diag.Errorf("Error reading teams: %v", err)
 	}
 
 	// Set the data source attributes to the values we got from the API
 	teams := make([]interface{}, 0)
-	for _, team := range teamsResponse.GetData() {
+	for _, team := range teamsResponse {
 		attributes := map[string]interface{}{
 			"id":          *team.GetID(),
 			"name":        *team.GetName(),

--- a/provider/teams_data.go
+++ b/provider/teams_data.go
@@ -62,6 +62,8 @@ func dataFireHydrantTeams(ctx context.Context, d *schema.ResourceData, m interfa
 			}
 			return response, nil
 		},
+		// This API has strict rate limiting. This delay will keep us under the limit.
+		GetPageDelay: time.Millisecond * 550,
 	}
 	teamsResponse, err := pagination.Paginate(ctx, opts)
 	if err != nil {

--- a/provider/teams_data.go
+++ b/provider/teams_data.go
@@ -9,6 +9,7 @@ import (
 	"github.com/firehydrant/firehydrant-go-sdk/models/operations"
 	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
 	"github.com/firehydrant/terraform-provider-firehydrant/provider/internal/pagination"
+	"github.com/firehydrant/terraform-provider-firehydrant/provider/internal/ptr"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -44,7 +45,9 @@ func dataFireHydrantTeams(ctx context.Context, d *schema.ResourceData, m interfa
 		"query": query,
 	})
 
-	request := operations.ListTeamsRequest{}
+	request := operations.ListTeamsRequest{
+		PerPage: ptr.Of(100),
+	}
 	if query != "" {
 		request.Query = &query
 	}

--- a/provider/teams_data_test.go
+++ b/provider/teams_data_test.go
@@ -2,7 +2,11 @@ package provider
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -28,6 +32,109 @@ func TestAccTeamsDataSource_QueryMatch(t *testing.T) {
 	})
 }
 
+// This is a unit test unlike other tests. This tests purpose is to test the
+// pagination logic. Other tests are in place to confirm the contract of the API
+// still matches the expectations of the provider.
+func TestTeamsDataSource_Pagination(t *testing.T) {
+	if os.Getenv("FIREHYDRANT_API_KEY") == "" {
+		t.Setenv("FIREHYDRANT_API_KEY", "unit-test-pagination")
+	}
+
+	var responsePage1, responsePage2 bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/ping" || strings.HasPrefix(r.URL.Path, "/v1/ping"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			switch page := r.URL.Query().Get("page"); page {
+			case "":
+				fallthrough
+			case "1":
+				responsePage1 = true
+				_, _ = w.Write([]byte(`{
+					"data": [{
+						"id": "11111111-1111-1111-1111-111111111111",
+						"name": "Silver Snakes",
+						"description": "The Silver Snakes",
+						"slug": "team-silver-snakes",
+						"services": [],
+						"owned_services": []
+					}],
+					"pagination": {
+						"count": 2,
+						"page": 1,
+						"items": 1,
+						"pages": 2,
+						"last": 2,
+						"prev": null,
+						"next": 2
+					}
+				}`))
+			case "2":
+				responsePage2 = true
+				_, _ = w.Write([]byte(`{
+					"data": [{
+						"id": "22222222-2222-2222-2222-222222222222",
+						"name": "Blue Barracudas",
+						"description": "The Blue Barracudas",
+						"slug": "team-blue-barracudas",
+						"services": [],
+						"owned_services": []
+					}],
+					"pagination": {
+						"count": 2,
+						"page": 2,
+						"items": 1,
+						"pages": 2,
+						"last": 2,
+						"prev": 1,
+						"next": null
+					}
+				}`))
+			default:
+				t.Errorf("unexpected list teams page query: %q", page)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+			return
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("FIREHYDRANT_BASE_URL", server.URL)
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamsDataSourceConfig_pagination(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.firehydrant_teams.paginated_teams", "teams.#", "2"),
+					resource.TestCheckResourceAttr("data.firehydrant_teams.paginated_teams", "teams.0.id", "11111111-1111-1111-1111-111111111111"),
+					resource.TestCheckResourceAttr("data.firehydrant_teams.paginated_teams", "teams.0.name", "Silver Snakes"),
+					resource.TestCheckResourceAttr("data.firehydrant_teams.paginated_teams", "teams.1.id", "22222222-2222-2222-2222-222222222222"),
+					resource.TestCheckResourceAttr("data.firehydrant_teams.paginated_teams", "teams.1.name", "Blue Barracudas"),
+					func(*terraform.State) error {
+						if !responsePage1 || !responsePage2 {
+							return fmt.Errorf("expected list-teams to request both page 1 and page 2 (pagination), saw page1=%v page2=%v", responsePage1, responsePage2)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func TestAccTeamsDataSource_basic(t *testing.T) {
 	t.Parallel()
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -46,49 +153,6 @@ func TestAccTeamsDataSource_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckTeamsContainsSharedTeams(name string, expectedTeamIDs []string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		teamsResource, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Can't find teams resource in state: %s", name)
-		}
-
-		if teamsResource.Primary.ID == "" {
-			return fmt.Errorf("Teams resource ID not set")
-		}
-
-		attributes := teamsResource.Primary.Attributes
-		teams, teamsOk := attributes["teams.#"]
-		if !teamsOk {
-			return fmt.Errorf("Teams list is missing")
-		}
-
-		teamsCount, err := strconv.Atoi(teams)
-		if err != nil {
-			return err
-		}
-
-		if teamsCount < len(expectedTeamIDs) {
-			return fmt.Errorf("Incorrect number of teams - expected at least %d, got %d", len(expectedTeamIDs), teamsCount)
-		}
-
-		// Check that we can find our expected team IDs in the results
-		foundTeams := make(map[string]bool)
-		for i := 0; i < teamsCount; i++ {
-			teamID := attributes[fmt.Sprintf("teams.%d.id", i)]
-			foundTeams[teamID] = true
-		}
-
-		for _, expectedID := range expectedTeamIDs {
-			if !foundTeams[expectedID] {
-				return fmt.Errorf("Expected team ID %s not found in results", expectedID)
-			}
-		}
-
-		return nil
-	}
 }
 
 func testAccCheckTeamsSet(name string) resource.TestCheckFunc {
@@ -141,4 +205,9 @@ data "firehydrant_teams" "all_teams" {
 	# dependency Terraform may read this data source before the team exists.
 	depends_on = [firehydrant_team.test_team]
 }`, rName)
+}
+
+func testAccTeamsDataSourceConfig_pagination() string {
+	return `
+data "firehydrant_teams" "paginated_teams" {}`
 }


### PR DESCRIPTION
## Description

Adding pagination for the Teams data source. 

This change includes a generic pagination method that will handle SDK-based API calls so we can add this same pagination approach to other data sources.

_Describe why you're making this change._

There can be more Teams in the system than the API default page size (20). We need to be able to bring back all of the teams that are available.