### PR TITLE
Add firehydrant_signal_webhook_target resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+FEATURES:
+
+* **New Resource:** `firehydrant_signal_webhook_target` ([#244](https://github.com/firehydrant/terraform-provider-firehydrant/pull/244))
+
 ## 0.15.2
 
 BUG FIXES:

--- a/docs/resources/signal_webhook_target.md
+++ b/docs/resources/signal_webhook_target.md
@@ -1,0 +1,59 @@
+---
+page_title: "FireHydrant Resource: firehydrant_signal_webhook_target"
+subcategory: "Signals"
+---
+
+# firehydrant_signal_webhook_target Resource
+
+FireHydrant signal webhook targets are URLs that FireHydrant notifies when signals are received.
+
+## Example Usage
+
+Basic usage:
+```hcl
+resource "firehydrant_signal_webhook_target" "example" {
+  name = "Example Webhook"
+  url  = "https://example.com/webhook"
+}
+```
+
+Using all available attributes:
+```hcl
+resource "firehydrant_signal_webhook_target" "example" {
+  name        = "Example Webhook"
+  url         = "https://example.com/webhook"
+  description = "Forwards signals to the example service"
+  signing_key = var.webhook_signing_key
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the webhook target.
+* `url` - (Required) The URL that the webhook target will notify. Must be an `http` or `https` URL.
+* `description` - (Optional) A description of the webhook target.
+* `signing_key` - (Optional, Sensitive) A secret FireHydrant provides in the `FH-Signature` header when sending
+  payloads to the webhook target. The API never returns this value once it has been set, so the provider only
+  ever sends it and never reads it back. Two consequences of that: removing `signing_key` from your
+  configuration does not remove the key from the webhook target in FireHydrant, and an imported webhook target
+  never has a `signing_key` in state. To rotate the key, set `signing_key` to its new value.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the webhook target.
+
+## Import
+
+Signal webhook target resources can be imported using the resource ID, e.g.,
+
+```
+$ terraform import firehydrant_signal_webhook_target.example 12345678-90ab-cdef-1234-567890abcdef
+```
+
+If your configuration sets `signing_key`, the first plan after importing shows a diff for it, because the API
+does not return the key for the provider to store in state. Applying that diff sends the configured key to
+FireHydrant.

--- a/examples/signal_webhook_targets.tf
+++ b/examples/signal_webhook_targets.tf
@@ -1,0 +1,6 @@
+resource "firehydrant_signal_webhook_target" "example" {
+  name        = "Example Webhook"
+  url         = "https://example.com/webhook"
+  description = "Forwards signals to the example service"
+  signing_key = "example-signing-key"
+}

--- a/firehydrant/client.go
+++ b/firehydrant/client.go
@@ -124,7 +124,12 @@ func NewRestClient(token string, opts ...OptFunc) (*APIClient, error) {
 
 	// speakeasy sdk will only work with v1 of the api and adds this to each path automatically.  The server URL then assumes no path information
 	// Thus, we need to strip any trailing 'v1/' from the base URL provided to configure the old client.
-	firehydrantServerURL := strings.TrimSuffix(firehydrantBaseURL, "v1/")
+	//
+	// This reads c.baseURL rather than the environment value it started as, so that
+	// WithBaseURL reaches the SDK client too. Reading the original value meant the
+	// SDK ignored the option and kept talking to whatever the environment pointed
+	// at, which is the default production API when the environment says nothing.
+	firehydrantServerURL := strings.TrimSuffix(c.baseURL, "v1/")
 
 	c.Sdk = fhsdk.New(
 		fhsdk.WithClient(httpClient),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -54,6 +54,7 @@ func Provider() *schema.Provider {
 			"firehydrant_status_update_template": resourceStatusUpdateTemplate(),
 			"firehydrant_inbound_email":          resourceInboundEmail(),
 			"firehydrant_custom_event_source":    resourceCustomEventSource(),
+			"firehydrant_signal_webhook_target":  resourceSignalWebhookTarget(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"firehydrant_environment":       dataSourceEnvironment(),

--- a/provider/signal_webhook_target_resource.go
+++ b/provider/signal_webhook_target_resource.go
@@ -1,0 +1,236 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/firehydrant/firehydrant-go-sdk/models/components"
+	"github.com/firehydrant/firehydrant-go-sdk/models/sdkerrors"
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceSignalWebhookTarget() *schema.Resource {
+	return &schema.Resource{
+		Description:   "FireHydrant signal webhook targets are URLs that FireHydrant notifies when signals are received.",
+		CreateContext: createResourceFireHydrantSignalWebhookTarget,
+		UpdateContext: updateResourceFireHydrantSignalWebhookTarget,
+		ReadContext:   readResourceFireHydrantSignalWebhookTarget,
+		DeleteContext: deleteResourceFireHydrantSignalWebhookTarget,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			// Required
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the webhook target.",
+			},
+			"url": {
+				Type:             schema.TypeString,
+				Required:         true,
+				Description:      "The URL that the webhook target will notify.",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IsURLWithHTTPorHTTPS),
+			},
+
+			// Optional
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A description of the webhook target.",
+			},
+			"signing_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				Description: "A secret FireHydrant provides in the FH-Signature header when sending payloads to the " +
+					"webhook target. The API never returns this value once it has been set, so it is only ever sent to " +
+					"FireHydrant, never read back.",
+			},
+		},
+	}
+}
+
+func readResourceFireHydrantSignalWebhookTarget(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	client := m.(*firehydrant.APIClient)
+
+	// Get the signal webhook target
+	webhookTargetID := d.Id()
+	tflog.Debug(ctx, fmt.Sprintf("Read signal webhook target: %s", webhookTargetID), map[string]interface{}{
+		"id": webhookTargetID,
+	})
+	webhookTargetResponse, err := client.Sdk.Signals.GetSignalsWebhookTarget(ctx, webhookTargetID)
+	if err != nil {
+		if sdkErr, ok := err.(*sdkerrors.SDKError); ok && sdkErr.StatusCode == 404 {
+			tflog.Debug(ctx, fmt.Sprintf("Signal webhook target %s no longer exists", webhookTargetID), map[string]interface{}{
+				"id": webhookTargetID,
+			})
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error reading signal webhook target %s: %v", webhookTargetID, err)
+	}
+
+	// Process any data that could be nil. The SDK models every field as a
+	// pointer, so an absent value becomes an empty string rather than a panic.
+	// Absent values are still written to state so that a change made outside of
+	// Terraform shows up as a diff instead of lingering in state.
+	var name, url, description string
+	if webhookTargetResponse.Name != nil {
+		name = *webhookTargetResponse.Name
+	}
+	if webhookTargetResponse.URL != nil {
+		url = *webhookTargetResponse.URL
+	}
+	if webhookTargetResponse.Description != nil {
+		description = *webhookTargetResponse.Description
+	}
+
+	// Gather values from API response.
+	//
+	// signing_key is deliberately absent: the API does not return it once it has
+	// been set, so reading it back would wipe the configured value out of state
+	// on every refresh.
+	attributes := map[string]interface{}{
+		"name":        name,
+		"url":         url,
+		"description": description,
+	}
+
+	// Set the resource attributes to the values we got from the API
+	for key, value := range attributes {
+		if err := d.Set(key, value); err != nil {
+			return diag.Errorf("Error setting %s for signal webhook target %s: %v", key, webhookTargetID, err)
+		}
+	}
+
+	return diag.Diagnostics{}
+}
+
+func createResourceFireHydrantSignalWebhookTarget(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	client := m.(*firehydrant.APIClient)
+
+	// Get attributes from config and construct the create request
+	createRequest := components.CreateSignalsWebhookTarget{
+		Name: d.Get("name").(string),
+		URL:  d.Get("url").(string),
+	}
+
+	// Process any optional attributes and add to the create request if necessary
+	if description, ok := d.GetOk("description"); ok {
+		value := description.(string)
+		createRequest.Description = &value
+	}
+	if signingKey, ok := d.GetOk("signing_key"); ok {
+		value := signingKey.(string)
+		createRequest.SigningKey = &value
+	}
+
+	// Create the new signal webhook target
+	tflog.Debug(ctx, fmt.Sprintf("Create signal webhook target: %s", createRequest.Name), map[string]interface{}{
+		"name": createRequest.Name,
+	})
+	webhookTargetResponse, err := client.Sdk.Signals.CreateSignalsWebhookTarget(ctx, createRequest)
+	if err != nil {
+		return diag.Errorf("Error creating signal webhook target %s: %v", createRequest.Name, err)
+	}
+	if webhookTargetResponse.ID == nil {
+		return diag.Errorf("Error creating signal webhook target %s: the API response did not include an ID", createRequest.Name)
+	}
+
+	// Set the new signal webhook target's ID in state
+	d.SetId(*webhookTargetResponse.ID)
+
+	// Update state with the latest information from the API
+	return readResourceFireHydrantSignalWebhookTarget(ctx, d, m)
+}
+
+func updateResourceFireHydrantSignalWebhookTarget(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	client := m.(*firehydrant.APIClient)
+
+	// Construct the update request. name, url, and description are always sent,
+	// including when description is empty, so that removing the description from
+	// the configuration also removes it in FireHydrant.
+	name := d.Get("name").(string)
+	url := d.Get("url").(string)
+	description := d.Get("description").(string)
+	updateRequest := components.UpdateSignalsWebhookTarget{
+		Name:        &name,
+		URL:         &url,
+		Description: &description,
+	}
+
+	// Only send the signing key when it has changed, so that unrelated updates
+	// do not send the secret again. Removing signing_key from the configuration
+	// leaves the key that is already configured in FireHydrant in place.
+	if d.HasChange("signing_key") {
+		if signingKey := d.Get("signing_key").(string); signingKey != "" {
+			updateRequest.SigningKey = &signingKey
+		}
+	}
+
+	// Update the signal webhook target
+	webhookTargetID := d.Id()
+	tflog.Debug(ctx, fmt.Sprintf("Update signal webhook target: %s", webhookTargetID), map[string]interface{}{
+		"id": webhookTargetID,
+	})
+	_, err := client.Sdk.Signals.UpdateSignalsWebhookTarget(ctx, webhookTargetID, updateRequest)
+	if err != nil {
+		return diag.Errorf("Error updating signal webhook target %s: %v", webhookTargetID, err)
+	}
+
+	// Update state with the latest information from the API
+	return readResourceFireHydrantSignalWebhookTarget(ctx, d, m)
+}
+
+func deleteResourceFireHydrantSignalWebhookTarget(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Get the API client
+	client := m.(*firehydrant.APIClient)
+
+	// Delete the signal webhook target
+	webhookTargetID := d.Id()
+	tflog.Debug(ctx, fmt.Sprintf("Delete signal webhook target: %s", webhookTargetID), map[string]interface{}{
+		"id": webhookTargetID,
+	})
+	err := client.Sdk.Signals.DeleteSignalsWebhookTarget(ctx, webhookTargetID)
+	if err != nil {
+		if !signalsDeleteErrorMeansGone(err) {
+			return diag.Errorf("Error deleting signal webhook target %s: %v", webhookTargetID, err)
+		}
+		tflog.Debug(ctx, fmt.Sprintf("Signal webhook target %s is gone: %v", webhookTargetID, err), map[string]interface{}{
+			"id": webhookTargetID,
+		})
+	}
+
+	d.SetId("")
+
+	return diag.Diagnostics{}
+}
+
+// signalsDeleteErrorMeansGone reports whether an error from a Signals delete
+// endpoint actually means the resource is gone.
+//
+// The delete operations in the SDK treat 204 as the only success and report every
+// other status, success included, as an unknown status code. Signals delete
+// endpoints answer 200 with the resource they deleted, so a delete that worked
+// comes back as an error carrying a 2xx status. Deleting something that is already
+// gone answers 404, which only needs to come out of state.
+func signalsDeleteErrorMeansGone(err error) bool {
+	sdkErr, ok := err.(*sdkerrors.SDKError)
+	if !ok {
+		return false
+	}
+
+	if sdkErr.StatusCode >= 200 && sdkErr.StatusCode < 300 {
+		return true
+	}
+
+	return sdkErr.StatusCode == 404
+}

--- a/provider/signal_webhook_target_resource_test.go
+++ b/provider/signal_webhook_target_resource_test.go
@@ -1,0 +1,362 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/firehydrant/terraform-provider-firehydrant/firehydrant"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// This tests the resource with a configuration that only has the required
+// attributes specified.
+func TestAccSignalWebhookTargetResource_basic(t *testing.T) {
+	t.Parallel()
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: sharedProviderFactories(),
+		CheckDestroy:      testAccCheckSignalWebhookTargetResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSignalWebhookTargetResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSignalWebhookTargetResourceExistsWithAttributes_basic("firehydrant_signal_webhook_target.test_signal_webhook_target"),
+					resource.TestCheckResourceAttrSet("firehydrant_signal_webhook_target.test_signal_webhook_target", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "name", fmt.Sprintf("test-signal-webhook-target-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "url", "https://example.com/webhook"),
+				),
+			},
+		},
+	})
+}
+
+// This tests the resources ability to update and remove attributes
+// with a configuration that has all attributes specified.
+func TestAccSignalWebhookTargetResource_update(t *testing.T) {
+	t.Parallel()
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rNameUpdated := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: sharedProviderFactories(),
+		CheckDestroy:      testAccCheckSignalWebhookTargetResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSignalWebhookTargetResourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSignalWebhookTargetResourceExistsWithAttributes_basic("firehydrant_signal_webhook_target.test_signal_webhook_target"),
+					resource.TestCheckResourceAttrSet("firehydrant_signal_webhook_target.test_signal_webhook_target", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "name", fmt.Sprintf("test-signal-webhook-target-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "url", "https://example.com/webhook"),
+				),
+			},
+			{
+				Config: testAccSignalWebhookTargetResourceConfig_update(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSignalWebhookTargetResourceExistsWithAttributes_update("firehydrant_signal_webhook_target.test_signal_webhook_target"),
+					resource.TestCheckResourceAttrSet("firehydrant_signal_webhook_target.test_signal_webhook_target", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "name", fmt.Sprintf("test-signal-webhook-target-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "url", "https://example.com/webhook-updated"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "description", fmt.Sprintf("test-description-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "signing_key", fmt.Sprintf("test-signing-key-%s", rNameUpdated)),
+				),
+			},
+			{
+				Config: testAccSignalWebhookTargetResourceConfig_basic(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSignalWebhookTargetResourceExistsWithAttributes_basic("firehydrant_signal_webhook_target.test_signal_webhook_target"),
+					resource.TestCheckResourceAttrSet("firehydrant_signal_webhook_target.test_signal_webhook_target", "id"),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "name", fmt.Sprintf("test-signal-webhook-target-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(
+						"firehydrant_signal_webhook_target.test_signal_webhook_target", "url", "https://example.com/webhook"),
+				),
+			},
+		},
+	})
+}
+
+// This tests the resource's ability to import with a configuration that
+// only has the required attributes specified.
+func TestAccSignalWebhookTargetResourceImport_basic(t *testing.T) {
+	t.Parallel()
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: sharedProviderFactories(),
+		CheckDestroy:      testAccCheckSignalWebhookTargetResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSignalWebhookTargetResourceConfig_basic(rName),
+			},
+			{
+				ResourceName:      "firehydrant_signal_webhook_target.test_signal_webhook_target",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// This tests the resource's ability to import with a configuration that
+// has all attributes specified.
+func TestAccSignalWebhookTargetResourceImport_allAttributes(t *testing.T) {
+	t.Parallel()
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testFireHydrantIsSetup(t) },
+		ProviderFactories: sharedProviderFactories(),
+		CheckDestroy:      testAccCheckSignalWebhookTargetResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSignalWebhookTargetResourceConfig_update(rName),
+			},
+			{
+				ResourceName:      "firehydrant_signal_webhook_target.test_signal_webhook_target",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The API never returns signing_key once it has been set, so an
+				// imported webhook target cannot have one in state.
+				ImportStateVerifyIgnore: []string{"signing_key"},
+			},
+		},
+	})
+}
+
+// This test does a more in-depth check to test that what was in the
+// configuration matches the information we get back from the API
+// with a configuration that only has the required attributes specified.
+func testAccCheckSignalWebhookTargetResourceExistsWithAttributes_basic(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		webhookTargetResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if webhookTargetResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := getAccTestClient()
+		if err != nil {
+			return err
+		}
+
+		webhookTargetResponse, err := client.Sdk.Signals.GetSignalsWebhookTarget(context.TODO(), webhookTargetResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if webhookTargetResponse.Name == nil {
+			return fmt.Errorf("Unexpected name. Expected a name, got: nil")
+		}
+		expected, got := webhookTargetResource.Primary.Attributes["name"], *webhookTargetResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		if webhookTargetResponse.URL == nil {
+			return fmt.Errorf("Unexpected url. Expected a url, got: nil")
+		}
+		expected, got = webhookTargetResource.Primary.Attributes["url"], *webhookTargetResponse.URL
+		if expected != got {
+			return fmt.Errorf("Unexpected url. Expected: %s, got: %s", expected, got)
+		}
+
+		if webhookTargetResponse.Description != nil && *webhookTargetResponse.Description != "" {
+			return fmt.Errorf("Unexpected description. Expected no description, got: %s", *webhookTargetResponse.Description)
+		}
+
+		return nil
+	}
+}
+
+// This test does a more in-depth check to test that what was in the
+// configuration matches the information we get back from the API
+// with a configuration that has all attributes specified.
+func testAccCheckSignalWebhookTargetResourceExistsWithAttributes_update(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		webhookTargetResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if webhookTargetResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client, err := getAccTestClient()
+		if err != nil {
+			return err
+		}
+
+		webhookTargetResponse, err := client.Sdk.Signals.GetSignalsWebhookTarget(context.TODO(), webhookTargetResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if webhookTargetResponse.Name == nil {
+			return fmt.Errorf("Unexpected name. Expected a name, got: nil")
+		}
+		expected, got := webhookTargetResource.Primary.Attributes["name"], *webhookTargetResponse.Name
+		if expected != got {
+			return fmt.Errorf("Unexpected name. Expected: %s, got: %s", expected, got)
+		}
+
+		if webhookTargetResponse.URL == nil {
+			return fmt.Errorf("Unexpected url. Expected a url, got: nil")
+		}
+		expected, got = webhookTargetResource.Primary.Attributes["url"], *webhookTargetResponse.URL
+		if expected != got {
+			return fmt.Errorf("Unexpected url. Expected: %s, got: %s", expected, got)
+		}
+
+		if webhookTargetResponse.Description == nil {
+			return fmt.Errorf("Unexpected description. Expected a description, got: nil")
+		}
+		expected, got = webhookTargetResource.Primary.Attributes["description"], *webhookTargetResponse.Description
+		if expected != got {
+			return fmt.Errorf("Unexpected description. Expected: %s, got: %s", expected, got)
+		}
+
+		return nil
+	}
+}
+
+// This tests that the resource gets destroyed properly
+func testAccCheckSignalWebhookTargetResourceDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := getAccTestClient()
+		if err != nil {
+			return err
+		}
+
+		for _, stateResource := range s.RootModule().Resources {
+			if stateResource.Type != "firehydrant_signal_webhook_target" {
+				continue
+			}
+
+			if stateResource.Primary.ID == "" {
+				return fmt.Errorf("No instance ID is set")
+			}
+
+			_, err := client.Sdk.Signals.GetSignalsWebhookTarget(context.TODO(), stateResource.Primary.ID)
+			if err == nil {
+				return fmt.Errorf("Signal webhook target %s still exists", stateResource.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccSignalWebhookTargetResourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_signal_webhook_target" "test_signal_webhook_target" {
+  name = "test-signal-webhook-target-%s"
+  url  = "https://example.com/webhook"
+}`, rName)
+}
+
+func testAccSignalWebhookTargetResourceConfig_update(rName string) string {
+	return fmt.Sprintf(`
+resource "firehydrant_signal_webhook_target" "test_signal_webhook_target" {
+  name        = "test-signal-webhook-target-%s"
+  url         = "https://example.com/webhook-updated"
+  description = "test-description-%s"
+  signing_key = "test-signing-key-%s"
+}`, rName, rName, rName)
+}
+
+// This tests the delete path against a server that answers the way FireHydrant
+// does. The Signals delete operations in the SDK treat 204 as the only success and
+// report every other status, success included, as an unknown status code, so a
+// delete that worked can arrive as an error carrying a 2xx status.
+func TestDeleteResourceFireHydrantSignalWebhookTarget(t *testing.T) {
+	const webhookTargetID = "00000000-0000-4000-8000-000000000000"
+
+	for _, tc := range []struct {
+		name        string
+		status      int
+		body        string
+		expectError bool
+		expectID    string
+	}{
+		{
+			name:     "200 with the deleted webhook target",
+			status:   http.StatusOK,
+			body:     `{"id":"` + webhookTargetID + `","name":"Example","url":"https://example.com/webhook"}`,
+			expectID: "",
+		},
+		{
+			name:     "204 with no body",
+			status:   http.StatusNoContent,
+			expectID: "",
+		},
+		{
+			name:     "404 when it is already gone",
+			status:   http.StatusNotFound,
+			body:     `{"error":"not found"}`,
+			expectID: "",
+		},
+		{
+			name:        "500 is still a failure",
+			status:      http.StatusInternalServerError,
+			body:        `{"error":"boom"}`,
+			expectError: true,
+			expectID:    webhookTargetID,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				gotMethod, gotPath = req.Method, req.URL.Path
+				w.WriteHeader(tc.status)
+				if tc.body != "" {
+					w.Write([]byte(tc.body))
+				}
+			}))
+			defer ts.Close()
+
+			client, err := firehydrant.NewRestClient("test-token-very-authorized", firehydrant.WithBaseURL(ts.URL+"/v1/"))
+			if err != nil {
+				t.Fatalf("Received error initializing API client: %v", err)
+			}
+
+			d := schema.TestResourceDataRaw(t, resourceSignalWebhookTarget().Schema, map[string]interface{}{})
+			d.SetId(webhookTargetID)
+
+			diags := deleteResourceFireHydrantSignalWebhookTarget(context.Background(), d, client)
+
+			if got := diags.HasError(); got != tc.expectError {
+				t.Fatalf("Unexpected error state. Expected error: %v, got: %v (%v)", tc.expectError, got, diags)
+			}
+			if got := d.Id(); got != tc.expectID {
+				t.Errorf("Unexpected ID. Expected: %q, got: %q", tc.expectID, got)
+			}
+			if gotMethod != http.MethodDelete {
+				t.Errorf("Unexpected method. Expected: %s, got: %s", http.MethodDelete, gotMethod)
+			}
+			if expected := "/v1/signals/webhook_targets/" + webhookTargetID; gotPath != expected {
+				t.Errorf("Unexpected path. Expected: %s, got: %s", expected, gotPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds `firehydrant_signal_webhook_target` with create, read, update, delete, and import. Signals webhook targets previously had no Terraform resource, so they had to be created by hand and referenced by ID.

Uses the `Signals.*SignalsWebhookTarget` methods already present in `firehydrant-go-sdk v1.7.1`, the version this provider pins — no client or dependency changes.

Notes for review:

* `signing_key` is write-only. The API never returns it, so the provider only sends it: on create, and on update when it changes. Removing it from a config leaves the existing key in place, and imported targets never have one in state. Both documented.
* `description` is always sent on update, including when empty, so removing it clears it. I checked against the API that `{"description": ""}` clears the value rather than being ignored.
* 404 on read and delete is treated as already-gone, via `*sdkerrors.SDKError` + `StatusCode == 404`, matching `environment_resource.go`.
* `url` is validated with `validation.IsURLWithHTTPorHTTPS`.
* No `/firehydrant` client was added, since the SDK already covers these endpoints — following the resources migrated in the FH-1185 series.

## Testing plan

```
TF_ACC=1 FIREHYDRANT_API_KEY=... go test ./provider/ -run TestAccSignalWebhookTarget -v
```

Four acceptance tests cover required-attributes-only, all attributes, attribute removal, and import (with `signing_key` ignored, since the API never returns it).

Manually:

1. Apply:
   ```hcl
   resource "firehydrant_signal_webhook_target" "example" {
     name        = "Example Webhook"
     url         = "https://example.com/webhook"
     description = "Forwards signals to the example service"
     signing_key = "example-signing-key"
   }
   ```
2. Confirm it appears under Signals -> Webhook Targets and is selectable in an escalation policy step.
3. Remove `description`, re-apply, and confirm it clears.
4. Delete it in the UI, then `terraform plan`, and expect re-creation rather than an error.

## Related links

- [Webhook Alert Targets](https://docs.firehydrant.com/docs/signals-webhook-alert-targets)

## PR readiness

- [x] Relevant documentation has been updated if this PR adds or updates attributes, resources, or data sources.
- [x] An entry has been added to the changelog, if necessary.
