### PR TITLE
Expose rotation_name/rotation_description on firehydrant_on_call_schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 
-* `firehydrant_on_call_schedule` now accepts `rotation_name` and `rotation_description` attributes that override the name/description of the initial rotation FireHydrant creates alongside the schedule. Without these, the initial rotation inherits the schedule's name, which makes layer-style rotations indistinguishable from the schedule itself in the UI. Both attributes are `ForceNew`.
+* `firehydrant_on_call_schedule` now accepts `rotation_name` and `rotation_description` attributes that override the name/description of the schedule's primary rotation. Without these, the rotation inherits the schedule's name, which makes layer-style rotations indistinguishable from the schedule itself in the UI. Both attributes are read back from the API on refresh and update the rotation in place via the schedule's PATCH endpoint when changed.
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.15.1
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+ENHANCEMENTS:
+
+* `firehydrant_on_call_schedule` now accepts `rotation_name` and `rotation_description` attributes that override the name/description of the initial rotation FireHydrant creates alongside the schedule. Without these, the initial rotation inherits the schedule's name, which makes layer-style rotations indistinguishable from the schedule itself in the UI. Both attributes are `ForceNew`.
+
 ## 0.15.0
 
 BREAKING CHANGES:

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -99,6 +99,8 @@ The following arguments are supported:
 * `restrictions` - (Optional) A block to define a restriction for the on-call schedule.
 * `effective_at` - (Optional) The date and time that the on-call schedule becomes effective. Must be in `YYYY-MM-DDTHH:MM:SSZ` format. Defaults to the current date and time. If set to the past, the schedule will be effective immediately. This attribute is not stored in Terraform state.
 * `start_time` - (Optional) An ISO8601 time string specifying when the initial rotation should start. This value is only used if the rotation's strategy type is "custom".
+* `rotation_name` - (Optional, ForceNew) Name for the initial rotation FireHydrant creates alongside the schedule. When omitted, the rotation inherits the schedule's name. Useful when modeling a source system whose schedules contain named layers (e.g. PagerDuty), so the layer keeps its name in FireHydrant.
+* `rotation_description` - (Optional, ForceNew) Description for the initial rotation. Falls back to the schedule's description when omitted.
 
 The `strategy` block supports:
 

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -99,8 +99,8 @@ The following arguments are supported:
 * `restrictions` - (Optional) A block to define a restriction for the on-call schedule.
 * `effective_at` - (Optional) The date and time that the on-call schedule becomes effective. Must be in `YYYY-MM-DDTHH:MM:SSZ` format. Defaults to the current date and time. If set to the past, the schedule will be effective immediately. This attribute is not stored in Terraform state.
 * `start_time` - (Optional) An ISO8601 time string specifying when the initial rotation should start. This value is only used if the rotation's strategy type is "custom".
-* `rotation_name` - (Optional, ForceNew) Name for the initial rotation FireHydrant creates alongside the schedule. Only consulted at schedule-create time — changes force replacement of the whole schedule, so use the `firehydrant_rotation` resource to rename the rotation after create. When omitted, the rotation inherits the schedule's name. Useful when modeling a source system whose schedules contain named layers (e.g. PagerDuty), so the layer keeps its name in FireHydrant.
-* `rotation_description` - (Optional, ForceNew) Description for the initial rotation. Only consulted at schedule-create time — use the `firehydrant_rotation` resource to update the rotation's description after create. Falls back to the schedule's description when omitted.
+* `rotation_name` - (Optional) Name of the schedule's primary rotation (the rotation FireHydrant creates alongside the schedule itself). When omitted, the rotation inherits the schedule's name. Changes are sent to the schedule's PATCH endpoint and update the rotation in place. Useful when modeling a source system whose schedules contain named layers (e.g. PagerDuty), so the layer keeps its name in FireHydrant.
+* `rotation_description` - (Optional) Description of the schedule's primary rotation. Falls back to the schedule's description when omitted. Changes are sent to the schedule's PATCH endpoint and update the rotation in place.
 
 The `strategy` block supports:
 

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -99,8 +99,8 @@ The following arguments are supported:
 * `restrictions` - (Optional) A block to define a restriction for the on-call schedule.
 * `effective_at` - (Optional) The date and time that the on-call schedule becomes effective. Must be in `YYYY-MM-DDTHH:MM:SSZ` format. Defaults to the current date and time. If set to the past, the schedule will be effective immediately. This attribute is not stored in Terraform state.
 * `start_time` - (Optional) An ISO8601 time string specifying when the initial rotation should start. This value is only used if the rotation's strategy type is "custom".
-* `rotation_name` - (Optional, ForceNew) Name for the initial rotation FireHydrant creates alongside the schedule. When omitted, the rotation inherits the schedule's name. Useful when modeling a source system whose schedules contain named layers (e.g. PagerDuty), so the layer keeps its name in FireHydrant.
-* `rotation_description` - (Optional, ForceNew) Description for the initial rotation. Falls back to the schedule's description when omitted.
+* `rotation_name` - (Optional, ForceNew) Name for the initial rotation FireHydrant creates alongside the schedule. Only consulted at schedule-create time — changes force replacement of the whole schedule, so use the `firehydrant_rotation` resource to rename the rotation after create. When omitted, the rotation inherits the schedule's name. Useful when modeling a source system whose schedules contain named layers (e.g. PagerDuty), so the layer keeps its name in FireHydrant.
+* `rotation_description` - (Optional, ForceNew) Description for the initial rotation. Only consulted at schedule-create time — use the `firehydrant_rotation` resource to update the rotation's description after create. Falls back to the schedule's description when omitted.
 
 The `strategy` block supports:
 

--- a/provider/on_call_schedule_resource.go
+++ b/provider/on_call_schedule_resource.go
@@ -43,19 +43,18 @@ func resourceOnCallSchedule() *schema.Resource {
 			"rotation_name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
-				Description: "Name for the initial rotation that FireHydrant creates alongside the schedule. " +
-					"Only consulted at schedule-create time; changes force replacement of the whole schedule, " +
-					"so use the firehydrant_rotation resource to rename the rotation after create. " +
-					"When omitted, the rotation inherits the schedule's name.",
+				Computed: true,
+				Description: "Name of the schedule's primary rotation (the rotation FireHydrant " +
+					"creates alongside the schedule itself). Set this to override the default " +
+					"(which inherits the schedule's name). Tracked in state; mutations are sent " +
+					"to the schedule's PATCH endpoint.",
 			},
 			"rotation_description": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Description for the initial rotation that FireHydrant creates alongside the schedule. " +
-					"Only consulted at schedule-create time; use the firehydrant_rotation resource to update " +
-					"the rotation's description after create. Falls back to the schedule's description when not provided.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "Description of the schedule's primary rotation. Set this to override " +
+					"the default (which inherits the schedule's description). Tracked in state.",
 			},
 			"member_ids": {
 				Type:          schema.TypeList,
@@ -322,6 +321,15 @@ func readResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.Resour
 		attributes["slack_user_group_id"] = *slackUserGroupID
 	}
 
+	if rotations := onCallSchedule.GetRotations(); len(rotations) > 0 {
+		if name := rotations[0].GetName(); name != nil {
+			attributes["rotation_name"] = *name
+		}
+		if description := rotations[0].GetDescription(); description != nil {
+			attributes["rotation_description"] = *description
+		}
+	}
+
 	// Set the data source attributes to the values we got from the API
 	for key, val := range attributes {
 		if err := d.Set(key, val); err != nil {
@@ -353,6 +361,15 @@ func updateResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.Reso
 	updateRequest := components.UpdateTeamOnCallSchedule{
 		Name:        &name,
 		Description: &description,
+	}
+
+	if v, ok := d.GetOk("rotation_name"); ok && v.(string) != "" {
+		rotationName := v.(string)
+		updateRequest.RotationName = &rotationName
+	}
+	if v, ok := d.GetOk("rotation_description"); ok && v.(string) != "" {
+		rotationDescription := v.(string)
+		updateRequest.RotationDescription = &rotationDescription
 	}
 
 	// Get slack_user_group_id if set

--- a/provider/on_call_schedule_resource.go
+++ b/provider/on_call_schedule_resource.go
@@ -40,6 +40,20 @@ func resourceOnCallSchedule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"rotation_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "Name for the initial rotation that FireHydrant creates alongside the schedule. " +
+					"If not provided, the schedule's name is used (which means the initial rotation appears " +
+					"under the same label as the schedule itself in the UI).",
+			},
+			"rotation_description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Description for the initial rotation that FireHydrant creates alongside the schedule. Falls back to the schedule's description when not provided.",
+			},
 			"member_ids": {
 				Type:          schema.TypeList,
 				Elem:          &schema.Schema{Type: schema.TypeString},
@@ -205,6 +219,18 @@ func createResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.Reso
 	if v, ok := d.GetOk("slack_user_group_id"); ok && v.(string) != "" {
 		slackUserGroupID := v.(string)
 		onCallSchedule.SlackUserGroupID = &slackUserGroupID
+	}
+
+	// Optional overrides for the schedule's initial rotation. FireHydrant always
+	// creates one rotation alongside the schedule; without these, that rotation
+	// inherits the schedule's name and description.
+	if v, ok := d.GetOk("rotation_name"); ok && v.(string) != "" {
+		rotationName := v.(string)
+		onCallSchedule.RotationName = &rotationName
+	}
+	if v, ok := d.GetOk("rotation_description"); ok && v.(string) != "" {
+		rotationDescription := v.(string)
+		onCallSchedule.RotationDescription = &rotationDescription
 	}
 
 	if onCallSchedule.Strategy.Type != "" {

--- a/provider/on_call_schedule_resource.go
+++ b/provider/on_call_schedule_resource.go
@@ -45,14 +45,17 @@ func resourceOnCallSchedule() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Description: "Name for the initial rotation that FireHydrant creates alongside the schedule. " +
-					"If not provided, the schedule's name is used (which means the initial rotation appears " +
-					"under the same label as the schedule itself in the UI).",
+					"Only consulted at schedule-create time; changes force replacement of the whole schedule, " +
+					"so use the firehydrant_rotation resource to rename the rotation after create. " +
+					"When omitted, the rotation inherits the schedule's name.",
 			},
 			"rotation_description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "Description for the initial rotation that FireHydrant creates alongside the schedule. Falls back to the schedule's description when not provided.",
+				Description: "Description for the initial rotation that FireHydrant creates alongside the schedule. " +
+					"Only consulted at schedule-create time; use the firehydrant_rotation resource to update " +
+					"the rotation's description after create. Falls back to the schedule's description when not provided.",
 			},
 			"member_ids": {
 				Type:          schema.TypeList,

--- a/provider/on_call_schedule_resource_test.go
+++ b/provider/on_call_schedule_resource_test.go
@@ -140,6 +140,86 @@ func testAccOnCallScheduleConfig_restrictions(rName, sharedTeamID string) string
 	`, sharedTeamID, rName, rName)
 }
 
+func TestAccOnCallScheduleResource_rotationName(t *testing.T) {
+	sharedTeamID := getSharedTeamID(t)
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: sharedProviderFactories(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckOnCallScheduleResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnCallScheduleConfig_rotationName(rName, sharedTeamID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_rotation_name", "id"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_rotation_name", "name", fmt.Sprintf("test-rotation-name-schedule-%s", rName)),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_rotation_name", "rotation_name", "Primary"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_rotation_name", "rotation_description", "first rotation under this schedule"),
+					testAccCheckOnCallScheduleInitialRotationName("firehydrant_on_call_schedule.test_rotation_name", "Primary"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOnCallScheduleConfig_rotationName(rName, sharedTeamID string) string {
+	return fmt.Sprintf(`
+	resource "firehydrant_on_call_schedule" "test_rotation_name" {
+		team_id              = "%s"
+		name                 = "test-rotation-name-schedule-%s"
+		description          = "test-description-%s"
+		time_zone            = "America/New_York"
+		rotation_name        = "Primary"
+		rotation_description = "first rotation under this schedule"
+
+		strategy {
+			type         = "weekly"
+			handoff_time = "10:00:00"
+			handoff_day  = "thursday"
+		}
+	}
+	`, sharedTeamID, rName, rName)
+}
+
+func testAccCheckOnCallScheduleInitialRotationName(resourceName, expectedRotationName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		stateResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found in state: %s", resourceName)
+		}
+		scheduleID := stateResource.Primary.ID
+		teamID := stateResource.Primary.Attributes["team_id"]
+		if scheduleID == "" || teamID == "" {
+			return fmt.Errorf("missing schedule_id or team_id for %s", resourceName)
+		}
+
+		client, err := getAccTestClient()
+		if err != nil {
+			return err
+		}
+		schedule, err := client.Sdk.Signals.GetTeamOnCallSchedule(context.Background(), teamID, scheduleID, nil, nil)
+		if err != nil {
+			return fmt.Errorf("fetching schedule %s: %w", scheduleID, err)
+		}
+		// FireHydrant always creates exactly one rotation alongside a schedule on create.
+		rotations := schedule.GetRotations()
+		if len(rotations) != 1 {
+			return fmt.Errorf("expected exactly 1 initial rotation for schedule %s, got %d", scheduleID, len(rotations))
+		}
+		actualName := ""
+		if rotations[0].Name != nil {
+			actualName = *rotations[0].Name
+		}
+		if actualName != expectedRotationName {
+			return fmt.Errorf("initial rotation name mismatch for schedule %s: want %q, got %q", scheduleID, expectedRotationName, actualName)
+		}
+		return nil
+	}
+}
+
 func testAccCheckOnCallScheduleResourceDestroy() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client, err := getAccTestClient()

--- a/provider/on_call_schedule_resource_test.go
+++ b/provider/on_call_schedule_resource_test.go
@@ -144,6 +144,8 @@ func TestAccOnCallScheduleResource_rotationName(t *testing.T) {
 	sharedTeamID := getSharedTeamID(t)
 	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlphaNum)
 
+	var initialRotationID string
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testFireHydrantIsSetup(t) },
 		ProviderFactories: sharedProviderFactories(),
@@ -152,28 +154,37 @@ func TestAccOnCallScheduleResource_rotationName(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOnCallScheduleConfig_rotationName(rName, sharedTeamID),
+				Config: testAccOnCallScheduleConfig_rotationName(rName, sharedTeamID, "Primary", "first rotation under this schedule"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("firehydrant_on_call_schedule.test_rotation_name", "id"),
 					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_rotation_name", "name", fmt.Sprintf("test-rotation-name-schedule-%s", rName)),
 					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_rotation_name", "rotation_name", "Primary"),
 					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_rotation_name", "rotation_description", "first rotation under this schedule"),
-					testAccCheckOnCallScheduleInitialRotationName("firehydrant_on_call_schedule.test_rotation_name", "Primary"),
+					testAccCheckPrimaryRotation("firehydrant_on_call_schedule.test_rotation_name", "Primary", "first rotation under this schedule", &initialRotationID),
+				),
+			},
+			{
+				// Mutate rotation_name/rotation_description in place. Asserts no replacement (same rotation ID) and the new values landed.
+				Config: testAccOnCallScheduleConfig_rotationName(rName, sharedTeamID, "Secondary", "renamed in place"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_rotation_name", "rotation_name", "Secondary"),
+					resource.TestCheckResourceAttr("firehydrant_on_call_schedule.test_rotation_name", "rotation_description", "renamed in place"),
+					testAccCheckPrimaryRotation("firehydrant_on_call_schedule.test_rotation_name", "Secondary", "renamed in place", &initialRotationID),
 				),
 			},
 		},
 	})
 }
 
-func testAccOnCallScheduleConfig_rotationName(rName, sharedTeamID string) string {
+func testAccOnCallScheduleConfig_rotationName(rName, sharedTeamID, rotationName, rotationDescription string) string {
 	return fmt.Sprintf(`
 	resource "firehydrant_on_call_schedule" "test_rotation_name" {
 		team_id              = "%s"
 		name                 = "test-rotation-name-schedule-%s"
 		description          = "test-description-%s"
 		time_zone            = "America/New_York"
-		rotation_name        = "Primary"
-		rotation_description = "first rotation under this schedule"
+		rotation_name        = "%s"
+		rotation_description = "%s"
 
 		strategy {
 			type         = "weekly"
@@ -181,10 +192,13 @@ func testAccOnCallScheduleConfig_rotationName(rName, sharedTeamID string) string
 			handoff_day  = "thursday"
 		}
 	}
-	`, sharedTeamID, rName, rName)
+	`, sharedTeamID, rName, rName, rotationName, rotationDescription)
 }
 
-func testAccCheckOnCallScheduleInitialRotationName(resourceName, expectedRotationName string) resource.TestCheckFunc {
+// testAccCheckPrimaryRotation verifies the schedule has exactly one rotation whose name and description match the expected values.
+// On the first invocation (when *capturedID is empty) it records the rotation ID; on subsequent invocations it asserts the ID
+// hasn't changed, which proves the rotation was updated in place rather than destroyed and recreated.
+func testAccCheckPrimaryRotation(resourceName, expectedName, expectedDescription string, capturedID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		stateResource, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -207,14 +221,35 @@ func testAccCheckOnCallScheduleInitialRotationName(resourceName, expectedRotatio
 		// FireHydrant always creates exactly one rotation alongside a schedule on create.
 		rotations := schedule.GetRotations()
 		if len(rotations) != 1 {
-			return fmt.Errorf("expected exactly 1 initial rotation for schedule %s, got %d", scheduleID, len(rotations))
+			return fmt.Errorf("expected exactly 1 rotation for schedule %s, got %d", scheduleID, len(rotations))
 		}
-		actualName := ""
+
+		gotID := ""
+		if rotations[0].ID != nil {
+			gotID = *rotations[0].ID
+		}
+		gotName := ""
 		if rotations[0].Name != nil {
-			actualName = *rotations[0].Name
+			gotName = *rotations[0].Name
 		}
-		if actualName != expectedRotationName {
-			return fmt.Errorf("initial rotation name mismatch for schedule %s: want %q, got %q", scheduleID, expectedRotationName, actualName)
+		gotDescription := ""
+		if rotations[0].Description != nil {
+			gotDescription = *rotations[0].Description
+		}
+
+		if gotName != expectedName {
+			return fmt.Errorf("rotation name mismatch for schedule %s: want %q, got %q", scheduleID, expectedName, gotName)
+		}
+		if gotDescription != expectedDescription {
+			return fmt.Errorf("rotation description mismatch for schedule %s: want %q, got %q", scheduleID, expectedDescription, gotDescription)
+		}
+
+		if capturedID != nil {
+			if *capturedID == "" {
+				*capturedID = gotID
+			} else if *capturedID != gotID {
+				return fmt.Errorf("rotation ID changed for schedule %s: want %q (in-place update), got %q (replacement)", scheduleID, *capturedID, gotID)
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
## Summary

FireHydrant always creates one rotation alongside a schedule on create, and today the provider has no way to name or describe that rotation independently of the schedule itself — so the rotation always inherits the schedule's name and description. The FH API and SDK already accept `rotation_name` and `rotation_description` on both the schedule create and schedule update endpoints; this PR exposes them in the Terraform schema, threads them through the create path, and routes mutations through the schedule's PATCH endpoint so they can be updated in place.

## Why this matters

For tools that mirror a source system whose schedules contain named layers — PagerDuty layers, OpsGenie rotations, VictorOps escalations — the layer's identity is silently lost today. The `signals-migrator` project hits this: every PD schedule with N layers ends up with N rotations in FH, but one of them is renamed from "Layer 6" (or whatever PD called it) to the schedule's name, and that one looks identical to the schedule itself in the FH UI. Customers see a "ghost" rotation and a missing named layer.

With this change, the migrator (and any other consumer) can pass `rotation_name = "Layer 6"` on the schedule, and FH names the primary rotation accordingly. No empty-placeholder rotations, no naming collisions with the schedule.

## Schema additions

```hcl
resource "firehydrant_on_call_schedule" "example" {
  name                 = "Weekend Coverage"
  rotation_name        = "Primary"        # NEW
  rotation_description = "first rotation" # NEW
  # ...
}
```

Both attributes are `Optional` and `Computed`:

- **Create** forwards them in `CreateTeamOnCallSchedule` (skipped via `GetOk` when unset, preserving FH's existing inheritance fallback to the schedule's name/description).
- **Update** forwards them in `UpdateTeamOnCallSchedule`; changes are applied to the primary rotation in place — no schedule replacement.
- **Read** hydrates both attributes from `schedule.rotations[0]`, so out-of-band changes surface as drift in `terraform plan`.

## Validation

Acceptance tests can't run end-to-end against this repo's CI config (per @AlexisJasso), so the new behavior was validated manually against staging using a locally-built provider binary. Detailed scenario results in the [first validation comment](https://github.com/firehydrant/terraform-provider-firehydrant/pull/236#issuecomment-4444292652) and the [follow-up after the in-place rewrite](https://github.com/firehydrant/terraform-provider-firehydrant/pull/236#issuecomment-4445009010). Covered: create with both fields, in-place update of `rotation_name`, schedule-level updates that should *not* trigger replacement, out-of-band drift detection, destroy, and a regression check confirming the FH inheritance fallback still works when the fields are omitted.

The acceptance test (`TestAccOnCallScheduleResource_rotationName`) now also has a second step that mutates `rotation_name` and asserts the rotation's ID is unchanged, which proves the update is in place rather than a destroy+create.

## SDK compatibility

Provider's `go.mod` pins `firehydrant/firehydrant-go-sdk v1.7.1`. Both `CreateTeamOnCallSchedule` and `UpdateTeamOnCallSchedule` expose `RotationName *string` and `RotationDescription *string` (with correct JSON tags and getters) in `v1.7.1` and remain in `v1.8.5` (current latest), so an SDK bump won't regress this change.