### PR TITLE
Stop dropping start_time for non-custom on-call schedule strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+BUG FIXES:
+
+* `firehydrant_on_call_schedule` no longer silently drops `start_time` when the strategy is `weekly` or `daily`. The provider discarded the value for every non-`custom` strategy before sending the create request, so the schedule's initial rotation started its shifts at the strategy boundary (e.g. the beginning of the week) instead of the configured start time. Because the API does not echo `start_time` back, the drop never surfaced as a state diff.
+
 ## 0.15.1
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.15.2
 
 BUG FIXES:
 

--- a/provider/on_call_schedule_resource.go
+++ b/provider/on_call_schedule_resource.go
@@ -212,9 +212,15 @@ func createResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.Reso
 			HandoffDay:    (*components.CreateTeamOnCallScheduleHandoffDay)(&handoffDay),
 			ShiftDuration: &shiftDuration,
 		},
-		StartTime:    &startTime,
 		MemberIds:    memberIDs,
 		Restrictions: oncallRestrictionsFromDataSDK(d),
+	}
+
+	// start_time seeds the initial rotation's first shift for every strategy
+	// type, not just custom. The API rejects an empty string, so only send it
+	// when configured.
+	if startTime != "" {
+		onCallSchedule.StartTime = &startTime
 	}
 
 	// Get slack_user_group_id if set and non-empty
@@ -258,7 +264,6 @@ func createResourceFireHydrantOnCallSchedule(ctx context.Context, d *schema.Reso
 
 			// Discard unused values to avoid ambiguity.
 			onCallSchedule.Strategy.ShiftDuration = nil
-			onCallSchedule.StartTime = nil
 		}
 	}
 

--- a/provider/on_call_schedule_resource_test.go
+++ b/provider/on_call_schedule_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,78 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+// Regression test: the API accepts start_time for every strategy type (it
+// seeds the initial rotation's first shift), but the provider used to discard
+// it for non-custom strategies, silently starting weekly rotations at the
+// beginning of the week. The API never echoes start_time back, so the drop
+// was invisible in state diffs.
+func TestOfflineOnCallScheduleCreate_sendsStartTimeForWeeklyStrategy(t *testing.T) {
+	var createBody map[string]interface{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if req.Method == "POST" {
+			if err := json.NewDecoder(req.Body).Decode(&createBody); err != nil {
+				t.Errorf("failed to decode create request body: %v", err)
+			}
+			w.WriteHeader(http.StatusCreated)
+		}
+		w.Write([]byte(`{
+  "id": "schedule-id",
+  "name": "test-schedule",
+  "description": "test-description",
+  "time_zone": "America/New_York",
+  "members": [],
+  "strategy": {"type": "weekly", "handoff_time": "10:00:00", "handoff_day": "thursday"},
+  "restrictions": [],
+  "rotations": []
+}`))
+	}))
+	defer ts.Close()
+
+	client := &firehydrant.APIClient{}
+	client.Sdk = fhsdk.New(
+		fhsdk.WithServerURL(ts.URL),
+		fhsdk.WithSecurity(components.Security{
+			APIKey: "test-token-very-authorized",
+		}),
+	)
+
+	startTime := "2026-06-15T09:00:00Z"
+	r := schema.TestResourceDataRaw(t, resourceOnCallSchedule().Schema, map[string]interface{}{
+		"team_id":     "team-1",
+		"name":        "test-schedule",
+		"description": "test-description",
+		"time_zone":   "America/New_York",
+		"start_time":  startTime,
+		"strategy": []interface{}{
+			map[string]interface{}{
+				"type":         "weekly",
+				"handoff_time": "10:00:00",
+				"handoff_day":  "thursday",
+			},
+		},
+	})
+
+	d := createResourceFireHydrantOnCallSchedule(context.Background(), r, client)
+	if d.HasError() {
+		t.Fatalf("error creating on-call schedule: %v", d)
+	}
+
+	if createBody == nil {
+		t.Fatal("create request body was never captured")
+	}
+
+	got, ok := createBody["start_time"]
+	if !ok {
+		t.Fatalf("start_time missing from create request body; body keys: %v", createBody)
+	}
+	if got != startTime {
+		t.Fatalf("expected start_time %q in create request body, got %q", startTime, got)
+	}
+}
 
 func TestAccOnCallScheduleResource_basic(t *testing.T) {
 	sharedTeamID := getSharedTeamID(t)

--- a/provider/rotation_resource_test.go
+++ b/provider/rotation_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -321,6 +322,78 @@ func TestOfflineRotationCreate(t *testing.T) {
 	}
 	if userID != "member-1" {
 		t.Fatalf("expected user_id to be member-1, got %s", userID)
+	}
+}
+
+func TestOfflineRotationCreate_sendsStartTime(t *testing.T) {
+	var createBody map[string]interface{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if req.Method == "POST" {
+			if err := json.NewDecoder(req.Body).Decode(&createBody); err != nil {
+				t.Errorf("failed to decode create request body: %v", err)
+			}
+			w.WriteHeader(http.StatusCreated)
+		}
+		w.Write([]byte(`{
+  "id": "rotation-id",
+  "name": "test-rotation",
+  "description": "test-description",
+  "members": [],
+  "team": {"id": "team-1", "name": "Philadelphia"},
+  "time_zone": "America/New_York",
+  "enable_slack_channel_notifications": false,
+  "prevent_shift_deletion": false,
+  "strategy": {"type": "weekly", "handoff_time": "10:00:00", "handoff_day": "thursday"},
+  "restrictions": [],
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z"
+}`))
+	}))
+	defer ts.Close()
+
+	client := &firehydrant.APIClient{}
+	client.Sdk = fhsdk.New(
+		fhsdk.WithServerURL(ts.URL),
+		fhsdk.WithSecurity(components.Security{
+			APIKey: "test-token-very-authorized",
+		}),
+	)
+
+	startTime := "2026-06-15T09:00:00Z"
+	r := schema.TestResourceDataRaw(t, resourceRotation().Schema, map[string]interface{}{
+		"team_id":     "team-1",
+		"schedule_id": "schedule-1",
+		"name":        "test-rotation",
+		"description": "test-description",
+		"time_zone":   "America/New_York",
+		"start_time":  startTime,
+		"strategy": []interface{}{
+			map[string]interface{}{
+				"type":         "weekly",
+				"handoff_time": "10:00:00",
+				"handoff_day":  "thursday",
+			},
+		},
+	})
+
+	d := createResourceFireHydrantRotation(context.Background(), r, client)
+	if d.HasError() {
+		t.Fatalf("error creating rotation: %v", d)
+	}
+
+	if createBody == nil {
+		t.Fatal("create request body was never captured")
+	}
+
+	got, ok := createBody["start_time"]
+	if !ok {
+		t.Fatalf("start_time missing from create request body; body keys: %v", createBody)
+	}
+	if got != startTime {
+		t.Fatalf("expected start_time %q in create request body, got %q", startTime, got)
 	}
 }
 


### PR DESCRIPTION
## BLUF

`firehydrant_on_call_schedule` no longer silently drops `start_time` when the strategy is `weekly` or `daily`. Previously the provider discarded the value for every non-`custom` strategy before sending the create request, so the schedule's initial rotation started its shifts at the strategy boundary (e.g. the beginning of the week) instead of the configured start time.

## Description

This is the underlying customer bug behind the recent rotation start-time reports: a weekly schedule defined in Terraform with an explicit `start_time` came up with shifts starting at the beginning of the week, as if `start_time` had never been set — because it never reached the API.

`createResourceFireHydrantOnCallSchedule` nil'd out `StartTime` for every strategy except `custom` ("discard unused values to avoid ambiguity", introduced in the SDK migration #206, so v0.15.x releases are affected). Three properties made the bug invisible:

- The API accepts top-level `start_time` for **all** strategy types — it seeds the first shift of the schedule's initial rotation (verified end-to-end in laddertruck: `OnCallScheduleCreator` → `OnCallRotationCreator` → `PopulateNewRotation` → `CreateShifts.build_shifts(start_time:)`), so the request succeeded without it.
- The API never echoes `start_time` back, so Terraform state kept the configured value and no drift ever appeared.
- The standalone `firehydrant_rotation` resource sends `start_time` correctly, so only the schedule-with-inline-rotation path — the one most Terraform configs use — was affected.

**The fix:** send `start_time` whenever it is configured, regardless of strategy type, and omit it when empty (the API rejects an empty string). The `custom`-strategy validation requiring `start_time` is unchanged, as is the update path (`start_time` remains create-only).

**Alternatives considered:** fixing this API-side (accepting that the provider omits the field and defaulting server-side) was rejected — the API behavior is correct and shared with the UI; the provider was simply not sending what the user wrote.

**Risks:** configurations that set `start_time` on weekly/daily schedules and have been silently ignored will now have it honored on **newly created** schedules. Existing schedules are untouched (the field is create-only), so there is no plan churn on upgrade.