### PR TITLE
CI: serialize acceptance-test runs repo-wide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request_target:
     types: [opened, synchronize]
     branches: ['*']
+# Acceptance tests from every branch run against one shared FireHydrant org
+# with one API key. Concurrent runs trip the org's request rate limit (429s)
+# and contend on shared fixtures, so serialize runs repo-wide. New runs queue
+# rather than cancel in-flight ones; note GitHub keeps at most one queued run
+# per group, so a superseded queued run is marked cancelled and needs a re-run.
+concurrency:
+  group: acceptance-tests
+  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

The first overlapping pair of CI runs since the suite went green (this repo's `dn-rotation-start-time` and `add_notification_policy`, 21:00–21:05 UTC today) failed each other: both run against the same FireHydrant org with the same API key, and the doubled request rate tripped the org's Rack::Attack limit — Datadog shows `rack_attack.throttled_request` 429s on `GET /v1/teams` and `GET /v1/services` — while the combined shift-population load pushed one schedule DELETE to a 14s lock wait and a `503 database_timeout`. Solo runs are reliably green (190/190 twice today).

## What

A repo-wide `concurrency` group on the Tests workflow: runs queue instead of overlapping, `cancel-in-progress: false` so in-flight runs always finish. Caveat documented in the workflow comment: GitHub keeps at most one *queued* run per group, so if three runs stack up, the middle one is marked cancelled and needs a manual re-run — a visible, explainable outcome instead of random 429 failures.

## Alternatives considered

- Per-branch groups: doesn't help — the contention is cross-branch (shared org).
- Provider-side 429 retry with backoff: worth doing for customers too, but it papers over the doubled load rather than removing it; possible follow-up.
- Separate orgs/API keys per run: the real long-term fix, much bigger lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)