### PR TITLE
CI: install terraform for acceptance tests, pin -parallel, bump actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,20 +25,35 @@ jobs:
           echo "Job originally triggered by ${{ github.actor }}"
           exit 1
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24
+
+      # Install terraform once and point the acceptance-test harness at it.
+      # Without TF_ACC_TERRAFORM_PATH, terraform-plugin-sdk downloads its own
+      # binary into /tmp at test time, and parallel tests race the download
+      # ("text file busy"). terraform_wrapper must stay off so the env var
+      # points at the real binary, not the wrapper script.
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Point acceptance tests at installed terraform
+        run: echo "TF_ACC_TERRAFORM_PATH=$(which terraform)" >> "$GITHUB_ENV"
 
       - name: Build
         run: make build
 
       - name: Test
-        run: go test -v -timeout=25m ./...
+        # -parallel 4 pins test parallelism (default is runner core count);
+        # keep in sync with `make testacc`.
+        run: go test -v -timeout=25m -parallel 4 ./...
         timeout-minutes: 25
         env:
           TF_ACC: 'true'


### PR DESCRIPTION
## Why

Supporting change for #237 (flaky acceptance tests). Two CI-level flake sources can't be fixed from that PR's branch because the Tests workflow runs on `pull_request_target`, which always takes the workflow definition from **main** — so the workflow changes land here separately.

## What

- **Install terraform via `hashicorp/setup-terraform` and export `TF_ACC_TERRAFORM_PATH`.** Without it, terraform-plugin-sdk downloads its own binary into `/tmp/plugintest-terraform*` at test time, and parallel tests race the download — the `fork/exec ... text file busy` failures seen in #237's runs (e.g. `TestAccServiceDataSource_allAttributes`). `terraform_wrapper: false` is required so the env var points at the real binary rather than the wrapper script.
- **Pin `go test -parallel 4`** to match `make testacc` instead of silently inheriting the runner's core count, so a future runner upgrade doesn't double test concurrency (and API contention) unannounced.
- **Bump `actions/checkout` v3→v4 and `actions/setup-go` v2→v5** — both currently emit Node 20 deprecation warnings, and runners force Node 24 as of June 2, 2026.

## Testing

Workflow-only change; validated by the next `pull_request_target` run after this merges (the run for #237 should stop producing `text file busy` failures). `make build` and the offline tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)